### PR TITLE
Add deployment.useHostNixStore option

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -87,7 +87,7 @@ rec {
 
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
-        { inherit (v.config.deployment) targetEnv targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys;
+        { inherit (v.config.deployment) targetEnv targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate useHostNixStore owners keys;
           #adhoc = optionalAttrs (v.config.deployment.targetEnv == "adhoc") v.config.deployment.adhoc;
           ec2 = optionalAttrs (v.config.deployment.targetEnv == "ec2") v.config.deployment.ec2;
           hetzner = optionalAttrs (v.config.deployment.targetEnv == "hetzner") v.config.deployment.hetzner;

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -94,6 +94,19 @@ in
       '';
     };
 
+    deployment.useHostNixStore = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If true, no store paths are copied to the deployed machine. Instead
+        the Nix store of host is mounted on the deployed machine and used in
+        read-only mode. This option is not supported by all nixops target
+        environments. The <literal>none</literal> target environment supports it
+        but don't provide an automatic way of setting up the required store
+        mount.
+      '';
+    };
+
     # Computed options useful for referring to other machines in
     # network specifications.
 
@@ -120,6 +133,15 @@ in
 
 
   config = {
+
+    assertions = [
+      { assertion = cfg.useHostNixStore -> (cfg.targetEnv == "none" || cfg.targetEnv == "virtualbox");
+        message = ''
+          The option useHostNixStore is not supported by the
+          target environment ${cfg.targetEnv}
+        '';
+      }
+    ];
 
     deployment.targetHost = mkDefault config.networking.hostName;
 

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -18,6 +18,7 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
         self.encrypted_links_to = set([e.get("value") for e in xml.findall("attrs/attr[@name='encryptedLinksTo']/list/string")])
         self.store_keys_on_machine = xml.find("attrs/attr[@name='storeKeysOnMachine']/bool").get("value") == "true"
         self.always_activate = xml.find("attrs/attr[@name='alwaysActivate']/bool").get("value") == "true"
+        self.use_host_nix_store = xml.find("attrs/attr[@name='useHostNixStore']/bool").get("value") == "true"
         self.keys = {k.get("name"): k.find("string").get("value") for k in xml.findall("attrs/attr[@name='keys']/attrs/attr")}
         self.owners = [e.get("value") for e in xml.findall("attrs/attr[@name='owners']/list/string")]
 

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -627,11 +627,12 @@ class Deployment(object):
 
         def worker(m):
             if not should_do(m, include, exclude): return
-            m.logger.log("copying closure...")
             m.new_toplevel = os.path.realpath(configs_path + "/" + m.name)
             if not os.path.exists(m.new_toplevel):
                 raise Exception("can't find closure of machine ‘{0}’".format(m.name))
-            m.copy_closure_to(m.new_toplevel)
+            if not self.definitions[m.name].use_host_nix_store:
+                m.logger.log("copying closure...")
+                m.copy_closure_to(m.new_toplevel)
 
         nixops.parallel.run_tasks(
             nr_workers=max_concurrent_copy,


### PR DESCRIPTION
If true, no store paths are copied to the deployed machine. Instead
the Nix store of host is mounted on the deployed machine and used in
read-only mode. This option is not supported by all nixops target
environments. The <literal>none</literal> target environment supports it
but don't provide an automatic way of setting up the required store
mount.
