### PR TITLE
Stop using openssh from nixpkgs on Darwin to avoid NixOS/nix#243

### DIFF
--- a/nix/virtualbox-image-nixops.nix
+++ b/nix/virtualbox-image-nixops.nix
@@ -23,10 +23,10 @@ in
           VBoxControl -nologo guestproperty get /VirtualBox/GuestInfo/Charon/ClientPublicKey | sed 's/Value: //' > ${clientKeyPath}.tmp
           mv ${clientKeyPath}.tmp ${clientKeyPath}
 
-          if [[ ! -f /etc/ssh/ssh_host_ecdsa_key ]]; then
-            VBoxControl -nologo guestproperty get /VirtualBox/GuestInfo/Charon/PrivateHostKey | sed 's/Value: //' > /etc/ssh/ssh_host_ecdsa_key.tmp
-            mv /etc/ssh/ssh_host_ecdsa_key.tmp /etc/ssh/ssh_host_ecdsa_key
-            chmod 0600 /etc/ssh/ssh_host_ecdsa_key
+          if [[ ! -f /etc/ssh/ssh_host_rsa_key ]]; then
+            VBoxControl -nologo guestproperty get /VirtualBox/GuestInfo/Charon/PrivateHostKey | sed 's/Value: //' > /etc/ssh/ssh_host_rsa_key.tmp
+            mv /etc/ssh/ssh_host_rsa_key.tmp /etc/ssh/ssh_host_rsa_key
+            chmod 0600 /etc/ssh/ssh_host_rsa_key
           fi
         '';
     };

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -217,7 +217,7 @@ def attr_property(name, default, type=str):
     return property(get, set)
 
 
-def create_key_pair(key_name="NixOps auto-generated key", type="ecdsa"):
+def create_key_pair(key_name="NixOps auto-generated key", type="rsa"):
     key_dir = tempfile.mkdtemp(prefix="nixops-tmp")
     res = subprocess.call(["ssh-keygen", "-t", type, "-f", key_dir + "/key", "-N", '', "-C", key_name],
                           stdout=devnull)

--- a/release.nix
+++ b/release.nix
@@ -91,8 +91,9 @@ rec {
           cp -av nix/* $out/share/nix/nixops
 
           # Add openssh to nixops' PATH. On some platforms, e.g. CentOS and RHEL
-          # the version of openssh is causing errors when have big networks (40+)
-          wrapProgram $out/bin/nixops --prefix PATH : "${openssh}/bin"
+          # the version of openssh is causing errors when have big networks (40+).
+          # Do not do that on Darwin due to random failures of nixpkgs openssh.
+          wrapProgram $out/bin/nixops ${if stdenv.isDarwin then '''' else ''--prefix PATH : "${openssh}/bin"''}
         ''; # */
 
       meta.description = "Nix package for ${stdenv.system}";


### PR DESCRIPTION
(Darwin version doesn't seems to manifest such errors)

Since Darwin's ssh doesn't yet support ecdsa, stop generating ecdsa keys by
default.
