### PR TITLE
Refactor SSH stuff into using paramiko.

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -250,8 +250,8 @@ class MachineState(nixops.resources.ResourceState):
                                                log_cb=self.logger.log_raw,
                                                **kwargs)
 
-    def invoke_shell(self):
-        return self._connect_ssh().invoke_shell()
+    def invoke_shell(self, command=None):
+        return self._connect_ssh().invoke_shell(command)
 
     def switch_to_configuration(self, method, sync, command=None):
         """

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -169,7 +169,8 @@ class MachineState(nixops.resources.ResourceState):
         self.run_command("mkdir -m 0700 -p /run/keys")
         for k, v in self.get_keys().items():
             self.log("uploading key ‘{0}’...".format(k))
-            self._connect_ssh().open("/run/keys/" + k, 'wb').write(v)
+            with self._connect_ssh().open("/run/keys/" + k, 'wb') as keyfile:
+                keyfile.write(v)
             self.run_command("chmod 600 /run/keys/" + k)
         self.run_command("touch /run/keys/done")
 

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -167,9 +167,10 @@ class MachineState(nixops.resources.ResourceState):
     def send_keys(self):
         if self.store_keys_on_machine: return
         self.run_command("mkdir -m 0700 -p /run/keys")
+        conn = self._connect_ssh()
         for k, v in self.get_keys().items():
             self.log("uploading key ‘{0}’...".format(k))
-            with self._connect_ssh().open("/run/keys/" + k, 'wb') as keyfile:
+            with conn.open("/run/keys/" + k, 'wb') as keyfile:
                 keyfile.write(v)
             self.run_command("chmod 600 /run/keys/" + k)
         self.run_command("touch /run/keys/done")

--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -257,7 +257,6 @@ class HetznerState(MachineState):
             server.reboot('hard')
             self.log_end("done.")
             self.state = self.STARTING
-            self.ssh.reset()
         else:
             MachineState.reboot(self, hard=hard)
 
@@ -290,7 +289,6 @@ class HetznerState(MachineState):
         self._wait_for_rescue(self.main_ipv4)
         self.rescue_passwd = rescue_passwd
         self.state = self.RESCUE
-        self.ssh.reset()
         if bootstrap:
             self._bootstrap_rescue(install, partitions)
 

--- a/nixops/logger.py
+++ b/nixops/logger.py
@@ -51,6 +51,13 @@ class Logger(object):
                 self._log_file.write(prefix)
             self._log_file.write(msg + "\n")
 
+    def log_raw(self, prefix, msg):
+        for line in msg.splitlines(True):
+            if line.endswith(('\n', '\r')):
+                self.log_end(prefix, line.rstrip('\r\n'))
+            else:
+                self.log_start(prefix, line)
+
     def get_logger_for(self, machine_name):
         """
         Returns a logger instance for a specific machine name.
@@ -141,6 +148,9 @@ class MachineLogger(object):
 
     def log_end(self, msg):
         self.main_logger.log_end(self._log_prefix, msg)
+
+    def log_raw(self, msg):
+        self.main_logger.log_raw(self._log_prefix, msg)
 
     def warn(self, msg):
         self.log(ansi_warn("warning: " + msg,

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -65,6 +65,28 @@ class SSHConnection(object):
         finally:
             termios.tcsetattr(sys.stdin, termios.TCSADRAIN, oldtty)
 
+    def upload(self, source, destination):
+        """
+        Upload the local file 'source' to the current host at 'destination'.
+        """
+        sftp = paramiko.SFTPClient.from_transport(self.ssh.get_transport())
+        sftp.put(source, destination)
+
+    def download(self, source, target):
+        """
+        Download the file 'source' from the current host to local file 'target'.
+        """
+        sftp = paramiko.SFTPClient.from_transport(self.ssh.get_transport())
+        sftp.get(source, target)
+
+    def open(self, *args, **kwargs):
+        """
+        Open a file instance on the remote side. This is the same as Python's
+        open() function but working on the remote file.
+        """
+        sftp = paramiko.SFTPClient.from_transport(self.ssh.get_transport())
+        return sftp.open(*args, **kwargs)
+
     def run_command(self, command, timeout=None, log_cb=None, bufsize=4096,
                     stdin_string=None, stdin=None, capture_stdout=False,
                     check=True):

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -89,7 +89,7 @@ class SSHConnection(object):
         stdin_done = stdin_string is None and stdin is None
         stdout = ""
         buf = ""
-        while not channel.eof_received:
+        while not channel.eof_received and not channel.closed:
             if not stdin_done and channel.send_ready():
                 if stdin_string is not None:
                     sent = channel.send(stdin_string[:bufsize])

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -206,5 +206,6 @@ class SSH(object):
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.MissingHostKeyPolicy())
         ssh.connect(host, username=username, key_filename=privkey,
-                    password=passwd, port=port, timeout=timeout)
+                    password=passwd, port=port, timeout=timeout,
+                    allow_agent=False, look_for_keys=False)
         return SSHConnection(ssh, host)

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -2,11 +2,12 @@
 import os
 import sys
 import tty
-import shlex
 import fcntl
 import struct
 import select
 import termios
+
+from contextlib import contextmanager
 
 import paramiko
 
@@ -79,13 +80,17 @@ class SSHConnection(object):
         sftp = paramiko.SFTPClient.from_transport(self.ssh.get_transport())
         sftp.get(source, target)
 
+    @contextmanager
     def open(self, *args, **kwargs):
         """
         Open a file instance on the remote side. This is the same as Python's
-        open() function but working on the remote file.
+        open() function but working on the remote file and using a context
+        manager. So you only can use this method using the with keyword.
         """
         sftp = paramiko.SFTPClient.from_transport(self.ssh.get_transport())
-        return sftp.open(*args, **kwargs)
+        fp = sftp.open(*args, **kwargs)
+        yield fp
+        fp.close()
 
     def run_command(self, command, timeout=None, log_cb=None, bufsize=4096,
                     stdin_string=None, stdin=None, capture_stdout=False,

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -31,7 +31,13 @@ class SSHConnection(object):
         self.ssh = ssh
         self.host = host
 
-    def invoke_shell(self):
+    def invoke_shell(self, command=None):
+        """
+        Invoke a 'command' on the target machine while allocating a PTY.
+
+        This is only meant to be used for interactive shells or programs and
+        doesn't directly allow for logging, such as run_command().
+        """
         transport = self.ssh.get_transport()
         channel = transport.open_session()
 
@@ -46,7 +52,10 @@ class SSHConnection(object):
         height, width = _get_term_size()
         current_term = os.getenv('TERM', 'vt100')
         channel.get_pty(current_term, width=width, height=height)
-        channel.invoke_shell()
+        if command is None:
+            channel.invoke_shell()
+        else:
+            channel.exec_command(command)
 
         oldtty = termios.tcgetattr(sys.stdin)
         oldflags = fcntl.fcntl(sys.stdin.fileno(), fcntl.F_GETFL)

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -151,12 +151,13 @@ class SSHConnection(object):
                 if stdin_done:
                     channel.shutdown_write()
 
-            if capture_stdout and channel.recv_stderr_ready():
-                data = channel.recv_stderr(bufsize)
-                if log_cb is not None:
-                    log_cb(data)
+            if capture_stdout:
+                while channel.recv_stderr_ready():
+                    data = channel.recv_stderr(bufsize)
+                    if log_cb is not None:
+                        log_cb(data)
 
-            if channel.recv_ready():
+            while channel.recv_ready():
                 data = channel.recv(bufsize)
                 if capture_stdout:
                     stdout += data

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -107,19 +107,17 @@ class SSHConnection(object):
                 if stdin_done:
                     channel.shutdown_write()
 
-                if not channel.recv_ready():
-                    continue
-
             if capture_stdout and channel.recv_stderr_ready():
                 data = channel.recv_stderr(bufsize)
                 if logger is not None:
                     logger.log_start(data)
 
-            data = channel.recv(bufsize)
-            if capture_stdout:
-                stdout += data
-            elif logger is not None:
-                logger.log_start(data)
+            if channel.recv_ready():
+                data = channel.recv(bufsize)
+                if capture_stdout:
+                    stdout += data
+                elif logger is not None:
+                    logger.log_start(data)
 
         exitcode = channel.recv_exit_status()
         if check and exitcode != 0:

--- a/release.nix
+++ b/release.nix
@@ -65,7 +65,15 @@ rec {
       buildInputs = [ pythonPackages.nose pythonPackages.coverage ];
 
       propagatedBuildInputs =
-        [ pythonPackages.paramiko
+        [ (pkgs.lib.overrideDerivation pythonPackages.paramiko (o: {
+            patches = (o.patches or []) ++ pkgs.lib.singleton (fetchurl {
+              # See https://github.com/paramiko/paramiko/pull/218
+              name = "ecdsa-private-keys.patch";
+              url = "https://github.com/aszlig/paramiko/compare/"
+                  + "c73764a947...ad33bb186f.diff";
+              sha256 = "1f1dxnd2di7jh3knn4qfipa46f6f9rqdzmc1lncwb3sbd772r8fx";
+            });
+          }))
           pythonPackages.prettytable
           pythonPackages.boto
           pythonPackages.hetzner

--- a/release.nix
+++ b/release.nix
@@ -65,7 +65,8 @@ rec {
       buildInputs = [ pythonPackages.nose pythonPackages.coverage ];
 
       propagatedBuildInputs =
-        [ pythonPackages.prettytable
+        [ pythonPackages.paramiko
+          pythonPackages.prettytable
           pythonPackages.boto
           pythonPackages.hetzner
           pythonPackages.sqlite3

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -15,6 +15,7 @@ import nixops.util
 import time
 from datetime import datetime
 from pprint import pprint
+from pipes import quote
 import logging
 import logging.handlers
 import syslog
@@ -478,9 +479,12 @@ def op_ssh():
     if not m: raise Exception("unknown machine ‘{0}’".format(machine))
     ssh_name = m.get_ssh_name()
     print >> sys.stderr, "connecting to {0}...".format(ssh_name)
-    # TODO: args.args quoting!
-    command = ' '.join(args.args) if len(args.args) > 0 else None
-    sys.exit(m.invoke_shell(command))
+    if len(args.args) > 0:
+        ret = m.invoke_shell(' '.join(map(quote, args.args)))
+    else:
+        ret = m.invoke_shell()
+    sys.exit(ret)
+
 
 def op_ssh_for_each():
     depl = open_deployment()
@@ -488,8 +492,7 @@ def op_ssh_for_each():
     jobs = args.parallel if args.parallel else 1
     def worker(m):
         if not nixops.deployment.should_do(m, args.include or [], args.exclude or []): return
-        # TODO: args.args quoting!
-        return m.run_command(' '.join(args.args), check=False)
+        return m.run_command(' '.join(map(quote, args.args)), check=False)
     results = nixops.parallel.run_tasks(nr_workers=len(depl.machines), tasks=depl.active.itervalues(), worker_fun=worker)
     sys.exit(max(results) if results != [] else 0)
 

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -479,8 +479,8 @@ def op_ssh():
     if not m: raise Exception("unknown machine ‘{0}’".format(machine))
     ssh_name = m.get_ssh_name()
     print >> sys.stderr, "connecting to {0}...".format(ssh_name)
-    if len(args.args) > 0:
-        ret = m.invoke_shell(' '.join(map(quote, args.args)))
+    if len(args.command) > 0:
+        ret = m.invoke_shell(' '.join(map(quote, args.command)))
     else:
         ret = m.invoke_shell()
     sys.exit(ret)
@@ -492,7 +492,7 @@ def op_ssh_for_each():
     jobs = args.parallel if args.parallel else 1
     def worker(m):
         if not nixops.deployment.should_do(m, args.include or [], args.exclude or []): return
-        return m.run_command(' '.join(map(quote, args.args)), check=False)
+        return m.run_command(' '.join(map(quote, args.command)), check=False)
     results = nixops.parallel.run_tasks(nr_workers=len(depl.machines), tasks=depl.active.itervalues(), worker_fun=worker)
     sys.exit(max(results) if results != [] else 0)
 
@@ -724,11 +724,13 @@ subparser.set_defaults(op=op_show_physical)
 subparser = add_subparser('ssh', help='login on the specified machine via SSH')
 subparser.set_defaults(op=op_ssh)
 subparser.add_argument('machine', metavar='MACHINE', help='identifier of the machine')
-subparser.add_argument('args', metavar="ARG", nargs='*', help='additional arguments to SSH')
+subparser.add_argument('command', metavar="COMMAND", nargs=argparse.REMAINDER,
+                       help='command to execute')
 
 subparser = add_subparser('ssh-for-each', help='execute a command on each machine via SSH')
 subparser.set_defaults(op=op_ssh_for_each)
-subparser.add_argument('args', metavar="ARG", nargs='*', help='additional arguments to SSH')
+subparser.add_argument('command', metavar="COMMAND", nargs=argparse.REMAINDER,
+                       help='command to execute on each machine')
 subparser.add_argument('--parallel', '-p', action='store_true', help='run in parallel')
 subparser.add_argument('--include', nargs='+', metavar='MACHINE-NAME', help='run command only on the specified machines')
 subparser.add_argument('--exclude', nargs='+', metavar='MACHINE-NAME', help='run command on all except the specified machines')

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -478,10 +478,11 @@ def op_ssh():
     if not m: raise Exception("unknown machine ‘{0}’".format(machine))
     ssh_name = m.get_ssh_name()
     print >> sys.stderr, "connecting to {0}...".format(ssh_name)
-    res = m.ssh.run_command(args.args, allow_ssh_args=True, logged=False,
-                            check=False)
-    sys.exit(res)
-
+    # TODO: args.args quoting!
+    if len(args.args) == 0:
+        sys.exit(m.invoke_shell())
+    else:
+        sys.exit(m.run_command(' '.join(args.args), check=False))
 
 def op_ssh_for_each():
     depl = open_deployment()
@@ -489,7 +490,8 @@ def op_ssh_for_each():
     jobs = args.parallel if args.parallel else 1
     def worker(m):
         if not nixops.deployment.should_do(m, args.include or [], args.exclude or []): return
-        return m.ssh.run_command(args.args, allow_ssh_args=True, check=False)
+        # TODO: args.args quoting!
+        return m.run_command(' '.join(args.args), check=False)
     results = nixops.parallel.run_tasks(nr_workers=len(depl.machines), tasks=depl.active.itervalues(), worker_fun=worker)
     sys.exit(max(results) if results != [] else 0)
 

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -479,10 +479,8 @@ def op_ssh():
     ssh_name = m.get_ssh_name()
     print >> sys.stderr, "connecting to {0}...".format(ssh_name)
     # TODO: args.args quoting!
-    if len(args.args) == 0:
-        sys.exit(m.invoke_shell())
-    else:
-        sys.exit(m.run_command(' '.join(args.args), check=False))
+    command = ' '.join(args.args) if len(args.args) > 0 else None
+    sys.exit(m.invoke_shell(command))
 
 def op_ssh_for_each():
     depl = open_deployment()

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -30,6 +30,14 @@ class RootLoggerTest(unittest.TestCase):
         self.root_logger.log_end("yyy: ", "end2")
         self.assert_log("xxx: begin1\nyyy: begin2\nxxx: end1\nyyy: end2\n")
 
+    def test_log_raw(self):
+        self.root_logger.log_raw(">", "aaa\nbb")
+        self.root_logger.log_raw(">", "b\nccc\n")
+        self.root_logger.log_raw(">", "ddd")
+        self.root_logger.log_raw(">", "\n")
+
+        self.assert_log(">aaa\n>bbb\n>ccc\n>ddd\n")
+
 class MachineLoggerTest(RootLoggerTest):
     def setUp(self):
         RootLoggerTest.setUp(self)

--- a/tests/unit/test_ssh_util.py
+++ b/tests/unit/test_ssh_util.py
@@ -61,6 +61,11 @@ class SSHTest(unittest.TestCase):
 
         channel = self.transport.accept(10)
         command = self.transport.server_object.command
+
+        if command == 'reboot':
+            channel.close()
+            return
+
         for i in itertools.count():
             data = channel.recv(self.BUFSIZE)
             if len(data) == 0:
@@ -147,3 +152,8 @@ class SSHTest(unittest.TestCase):
 
         self.assertEqual(len(output), 0)
         self.assert_textdiff(payload, ''.join(stderr))
+
+    def test_channel_closed(self):
+        client = self.connect_client()
+        result = client.run_command("reboot", check=False)
+        self.assertEqual(result, -1)

--- a/tests/unit/test_ssh_util.py
+++ b/tests/unit/test_ssh_util.py
@@ -1,0 +1,122 @@
+import os
+import unittest
+import socket
+import threading
+import itertools
+import difflib
+
+from StringIO import StringIO
+
+import paramiko
+
+from nixops.ssh_util import SSH
+
+
+class TestSSHServer(paramiko.ServerInterface):
+    def get_allowed_auths(self):
+        return 'publickey,password'
+
+    def check_auth_password(self, user, passwd):
+        return paramiko.AUTH_SUCCESSFUL
+
+    def check_auth_publickey(self, user, key):
+        return paramiko.AUTH_SUCCESSFUL
+
+    def check_channel_request(self, kind, chanid):
+        return paramiko.OPEN_SUCCEEDED
+
+    def check_channel_exec_request(self, channel, command):
+        return True
+
+
+class SSHTest(unittest.TestCase):
+    HOST_KEY = paramiko.RSAKey.generate(1024)
+    BUFSIZE = 1024
+
+    def setUp(self):
+        self.sock = socket.socket()
+        self.sock.bind(('localhost', 0))
+        self.sock.listen(1)
+        self.addr, self.port = self.sock.getsockname()
+        self.trigger = threading.Event()
+
+        threading.Thread(target=self.run_server).start()
+
+    def tearDown(self):
+        # Just ping the socket to ensure it won't block if something goes wrong
+        # before the first connect.
+        socket.create_connection((self.addr, self.port)).close()
+
+        for attrname in ('transport', 'server', 'sock'):
+            attr = getattr(self, attrname, None)
+            if attr is not None:
+                attr.close()
+
+    def run_server(self):
+        self.server, addr = self.sock.accept()
+        self.transport = paramiko.Transport(self.server)
+        self.transport.add_server_key(self.HOST_KEY)
+        self.transport.start_server(self.trigger, TestSSHServer())
+
+        channel = self.transport.accept(10)
+        for i in itertools.count():
+            data = channel.recv(self.BUFSIZE)
+            if len(data) == 0:
+                break
+            if i % 2 == 0:
+                channel.send(data)
+            else:
+                channel.send_stderr(data)
+        channel.send_exit_status(0)
+        channel.close()
+
+    def connect_client(self):
+        ssh = SSH()
+        client = ssh.connect(self.addr, port=self.port, passwd='')
+        self.trigger.wait(1.0)
+        self.assertTrue(self.trigger.isSet())
+        self.assertTrue(self.transport.is_authenticated())
+        return client
+
+    def pprint_text(self, text):
+        if len(text) > 20:
+            return "{0}... ({1} bytes)".format(text[:20], len(text))
+        else:
+            return text
+
+    def assert_textdiff(self, expect, result):
+        if expect == result:
+            return
+
+        delta = difflib.SequenceMatcher(a=expect, b=result)
+        diffs = []
+
+        for tag, i1, i2, j1, j2 in delta.get_opcodes():
+            if tag == 'delete':
+                msg = '{0} missing at position {1}'
+                diffs.append(msg.format(self.pprint_text(expect[i1:i2]), j1))
+            elif tag == 'replace':
+                msg = 'expected {0} at position {1}, but got {2} instead'
+                diffs.append(msg.format(self.pprint_text(expect[i1:i2]), j1,
+                                        self.pprint_text(result[j1:j2])))
+            elif tag == 'insert':
+                msg = 'excess {0} at position {1}'
+                diffs.append(msg.format(self.pprint_text(result[j1:j2]), i1))
+
+        self.fail(', '.join(diffs))
+
+    def test_stream_passthrough(self):
+        client = self.connect_client()
+        payload = ('A' * self.BUFSIZE + 'B' * self.BUFSIZE) * 100
+        stdin = StringIO(payload)
+        output = client.run_command("dummy", stdin=stdin, capture_stdout=True)
+
+        self.assert_textdiff('A' * self.BUFSIZE * 100, output)
+
+    def test_string_passthrough(self):
+        client = self.connect_client()
+        payload = ('A' * self.BUFSIZE + 'B' * self.BUFSIZE) * 100
+        output = client.run_command("dummy", stdin_string=payload,
+                                    capture_stdout=True)
+
+        self.assert_textdiff('A' * self.BUFSIZE * 100, output)


### PR DESCRIPTION
I know, this adds an additional dependency, but using `Popen` to execute OpenSSH directly, really is painful in [a](https://github.com/NixOS/nixops/blob/9893dc751d49f83f37eb4240ed9d5633f38c0b7f/nixops/backends/__init__.py#L368) [lot](https://github.com/aszlig/nixops/commit/ce0d4e66d963885afb7a03a05c7410e85afa566f) [of](https://github.com/aszlig/nixops/commit/9cca2d8d795f18c7c6490ba642ed335a770b5025) [cases](https://github.com/NixOS/nixops/blob/9893dc751d49f83f37eb4240ed9d5633f38c0b7f/nixops/backends/__init__.py#L39-L42) where we have to implement things using a bunch of temporary files and dirty workarounds. [Paramiko](https://github.com/paramiko/paramiko) on the other side is a pure Python implementation and it's way easier to handle keys, passwords, file uploads, persistent sessions (not to mention [host keys](https://github.com/NixOS/nixops/blob/d1cf2c065d726e14e6da192741e8aae780812a9a/nixops/known_hosts.py)) and other stuff without the need to create temporary files or do really ugly and error-prone workarounds.

The only thing I've stumbled on so far which can't be used directly is `nix-copy-closure`, but even there, we could use `nix-store --export/--import` directly and connect the `file` instances.

Things to finish before it's ready for merge:
- [x] File copying.
- [ ] Flags to `ssh-for-each` and `ssh` (what do people want here?)
- [x] Always allocate a PTY on `nixops ssh`.
- [x] Fix buffering issue on `nixops ssh`.
- [ ] Provide more meaningful error messages.
- [ ] Be more fault-tolerant so that we don't end up being in an unrecoverable state.
- [ ] Properly control agent and X-forwarding.
- [ ] Fix exception if stdin is a pipe/not a TTY.
- [ ] Refactor SSH channel stdin/stdout/stderr processing.
