### PR TITLE
hetzner: Fix type for prefixLength in net_info.

### DIFF
--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -459,7 +459,7 @@ class HetznerState(MachineState):
             ipv4, prefix = result
             iface_attrs[iface] = {
                 'ipAddress': ipv4,
-                'prefixLength': prefix,
+                'prefixLength': int(prefix),
             }
 
             # We can't handle Hetzner-specific networking info in test mode.


### PR DESCRIPTION
This actually was an oversight from the pretty-printer branch during a last-minute fix. Luckily the VM test is covering this and has properly failed:

http://hydra.nixos.org/build/5965297

To: @rbvermaa
