### PR TITLE
try prefix match if no uuid is found in Deployments

### DIFF
--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -125,7 +125,15 @@ class StateFile(object):
         else:
             c.execute("select uuid from Deployments d where uuid = ? or exists (select 1 from DeploymentAttrs where deployment = d.uuid and name = 'name' and value = ?)", (uuid, uuid))
         res = c.fetchall()
-        if len(res) == 0: return None
+        if len(res) == 0:
+            if uuid:
+                # try the prefix match
+                c.execute("select uuid from Deployments where uuid glob ?", (uuid + '*', ))
+                res = c.fetchall()
+                if len(res) == 0:
+                    return None
+            else:
+                return None
         if len(res) > 1:
             if uuid:
                 raise Exception("state file contains multiple deployments with the same name, so you should specify one using its UUID")


### PR DESCRIPTION
allows to run stuff like
% nixops deploy -d 63   # while uuid is 63147f87-bbb4-11e3-b8ac-8c2937e6c6de
