### PR TITLE
ssh_util: Don't mutate flags passed by reference.

### DIFF
--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -150,7 +150,7 @@ class SSH(object):
         Start (if necessary) an SSH master connection to speed up subsequent
         SSH sessions. Returns the SSHMaster instance on success.
         """
-        flags += self._get_flags()
+        flags = flags + self._get_flags()
         if self._ssh_master is not None:
             return weakref.proxy(self._ssh_master)
 
@@ -203,10 +203,10 @@ class SSH(object):
         """
         tries = 5
         if timeout is not None:
-            flags += ["-o", "ConnectTimeout={0}".format(timeout)]
+            flags = flags + ["-o", "ConnectTimeout={0}".format(timeout)]
             tries = 1
         master = self.get_master(flags, tries)
-        flags += self._get_flags()
+        flags = flags + self._get_flags()
         if logged:
             flags.append("-x")
         cmd = ["ssh"] + master.opts + flags


### PR DESCRIPTION
There is a subtle difference in python between doing "l += x" and
"l = l + x" on lists, because the former will change the list instance
in place (brought to you by **iadd**).

See for example:

> > > l = [1,2,3]
> > > def foo(bar): bar = bar + [4,5,6]
> > > ...
> > > foo(l); l
> > > [1, 2, 3]
> > > def foo(bar): bar += [4,5,6]
> > > ...
> > > foo(l); l
> > > [1, 2, 3, 4, 5, 6]

This usually doesn't do much harm in case of SSH flags, but if you do
ssh-for-each on >= 100 machines, OpenSSH will bail out with:

Too many identity files specified (max 100)

So, we're going to use "flags = flags + x" now instead of +=, which
should fix the problem until the paramiko branch is ready for merge.

Thanks to @rbvermaa for the report.

Signed-off-by: aszlig aszlig@redmoonstudios.org
