### PR TITLE
Add '--repair' option to nixos deploy.

### DIFF
--- a/doc/manual/nixops.xml
+++ b/doc/manual/nixops.xml
@@ -423,6 +423,7 @@ $ nixops delete -d foo</screen>
     <arg choice='plain'><option>-k</option></arg>
   </group>
   <arg><option>--dry-run</option></arg>
+  <arg><option>--repair</option></arg>
   <arg><option>--create-only</option></arg>
   <arg><option>--build-only</option></arg>
   <arg><option>--copy-only</option></arg>
@@ -482,6 +483,14 @@ them.</para>
 
     <listitem><para>Dry run; show what would be done by this command
     without actually doing it.</para></listitem>
+
+  </varlistentry>
+
+  <varlistentry><term><option>--repair</option></term>
+
+    <listitem><para>Use --repair when calling nix-build. This is useful
+    for repairing the nix store when some inconsistency is found and
+    nix-copy-closure is failing as a result.</para></listitem>
 
   </varlistentry>
 

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -519,7 +519,7 @@ class Deployment(object):
         return profile
 
 
-    def build_configs(self, include, exclude, dry_run=False):
+    def build_configs(self, include, exclude, dry_run=False, repair=False):
         """Build the machine configurations in the Nix store."""
 
         def write_temp_file(tmpfile, contents):
@@ -582,7 +582,8 @@ class Deployment(object):
                 + self._eval_flags(self.nix_exprs + [phys_expr]) +
                 ["--arg", "names", py2nix(names, inline=True),
                  "-A", "machines", "-o", self.tempdir + "/configs"]
-                + (["--dry-run"] if dry_run else []),
+                + (["--dry-run"] if dry_run else [])
+                + (["--repair"] if repair else []),
                 stderr=self.logger.log_file).rstrip()
         except subprocess.CalledProcessError:
             raise Exception("unable to build all machine configurations")
@@ -800,7 +801,7 @@ class Deployment(object):
     def _deploy(self, dry_run=False, build_only=False, create_only=False, copy_only=False,
                 include=[], exclude=[], check=False, kill_obsolete=False,
                 allow_reboot=False, allow_recreate=False, force_reboot=False,
-                max_concurrent_copy=5, sync=True, always_activate=False):
+                max_concurrent_copy=5, sync=True, always_activate=False, repair=False):
         """Perform the deployment defined by the deployment specification."""
 
         self.evaluate_active(include, exclude, kill_obsolete)
@@ -853,12 +854,12 @@ class Deployment(object):
 
         # Build the machine configurations.
         if dry_run:
-            self.build_configs(dry_run=True, include=include, exclude=exclude)
+            self.build_configs(dry_run=True, repair=repair, include=include, exclude=exclude)
             return
 
         # Record configs_path in the state so that the ‘info’ command
         # can show whether machines have an outdated configuration.
-        self.configs_path = self.build_configs(include=include, exclude=exclude)
+        self.configs_path = self.build_configs(repair=repair, include=include, exclude=exclude)
 
         if build_only: return
 

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -349,7 +349,8 @@ def op_deploy():
                 force_reboot=args.force_reboot,
                 max_concurrent_copy=args.max_concurrent_copy,
                 sync=not args.no_sync,
-                always_activate=args.always_activate)
+                always_activate=args.always_activate,
+                repair=args.repair)
 
 
 def op_send_keys():
@@ -668,6 +669,7 @@ subparser = add_subparser('deploy', help='deploy the network configuration')
 subparser.set_defaults(op=op_deploy)
 subparser.add_argument('--kill-obsolete', '-k', action='store_true', help='kill obsolete virtual machines')
 subparser.add_argument('--dry-run', action='store_true', help='show what would be done')
+subparser.add_argument('--repair', action='store_true', help='use --repair when calling nix-build (slow)')
 subparser.add_argument('--build-only', action='store_true', help='build only; do not perform deployment actions')
 subparser.add_argument('--create-only', action='store_true', help='exit after creating missing machines')
 subparser.add_argument('--copy-only', action='store_true', help='exit after copying closures')


### PR DESCRIPTION
This is useful for repairing the nix store when some inconsistency is found and nix-copy-closure is failing as a result.
