### PR TITLE
add placement group

### DIFF
--- a/nix/ec2-placement-group.nix
+++ b/nix/ec2-placement-group.nix
@@ -1,0 +1,35 @@
+{ config, pkgs, uuid, name, ... }:
+
+with pkgs.lib;
+
+{
+
+  options = {
+
+    name = mkOption {
+      default = "charon-${uuid}-${name}";
+      type = types.str;
+      description = "Name of the placement group.";
+    };
+
+    strategy = mkOption {
+      default = "cluster";
+      type = types.str;
+      description = "The placement strategy of the new placement group. Currently, the only acceptable value is “cluster”.";
+    };
+
+    region = mkOption {
+      type = types.str;
+      description = "Amazon EC2 region.";
+    };
+
+    accessKeyId = mkOption {
+      default = "";
+      type = types.str;
+      description = "The AWS Access Key ID.";
+    };
+  };
+
+  config._type = "ec2-placement-group";
+
+}

--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -324,6 +324,16 @@ in
       '';
     };
 
+    deployment.ec2.placementGroup = mkOption {
+      default = "";
+      example = "my-cluster";
+      type = union types.str (resource "ec2-placement-group");
+      apply = x: if builtins.isString x then x else x.name;
+      description = ''
+        Placement group for the instance.
+      '';
+    };
+
     deployment.ec2.tags = mkOption {
       default = { };
       example = { foo = "bar"; xyzzy = "bla"; };

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -79,6 +79,7 @@ rec {
   resources.s3Buckets = evalResources ./s3-bucket.nix (zipAttrs resourcesByType.s3Buckets or []);
   resources.iamRoles = evalResources ./iam-role.nix (zipAttrs resourcesByType.iamRoles or []);
   resources.ec2SecurityGroups = evalResources ./ec2-security-group.nix (zipAttrs resourcesByType.ec2SecurityGroups or []);
+  resources.ec2PlacementGroups = evalResources ./ec2-placement-group.nix (zipAttrs resourcesByType.ec2PlacementGroups or []);
   resources.ebsVolumes = evalResources ./ebs-volume.nix (zipAttrs resourcesByType.ebsVolumes or []);
   resources.elasticIPs = evalResources ./elastic-ip.nix (zipAttrs resourcesByType.elasticIPs or []);
 

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -367,6 +367,7 @@ import nixops.resources.sqs_queue
 import nixops.resources.s3_bucket
 import nixops.resources.iam_role
 import nixops.resources.ec2_security_group
+import nixops.resources.ec2_placement_group
 import nixops.resources.ebs_volume
 import nixops.resources.elastic_ip
 
@@ -393,6 +394,7 @@ def create_state(depl, type, name, id):
               nixops.resources.iam_role.IAMRoleState,
               nixops.resources.s3_bucket.S3BucketState,
               nixops.resources.ec2_security_group.EC2SecurityGroupState,
+              nixops.resources.ec2_placement_group.EC2PlacementGroupState,
               nixops.resources.ebs_volume.EBSVolumeState,
               nixops.resources.elastic_ip.ElasticIPState
               ]:

--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -45,6 +45,7 @@ class EC2Definition(MachineDefinition):
         self.key_pair = x.find("attr[@name='keyPair']/string").get("value")
         self.private_key = x.find("attr[@name='privateKey']/string").get("value")
         self.security_groups = [e.get("value") for e in x.findall("attr[@name='securityGroups']/list/string")]
+        self.placement_group = x.find("attr[@name='placementGroup']/string").get("value")
         self.instance_profile = x.find("attr[@name='instanceProfile']/string").get("value")
         self.tags = {k.get("name"): k.find("string").get("value") for k in x.findall("attr[@name='tags']/attrs/attr")}
         self.root_disk_size = int(x.find("attr[@name='ebsInitialRootDiskSize']/int").get("value"))
@@ -97,6 +98,7 @@ class EC2State(MachineState):
     private_key_file = nixops.util.attr_property("ec2.privateKeyFile", None)
     instance_profile = nixops.util.attr_property("ec2.instanceProfile", None)
     security_groups = nixops.util.attr_property("ec2.securityGroups", None, 'json')
+    placement_group = nixops.util.attr_property("ec2.placementGroup", None, 'json')
     tags = nixops.util.attr_property("ec2.tags", {}, 'json')
     block_device_mapping = nixops.util.attr_property("ec2.blockDeviceMapping", {}, 'json')
     root_device_type = nixops.util.attr_property("ec2.rootDeviceType", None)
@@ -132,6 +134,7 @@ class EC2State(MachineState):
             self.private_host_key = None
             self.instance_profile = None
             self.security_groups = None
+            self.placement_group = None
             self.tags = {}
             self.block_device_mapping = {}
             self.root_device_type = None
@@ -422,6 +425,7 @@ class EC2State(MachineState):
                 isinstance(r, nixops.resources.ec2_keypair.EC2KeyPairState) or
                 isinstance(r, nixops.resources.iam_role.IAMRoleState) or
                 isinstance(r, nixops.resources.ec2_security_group.EC2SecurityGroupState) or
+                isinstance(r, nixops.resources.ec2_placement_group.EC2PlacementGroupState) or
                 isinstance(r, nixops.resources.ebs_volume.EBSVolumeState) or
                 isinstance(r, nixops.resources.elastic_ip.ElasticIPState)}
 
@@ -543,6 +547,7 @@ class EC2State(MachineState):
             placement=zone,
             key_name=defn.key_pair,
             security_groups=defn.security_groups,
+            placement_group=defn.placement_group,
             block_device_map=devmap,
             user_data=user_data,
             image_id=defn.ami,
@@ -763,6 +768,7 @@ class EC2State(MachineState):
                 self.instance_type = defn.instance_type
                 self.key_pair = defn.key_pair
                 self.security_groups = defn.security_groups
+                self.placement_group = defn.placement_group
                 self.zone = instance.placement
                 self.client_token = None
                 self.private_host_key = None
@@ -794,6 +800,12 @@ class EC2State(MachineState):
                 'cannot change security groups of an existing instance (from [{0}] to [{1}])'.format(
                     ", ".join(set(defn.security_groups)),
                     ", ".join(instance_groups))
+            )
+        if defn.placement_group != instance.placement_group:
+            self.warn(
+                'cannot change placement group of an existing instance (from [{0}] to [{1}])'.format(
+                    defn.placement_group,
+                    instance.placement_group)
             )
 
         # Reapply tags if they have changed.

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -335,6 +335,10 @@ class Deployment(object):
             defn = nixops.resources.ec2_security_group.EC2SecurityGroupDefinition(x)
             self.definitions[defn.name] = defn
 
+        for x in res.find("attr[@name='ec2PlacementGroups']/attrs").findall("attr"):
+            defn = nixops.resources.ec2_placement_group.EC2PlacementGroupDefinition(x)
+            self.definitions[defn.name] = defn
+
         for x in res.find("attr[@name='ebsVolumes']/attrs").findall("attr"):
             defn = nixops.resources.ebs_volume.EBSVolumeDefinition(x)
             self.definitions[defn.name] = defn

--- a/nixops/resources/ec2_placement_group.py
+++ b/nixops/resources/ec2_placement_group.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+
+# Automatic provisioning of EC2 placement groups
+
+import boto.ec2.placementgroup
+import nixops.resources
+import nixops.util
+import nixops.ec2_utils
+
+class EC2PlacementGroupDefinition(nixops.resources.ResourceDefinition):
+    """Definition of an EC2 placement group."""
+
+    @classmethod
+    def get_type(cls):
+        return "ec2-placement-group"
+
+    def __init__(self, xml):
+        super(EC2PlacementGroupDefinition, self).__init__(xml)
+        self.placement_group_name = xml.find("attrs/attr[@name='name']/string").get("value")
+        self.placement_group_strategy = xml.find("attrs/attr[@name='strategy']/string").get("value")
+        self.region = xml.find("attrs/attr[@name='region']/string").get("value")
+        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get("value")
+
+    def show_type(self):
+        return "{0} [{1}]".format(self.get_type(), self.region)
+
+class EC2PlacementGroupState(nixops.resources.ResourceState):
+    """State of an EC2 placement group."""
+
+    region = nixops.util.attr_property("ec2.region", None)
+    placement_group_name = nixops.util.attr_property("ec2.placementGroupName", None)
+    placement_group_strategy = nixops.util.attr_property("ec2.placementGroupStrategy", None)
+    old_placement_groups = nixops.util.attr_property("ec2.oldPlacementGroups", [], 'json')
+    access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
+
+    @classmethod
+    def get_type(cls):
+        return "ec2-placement-group"
+
+    def __init__(self, depl, name, id):
+        super(EC2PlacementGroupState, self).__init__(depl, name, id)
+        self._conn = None
+
+    def show_type(self):
+        s = super(EC2PlacementGroupState, self).show_type()
+        if self.region: s = "{0} [{1}]".format(s, self.region)
+        return s
+
+    def prefix_definition(self, attr):
+        return {('resources', 'ec2PlacementGroups'): attr}
+
+    def get_physical_spec(self):
+        return {}
+
+    @property
+    def resource_id(self):
+        return self.placement_group_name
+
+    def create_after(self, resources):
+        return {}
+
+    def _connect(self):
+        if self._conn: return
+        self._conn = nixops.ec2_utils.connect(self.region, self.access_key_id)
+
+    def create(self, defn, check, allow_reboot, allow_recreate):
+        # Name or region change means a completely new security group
+        if self.placement_group_name and (defn.placement_group_name != self.placement_group_name or defn.region != self.region):
+            with self.depl._db:
+                self.state = self.UNKNOWN
+                self.old_placement_groups = self.old_placement_groups + [{'name': self.placement_group_name, 'region': self.region}]
+
+        with self.depl._db:
+            self.region = defn.region
+            self.access_key_id = defn.access_key_id or nixops.ec2_utils.get_access_key_id()
+            self.placement_group_name = defn.placement_group_name
+            self.placement_group_strategy = defn.placement_group_strategy
+
+        grp = None
+        if check:
+            with self.depl._db:
+                self._connect()
+
+                try:
+                    grp = self._conn.get_all_placement_groups([ defn.placement_group_name ])[0]
+                    self.state = self.UP
+                    self.placement_group_strategy = grp.strategy
+                except boto.exception.EC2ResponseError as e:
+                    if e.error_code == u'InvalidGroup.NotFound':
+                        self.state = self.Missing
+                    else:
+                        raise
+
+        if self.state == self.MISSING or self.state == self.UNKNOWN:
+            self._connect()
+            try:
+                self.logger.log("creating EC2 placement group ‘{0}’...".format(self.placement_group_name))
+                created = self._conn.create_placement_group(self.placement_group_name, self.placement_group_strategy)
+            except boto.exception.EC2ResponseError as e:
+                if self.state != self.UNKNOWN or e.error_code != u'InvalidGroup.Duplicate':
+                    raise
+
+        self.state = self.UP
+
+    def after_activation(self, defn):
+        region = self.region
+        self._connect()
+        conn = self._conn
+        for group in self.old_placement_groups:
+            if group['region'] != region:
+                region = group['region']
+                conn = nixops.ec2_utils.connect(region, self.access_key_id)
+            try:
+                conn.delete_placement_group(group['name'])
+            except boto.exception.EC2ResponseError as e:
+                if e.error_code != u'InvalidGroup.NotFound':
+                    raise
+        self.old_placement_groups = []
+
+    def destroy(self, wipe=False):
+        if self.state == self.UP or self.state == self.STARTING:
+            self.logger.log("deleting EC2 placement group `{0}'...".format(self.placement_group_name))
+            self._connect()
+            self._conn.delete_placement_group(self.placement_group_name)
+            self.state = self.MISSING
+        return True


### PR DESCRIPTION
This patch allows to group EC2 instances for applications that benefit from low network latency, high network throughput, or both.

See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html.
