### PR TITLE
Replace UTF8 forward ticks with single quotes.

### DIFF
--- a/charon/backends/__init__.py
+++ b/charon/backends/__init__.py
@@ -75,7 +75,7 @@ class MachineState:
         self.depl.update_machine_state(self)
         
     def create(self, defn, check):
-        """Create or update the machine instance defined by ‘defn’, if appropriate."""
+        """Create or update the machine instance defined by 'defn', if appropriate."""
         assert False
 
     def serialise(self):
@@ -98,12 +98,12 @@ class MachineState:
 
     def destroy(self):
         """Destroy this machine, if possible."""
-        self.warn("don't know how to destroy machine ‘{0}’".format(self.name))
+        self.warn("don't know how to destroy machine '{0}'".format(self.name))
         return False
 
     def stop(self):
         """Stop this machine, if possible."""
-        self.warn("don't know how to stop machine ‘{0}’".format(self.name))
+        self.warn("don't know how to stop machine '{0}'".format(self.name))
         
     def start(self):
         """Start this machine, if possible."""
@@ -168,7 +168,7 @@ class MachineState:
              "-M", "-N", "-f"]
             + self.get_ssh_flags())
         if res != 0: 
-            raise Exception("unable to start SSH master connection to ‘{0}’".format(self.name))
+            raise Exception("unable to start SSH master connection to '{0}'".format(self.name))
 
         # Kill the master on exit.
         atexit.register(
@@ -242,7 +242,7 @@ class MachineState:
 
         if stdin_string != None: process.stdin.close()
         if check and res != 0:
-            raise Exception("command ‘{0}’ failed on machine ‘{1}’".format(command, self.name))
+            raise Exception("command '{0}' failed on machine '{1}'".format(command, self.name))
         return stdout if capture_stdout else res
 
     def run_command(self, command, check=True, capture_stdout=False, stdin_string=None):
@@ -287,7 +287,7 @@ class MachineState:
             ["umask 077 && mkdir -p /root/.ssh && cat > /root/.ssh/id_charon_vpn"],
             stdin=f)
         f.close()
-        if res != 0: raise Exception("unable to upload VPN key to ‘{0}’".format(self.name))
+        if res != 0: raise Exception("unable to upload VPN key to '{0}'".format(self.name))
         self._public_vpn_key = public
         self.write()
 
@@ -304,7 +304,7 @@ def create_definition(xml):
               charon.backends.ec2.EC2Definition]:
         if target_env == i.get_type():
             return i(xml)
-    raise Exception("unknown backend type ‘{0}’".format(target_env))
+    raise Exception("unknown backend type '{0}'".format(target_env))
 
 def create_state(depl, type, name):
     """Create a machine state object of the desired backend type."""
@@ -313,4 +313,4 @@ def create_state(depl, type, name):
               charon.backends.ec2.EC2State]:
         if type == i.get_type():
             return i(depl, name)
-    raise Exception("unknown backend type ‘{0}’".format(type))
+    raise Exception("unknown backend type '{0}'".format(type))

--- a/charon/backends/ec2.py
+++ b/charon/backends/ec2.py
@@ -29,7 +29,7 @@ class EC2Definition(MachineDefinition):
         self.region = x.find("attr[@name='region']/string").get("value")
         self.controller = x.find("attr[@name='controller']/string").get("value")
         self.ami = x.find("attr[@name='ami']/string").get("value")
-        if self.ami == "": raise Exception("no AMI defined for EC2 machine ‘{0}’".format(self.name))
+        if self.ami == "": raise Exception("no AMI defined for EC2 machine '{0}'".format(self.name))
         self.instance_type = x.find("attr[@name='instanceType']/string").get("value")
         self.key_pair = x.find("attr[@name='keyPair']/string").get("value")
         self.private_key = x.find("attr[@name='privateKey']/string").get("value")
@@ -137,7 +137,7 @@ class EC2State(MachineState):
         
     def get_ssh_name(self):
         if not self._public_ipv4:
-            raise Exception("EC2 machine ‘{0}’ does not have a public IPv4 address (yet)".format(self.name))
+            raise Exception("EC2 machine '{0}' does not have a public IPv4 address (yet)".format(self.name))
         return self._public_ipv4
 
     
@@ -203,7 +203,7 @@ class EC2State(MachineState):
                     break
             
         if not secret_access_key:
-            raise Exception("please set $EC2_SECRET_KEY or $AWS_SECRET_ACCESS_KEY, or add the key for ‘{0}’ to ~/ec2-keys"
+            raise Exception("please set $EC2_SECRET_KEY or $AWS_SECRET_ACCESS_KEY, or add the key for '{0}' to ~/ec2-keys"
                             .format(self._access_key_id))
 
         self._conn = boto.ec2.connect_to_region(
@@ -216,7 +216,7 @@ class EC2State(MachineState):
         reservations = self._conn.get_all_instances([instance_id])
         if len(reservations) == 0:
             if allow_missing: return None
-            raise Exception("EC2 instance ‘{0}’ disappeared!".format(instance_id))
+            raise Exception("EC2 instance '{0}' disappeared!".format(instance_id))
         return reservations[0].instances[0]
 
 
@@ -225,7 +225,7 @@ class EC2State(MachineState):
         self.connect()
         volumes = self._conn.get_all_volumes([volume_id])
         if len(volumes) != 1:
-            raise Exception("unable to find volume ‘{0}’".format(volume_id))
+            raise Exception("unable to find volume '{0}'".format(volume_id))
         return volumes[0]
 
 
@@ -236,7 +236,7 @@ class EC2State(MachineState):
             instance.update()
             self.log_continue("({0}) ".format(instance.state))
             if instance.state not in {"pending", "running", "scheduling", "launching", "stopped"}:
-                raise Exception("EC2 instance ‘{0}’ failed to start (state is ‘{1}’)".format(self._instance_id, instance.state))
+                raise Exception("EC2 instance '{0}' failed to start (state is '{1}')".format(self._instance_id, instance.state))
             if instance.ip_address: break
             time.sleep(3)
             
@@ -262,7 +262,7 @@ class EC2State(MachineState):
         if not self._access_key_id:
             self._access_key_id = defn.access_key_id or os.environ.get('EC2_ACCESS_KEY') or os.environ.get('AWS_ACCESS_KEY_ID')
             if not self._access_key_id:
-                raise Exception("please set ‘deployment.ec2.accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+                raise Exception("please set 'deployment.ec2.accessKeyId', $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
 
         self._private_key = defn.private_key or None
         
@@ -272,7 +272,7 @@ class EC2State(MachineState):
             self.connect()
             instance = self._get_instance_by_id(self._instance_id, allow_missing=True)
             if instance is None or instance.state in {"shutting-down", "terminated"}:
-                self.log("EC2 instance went away (state ‘{0}’), will recreate".format(instance.state if instance else "gone"))
+                self.log("EC2 instance went away (state '{0}'), will recreate".format(instance.state if instance else "gone"))
                 self._reset_state()
                 self.write()
             elif instance.state == "stopped":
@@ -280,7 +280,7 @@ class EC2State(MachineState):
 
                 # Modify the instance type, if desired.
                 if self._instance_type != defn.instance_type:
-                    self.log("changing instance type from ‘{0}’ to ‘{1}’...".format(self._instance_type, defn.instance_type))
+                    self.log("changing instance type from '{0}' to '{1}'...".format(self._instance_type, defn.instance_type))
                     instance.modify_attribute("instanceType", defn.instance_type)
                     self._instance_type = defn.instance_type
                     self.write()
@@ -294,7 +294,7 @@ class EC2State(MachineState):
 
         # Start the instance.
         if not self._instance_id:
-            self.log("creating EC2 instance (AMI ‘{0}’, type ‘{1}’, region ‘{2}’)...".format(
+            self.log("creating EC2 instance (AMI '{0}', type '{1}', region '{2}')...".format(
                 defn.ami, defn.instance_type, defn.region))
 
             self._region = defn.region
@@ -315,7 +315,7 @@ class EC2State(MachineState):
             devs_mapped = {}
             for k, v in defn.block_device_mapping.iteritems():
                 if re.match("/dev/sd[a-e]", k) and not v['disk'].startswith("ephemeral"):
-                    raise Exception("non-ephemeral disk not allowed on device ‘{0}’; use /dev/xvdf or higher".format(_sd_to_xvd(k)))
+                    raise Exception("non-ephemeral disk not allowed on device '{0}'; use /dev/xvdf or higher".format(_sd_to_xvd(k)))
                 if v['disk'] == '':
                     if self._booted_from_ebs():
                         devmap[k] = boto.ec2.blockdevicemapping.BlockDeviceType(
@@ -334,14 +334,14 @@ class EC2State(MachineState):
                     # zone of the volume.
                     volume = self._get_volume_by_id(v['disk'])
                     if not zone:
-                        self.log("starting EC2 instance in zone ‘{0}’ due to volume ‘{1}’".format(
+                        self.log("starting EC2 instance in zone '{0}' due to volume '{1}'".format(
                             volume.zone, v['disk']))
                         zone = volume.zone
                     elif zone != volume.zone:
-                        raise Exception("unable to start EC2 instance ‘{0}’ in zone ‘{1}’ because volume ‘{2}’ is in zone ‘{3}’"
+                        raise Exception("unable to start EC2 instance '{0}' in zone '{1}' because volume '{2}' is in zone '{3}'"
                                         .format(self.name, zone, v['disk'], volume.zone))
                 else:
-                    raise Exception("device mapping ‘{0}’ not (yet) supported".format(v['disk']))
+                    raise Exception("device mapping '{0}' not (yet) supported".format(v['disk']))
 
             # FIXME: Should use client_token to ensure idempotency.
             reservation = ami.run(
@@ -375,12 +375,12 @@ class EC2State(MachineState):
                 break
             except boto.exception.EC2ResponseError as e:
                 if e.error_code != "InvalidInstanceID.NotFound": raise
-            self.log("EC2 instance ‘{0}’ not known yet, waiting...".format(self._instance_id))
+            self.log("EC2 instance '{0}' not known yet, waiting...".format(self._instance_id))
             time.sleep(3)
 
         # Warn about some EC2 options that we cannot update for an existing instance.
         if self._instance_type != defn.instance_type:
-            self.warn("cannot change type of a running instance (do ‘charon stop’ first)")
+            self.warn("cannot change type of a running instance (do 'charon stop' first)")
         if self._region != defn.region:
             self.warn("cannot change region of a running instance")
                     
@@ -409,20 +409,20 @@ class EC2State(MachineState):
                     if instance.state == "running": break
                     if instance.state not in {"running", "pending"}:
                         raise Exception(
-                            "EC2 instance ‘{0}’ failed to reach running state (state is ‘{1}’)"
+                            "EC2 instance '{0}' failed to reach running state (state is '{1}')"
                             .format(self._instance_id, instance.state))
                     time.sleep(3)
                     instance.update()
                 self.log_end("")
 
-                self.log("associating IP address ‘{0}’...".format(defn.elastic_ipv4))
+                self.log("associating IP address '{0}'...".format(defn.elastic_ipv4))
                 self._conn.associate_address(instance_id=self._instance_id, public_ip=defn.elastic_ipv4)
                 self._elastic_ipv4 = defn.elastic_ipv4
                 self._public_ipv4 = defn.elastic_ipv4
                 self._ssh_pinged = False
                 charon.known_hosts.add(defn.elastic_ipv4, self._public_host_key)
             else:
-                self.log("disassociating IP address ‘{0}’...".format(self._elastic_ipv4))
+                self.log("disassociating IP address '{0}'...".format(self._elastic_ipv4))
                 self._conn.disassociate_address(public_ip=self._elastic_ipv4)
                 self._elastic_ipv4 = None
                 self._public_ipv4 = None
@@ -456,18 +456,18 @@ class EC2State(MachineState):
         # Attach missing volumes.
         for k, v in defn.block_device_mapping.iteritems():
             if k not in self._block_device_mapping:
-                self.log("attaching volume ‘{0}’ as ‘{1}’...".format(v['disk'], _sd_to_xvd(k)))
+                self.log("attaching volume '{0}' as '{1}'...".format(v['disk'], _sd_to_xvd(k)))
                 self.connect()
                 if v['disk'].startswith("vol-"):
                     self._conn.attach_volume(v['disk'], self._instance_id, k)
                     self._block_device_mapping[k] = v
                     self.write()
                 else:
-                    raise Exception("adding device mapping ‘{0}’ to a running instance is not (yet) supported".format(v['disk']))
+                    raise Exception("adding device mapping '{0}' to a running instance is not (yet) supported".format(v['disk']))
 
         for k, v in self._block_device_mapping.items():
             if v.get('needsAttach', False):
-                self.log("attaching volume ‘{0}’ as ‘{1}’...".format(v['volumeId'], _sd_to_xvd(k)))
+                self.log("attaching volume '{0}' as '{1}'...".format(v['volumeId'], _sd_to_xvd(k)))
                 self.connect()
 
                 volume_tags = {'Name': "{0} [{1} - {2}]".format(self.depl.description, self.name, _sd_to_xvd(k))}
@@ -496,14 +496,14 @@ class EC2State(MachineState):
                     filters={'attachment.instance-id': self._instance_id,
                              'attachment.device': k})
                 if len(volumes) != 1:
-                    raise Exception("unable to find volume attached to ‘{0}’ on EC2 machine ‘{1}’".format(k, self.name))
+                    raise Exception("unable to find volume attached to '{0}' on EC2 machine '{1}'".format(k, self.name))
                 v['volumeId'] = volumes[0].id
                 self.write()
                 
         # Detach volumes that are no longer in the deployment spec.
         for k, v in self._block_device_mapping.items():
             if k not in defn.block_device_mapping:
-                self.log("detaching device ‘{0}’...".format(_sd_to_xvd(k)))
+                self.log("detaching device '{0}'...".format(_sd_to_xvd(k)))
                 self.connect()
                 volumes = self._conn.get_all_volumes([], filters={'attachment.instance-id': self._instance_id, 'attachment.device': k})
                 assert len(volumes) <= 1
@@ -517,7 +517,7 @@ class EC2State(MachineState):
                     else:
                         self.run_command("umount -l {0}".format(device), check=False)
                     if not self._conn.detach_volume(volumes[0].id, instance_id=self._instance_id, device=k):
-                        raise Exception("unable to detach device ‘{0}’ from EC2 machine ‘{1}’".format(v['disk'], self.name))
+                        raise Exception("unable to detach device '{0}' from EC2 machine '{1}'".format(v['disk'], self.name))
                     # FIXME: Wait until the volume is actually detached.
                     
                 if v.get('charonDeleteOnTermination', False) or v.get('deleteOnTermination', False):
@@ -534,9 +534,9 @@ class EC2State(MachineState):
 
 
     def _delete_volume(self, volume_id):
-        if not self.depl.confirm("are you sure you want to destroy EC2 volume ‘{0}’?".format(volume_id)):
-            raise Exception("not destroying EC2 volume ‘{0}’".format(volume_id))
-        self.log("destroying EC2 volume ‘{0}’...".format(volume_id))
+        if not self.depl.confirm("are you sure you want to destroy EC2 volume '{0}'?".format(volume_id)):
+            raise Exception("not destroying EC2 volume '{0}'".format(volume_id))
+        self.log("destroying EC2 volume '{0}'...".format(volume_id))
         try:
             volume = self._get_volume_by_id(volume_id)
             charon.util.check_wait(lambda: volume.update() == 'available')
@@ -547,7 +547,7 @@ class EC2State(MachineState):
 
 
     def destroy(self):
-        if not self.depl.confirm("are you sure you want to destroy EC2 machine ‘{0}’?".format(self.name)): return False
+        if not self.depl.confirm("are you sure you want to destroy EC2 machine '{0}'?".format(self.name)): return False
         
         self.log_start("destroying EC2 machine... ".format(self.name))
 
@@ -586,7 +586,7 @@ class EC2State(MachineState):
             if instance.state == "stopped": break
             if instance.state not in {"running", "stopping"}:
                 raise Exception(
-                    "EC2 instance ‘{0}’ failed to stop (state is ‘{1}’)"
+                    "EC2 instance '{0}' failed to stop (state is '{1}')"
                     .format(self._instance_id, instance.state))
             time.sleep(3)
             instance.update()
@@ -610,7 +610,7 @@ class EC2State(MachineState):
         self._wait_for_ip(instance)
         
         if prev_private_ipv4 != self._private_ipv4 or prev_public_ipv4 != self._public_ipv4:
-            self.warn("IP address has changed, you may need to run ‘charon deploy’")
+            self.warn("IP address has changed, you may need to run 'charon deploy'")
 
     def reboot(self):
         self.log("rebooting EC2 machine... ")

--- a/charon/backends/virtualbox.py
+++ b/charon/backends/virtualbox.py
@@ -102,7 +102,7 @@ class VirtualBoxState(MachineState):
 
     
     def _get_vm_info(self):
-        '''Return the output of ‘VBoxManage showvminfo’ in a dictionary.'''
+        '''Return the output of 'VBoxManage showvminfo' in a dictionary.'''
         lines = self._logged_exec(
             ["VBoxManage", "showvminfo", "--machinereadable", self._vm_id],
             capture_stdout=True, check=False).splitlines()
@@ -110,7 +110,7 @@ class VirtualBoxState(MachineState):
         # shutting down (even though the necessary info is returned on
         # stdout).
         if len(lines) == 0:
-            raise Exception("unable to get info on VirtualBox VM ‘{0}’".format(self.name))
+            raise Exception("unable to get info on VirtualBox VM '{0}'".format(self.name))
         vminfo = {}
         for l in lines:
             (k, v) = l.split("=", 1)
@@ -122,7 +122,7 @@ class VirtualBoxState(MachineState):
         '''Return the state ("running", etc.) of a VM.'''
         vminfo = self._get_vm_info()
         if 'VMState' not in vminfo:
-            raise Exception("unable to get state of VirtualBox VM ‘{0}’".format(self.name))
+            raise Exception("unable to get state of VirtualBox VM '{0}'".format(self.name))
         return vminfo['VMState'].replace('"', '')
 
 
@@ -173,7 +173,7 @@ class VirtualBoxState(MachineState):
         if not self._disk:
             vm_dir = os.environ['HOME'] + "/VirtualBox VMs/" + self._vm_id
             if not os.path.isdir(vm_dir):
-                raise Exception("can't find directory of VirtualBox VM ‘{0}’".format(self.name))
+                raise Exception("can't find directory of VirtualBox VM '{0}'".format(self.name))
 
             disk = vm_dir + "/disk1.vdi"
 
@@ -232,7 +232,7 @@ class VirtualBoxState(MachineState):
 
 
     def destroy(self):
-        if not self.depl.confirm("are you sure you want to destroy VirtualBox VM ‘{0}’?".format(self.name)): return False
+        if not self.depl.confirm("are you sure you want to destroy VirtualBox VM '{0}'?".format(self.name)): return False
         
         self.log("destroying VirtualBox VM...")
 
@@ -278,4 +278,4 @@ class VirtualBoxState(MachineState):
         self._wait_for_ip()
 
         if prev_ipv4 != self._ipv4:
-            self.warn("IP address has changed, you may need to run ‘charon deploy’")
+            self.warn("IP address has changed, you may need to run 'charon deploy'")

--- a/charon/deployment.py
+++ b/charon/deployment.py
@@ -44,7 +44,7 @@ class Deployment:
                 fcntl.lockf(self._state_file_lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except exceptions.IOError as e:
                 if e.errno != errno.EAGAIN: raise
-                self.log("waiting for exclusive lock on ‘{0}’...".format(self.state_file))
+                self.log("waiting for exclusive lock on '{0}'...".format(self.state_file))
                 fcntl.lockf(self._state_file_lock, fcntl.LOCK_EX)
 
         if create:
@@ -214,7 +214,7 @@ class Deployment:
             for m2_name in defn.encrypted_links_to:
                 
                 if m2_name not in self.active:
-                    raise Exception("‘deployment.encryptedLinksTo’ in machine ‘{0}’ refers to an unknown machine ‘{1}’"
+                    raise Exception("'deployment.encryptedLinksTo' in machine '{0}' refers to an unknown machine '{1}'"
                                     .format(m.name, m2_name))
                 m2 = self.active[m2_name]
                 # Don't create two tunnels between a pair of machines.
@@ -230,7 +230,7 @@ class Deployment:
                 lines.append('        remoteIPv4 = "{0}";'.format(remote_ipv4))
                 lines.append('        privateKey = "/root/.ssh/id_charon_vpn";')
                 lines.append('      }};'.format(m2.name))
-                # FIXME: set up the authorized_key file such that ‘m’
+                # FIXME: set up the authorized_key file such that 'm'
                 # can do nothing more than create a tunnel.
                 authorized_keys[m2.name].append('"' + m._public_vpn_key + '"')
                 kernel_modules[m.name].add('"tun"')
@@ -294,7 +294,7 @@ class Deployment:
             m.log("copying closure...")
             m.new_toplevel = os.path.realpath(configs_path + "/" + m.name)
             if not os.path.exists(m.new_toplevel):
-                raise Exception("can't find closure of machine ‘{0}’".format(m.name))
+                raise Exception("can't find closure of machine '{0}'".format(m.name))
             m.copy_closure_to(m.new_toplevel)
 
         charon.parallel.run_tasks(nr_workers=len(self.active), tasks=self.active.itervalues(), worker_fun=worker)
@@ -317,7 +317,7 @@ class Deployment:
                 "cur=$(readlink /var/run/current-system); " +
                 'if [ "$cur" != ' + m.new_toplevel + " ]; then /nix/var/nix/profiles/system/bin/switch-to-configuration switch; fi",
                 check=False)
-            if res != 0: raise Exception("unable to activate new configuration on machine ‘{0}’".format(m.name))
+            if res != 0: raise Exception("unable to activate new configuration on machine '{0}'".format(m.name))
 
             # Record that we switched this machine to the new
             # configuration.
@@ -350,14 +350,14 @@ class Deployment:
         self.set_log_prefixes()
         
         # Determine the set of active machines.  (We can't just delete
-        # obsolete machines from ‘self.machines’ because they contain
+        # obsolete machines from 'self.machines' because they contain
         # important state that we don't want to forget about.)
         self.active = {}
         for m in self.machines.values():
             if m.name in self.definitions:
                 self.active[m.name] = m
             else:
-                self.log("machine ‘{0}’ is obsolete".format(m.name))
+                self.log("machine '{0}' is obsolete".format(m.name))
                 if not should_do(m, include, exclude): continue
                 if kill_obsolete and m.destroy(): self.delete_machine(m)
 
@@ -374,7 +374,7 @@ class Deployment:
                 if not should_do(m, include, exclude): return
                 defn = self.definitions[m.name]
                 if m.get_type() != defn.get_type():
-                    raise Exception("the type of machine ‘{0}’ changed from ‘{1}’ to ‘{2}’, which is currently unsupported"
+                    raise Exception("the type of machine '{0}' changed from '{1}' to '{2}', which is currently unsupported"
                                     .format(m.name, m.get_type(), defn.get_type()))
                 m.create(self.definitions[m.name], check=check)
                 m.wait_for_ssh(check=check)
@@ -390,7 +390,7 @@ class Deployment:
 
         self.configs_path = self.build_configs(include=include, exclude=exclude)
 
-        # Record configs_path in the state so that the ‘info’ command
+        # Record configs_path in the state so that the 'info' command
         # can show whether machines have an outdated configuration.
         self.write_state()
 
@@ -455,7 +455,7 @@ class Deployment:
         if not self.is_valid_machine_name(new_name):
             raise Exception("{0} is not a valid machine identifier.".format(new_name))
 
-        self.log("Renaming machine ‘{0}’ to ‘{1}’...".format(name, new_name))
+        self.log("Renaming machine '{0}' to '{1}'...".format(name, new_name))
         machine = self._machine_state.pop(name)
         self._machine_state[new_name] = machine
         self.write_state()

--- a/charon/util.py
+++ b/charon/util.py
@@ -11,7 +11,7 @@ import struct
 devnull = open(os.devnull, 'rw')
 
 def check_wait(test, initial=10, factor=1, max_tries=60):
-    """Call function ‘test’ periodically until it returns True or a timeout occurs."""
+    """Call function 'test' periodically until it returns True or a timeout occurs."""
     wait = initial
     tries = 0
     while tries < max_tries and not test():

--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -285,7 +285,7 @@ in
       if cfg.region == "us-east-1" && config.nixpkgs.system == "x86_64-linux" &&  cfg.ebsBoot then "ami-dabe1db3" else
       if cfg.region == "us-west-1" && config.nixpkgs.system == "x86_64-linux" && !cfg.ebsBoot then "ami-4996ce0c" else
       # !!! Doesn't work, not lazy enough.
-      #throw "I don't know an AMI for region ‘${cfg.region}’ and platform type ‘${config.nixpkgs.system}’"
+      #throw "I don't know an AMI for region '${cfg.region}' and platform type '${config.nixpkgs.system}'"
       "");
 
     # Workaround: the evaluation of blockDeviceMapping requires fileSystems to be defined.
@@ -319,7 +319,7 @@ in
                   # just check if the first sector is empty.
                   type=$(blkid -p -s TYPE -o value "${name}" || true)
                   if [ -z "$type" ]; then
-                    echo "initialising encryption on device ‘${name}’..."
+                    echo "initialising encryption on device '${name}'..."
                     cryptsetup luksFormat "${name}" --key-file=${keyFile}
                   fi
 

--- a/scripts/charon
+++ b/scripts/charon
@@ -117,7 +117,7 @@ def op_ssh():
     depl = deployment.Deployment(args.state_file, lock=False)
     (username, machine) = parse_machine(args.machine)
     m = depl.machines.get(machine)
-    if not m: raise Exception("unknown machine ‘{0}’".format(machine))
+    if not m: raise Exception("unknown machine '{0}'".format(machine))
     ssh_name = m.get_ssh_name()
     print >> sys.stderr, "connecting to {0}...".format(ssh_name)
     res = subprocess.call(["ssh", username + "@" + ssh_name] + m.get_ssh_flags() + args.args)
@@ -136,7 +136,7 @@ def op_ssh_for_each():
         results = []
         for m in depl.machines.itervalues():
             ssh_name = m.get_ssh_name()
-            print >> sys.stderr, "running command on ‘{0}’...".format(m.name)
+            print >> sys.stderr, "running command on '{0}'...".format(m.name)
             results.append(subprocess.call(["ssh", "root@" + ssh_name] + m.get_ssh_flags() + args.args))
     sys.exit(max(results))
 
@@ -148,7 +148,7 @@ def scp_loc(ssh_name, remote, loc):
 def op_scp():
     depl = deployment.Deployment(args.state_file, lock=False)
     m = depl.machines.get(args.machine)
-    if not m: raise Exception("unknown machine ‘{0}’".format(args.machine))
+    if not m: raise Exception("unknown machine '{0}'".format(args.machine))
     ssh_name = m.get_ssh_name()
     from_loc = scp_loc(ssh_name, args.scp_from, args.source)
     to_loc = scp_loc(ssh_name, args.scp_to, args.destination)

--- a/tests/none-backend.nix
+++ b/tests/none-backend.nix
@@ -125,7 +125,7 @@ in
       $coordinator->succeed("cp ${./id_test.pub} id_test.pub");
       $coordinator->succeed("charon create ./physical.nix ./logical.nix");
 
-      # Test ‘charon info’.
+      # Test 'charon info'.
       subtest "info-before", sub {
         $coordinator->succeed("${env} charon info >&2");
       };
@@ -138,17 +138,17 @@ in
         $target1->succeed("vim --version >&2");
       };
 
-      # Test ‘charon info’.
+      # Test 'charon info'.
       subtest "info-after", sub {
         $coordinator->succeed("${env} charon info >&2");
       };
       
-      # Test ‘charon ssh’.
+      # Test 'charon ssh'.
       subtest "ssh", sub {
         $coordinator->succeed("${env} charon ssh target1 -- -v ls / >&2");
       };
       
-      # Test ‘charon check’.
+      # Test 'charon check'.
       subtest "check", sub {
         $coordinator->succeed("${env} charon check");
       };


### PR DESCRIPTION
I don't know why it's really necessary to use unicode characters here, especially because if you are working in a heterogenous environment, not everyone will have unicode enabled terminals. In addition exactly those forward ticks trigger terminal codes which result in killing off the word within those quotes. I think that's not intended to happen with expressions you want to emphasize.
