### PR TITLE
backends: Check units with systemctl --no-legend.

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -102,7 +102,8 @@ class MachineState(nixops.resources.ResourceState):
             res.load = avg
 
             # Get the systemd units that are in a failed state or in progress.
-            out = self.run_command("systemctl --all --full", capture_stdout=True).split('\n')
+            out = self.run_command("systemctl --all --full --no-legend",
+                                   capture_stdout=True).split('\n')
             res.failed_units = []
             res.in_progress_units = []
             for l in out:


### PR DESCRIPTION
If legend is enabled, the unit names are indented by two spaces in systemd 212. But if used with `--no-legend` we not only get something that resembles the old behaviour (without the initial two spaces), we also can be sure that we don't match anything in the legend and/or additional descriptions around the actual content.
