### PR TITLE
hetzner: Truncate server name at 100 chars instead of 50

### DIFF
--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -541,10 +541,7 @@ class HetznerState(MachineState):
             self._detect_hardware()
             server = self._get_server_by_ip(self.main_ipv4)
             vm_id = "nixops-{0}-{1}".format(self.depl.uuid, self.name)
-            # XXX: Truncated to 50 chars until the Robot allows more.
-            #      And this also means, that this field is unreliable so we
-            #      can't use it for uniquely identifying machine UUIDs.
-            server.set_name(vm_id[:50])
+            server.set_name(vm_id[:100])
             self.vm_id = vm_id
             known_hosts.remove(self.main_ipv4)
             self.just_installed = True


### PR DESCRIPTION
The increase of the server name length was part of my wishlist to the folks at Hetzner which they implemented in the meantime (before, the maximum length was 50 chars which leaves room for the UUID but truncated host names at 6 chars). So thanks to the Hetzner Robot team for increasing that limit.

For us, this means that we can store the full `vm_id` in the Robot which currently only makes it easier to distinguish individial NixOps hosts in the Robot.

In the long term however, it could be useful reconstructing/recovering deploments (see #2).
