### PR TITLE
hetzner: Switch to nixos-generate-config.

### DIFF
--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -335,8 +335,10 @@ class HetznerState(MachineState):
 
     def _detect_hardware(self):
         self.log_start("detecting hardware...")
-        hardware = self.run_command("nixos-hardware-scan", capture_stdout=True)
-        self.hw_info = hardware
+        cmd = "nixos-generate-config --no-filesystems --show-hardware-config"
+        hardware = self.run_command(cmd, capture_stdout=True)
+        self.hw_info = '\n'.join([line for line in hardware.splitlines()
+                                  if not line.rstrip().startswith('#')])
         self.log_end("done.")
 
     def switch_to_configuration(self, method, sync, command=None):


### PR DESCRIPTION
First of all, because of the nixos->nixpkgs merge, we can no longer reference `nixos-hardware-scan` by using `<nixos>` and second, the commit NixOS/nixpkgs@3ed41735b84c44d30435b5a828b428419571d42e renames `nixos-hardware-scan` to `nixos-generate-config`.

Unfortunately, `nixos-generate-config` now no longer is very pipe-friendly and needed some fixups, see:
- NixOS/nixpkgs@f182fdf6ed3acf820a5f619eda9bffee1ecd1c46
- NixOS/nixpkgs@a546069ad34f72ac0ae57ae87b76fe26350494ad

These commits bring the back the old behaviour of simply printing the hardware configuration without `fileSystems` and `swapDevices` to stdout.

Unfortunately, another change was made: The new implementation now creates a hardware configuration file which contains UTF-8 sequences and thus causes trouble when writing them into a SQLite database.

We have three options here:
- Simply remove the comments of the hardware configuration.
- Properly `.decode('utf-8')` the file and convert back the value on the next database read.
- Use binary encoding when working with the state database.

As both the second and third option require lots of patching, we're going for the first option of simply stripping off the comments as they're not really appropriate for our purposes as we don't allow it to be generated explicitely (yet).
