### PR TITLE
Use dedicated SSH keypair for "none" backend.

### DIFF
--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -33,6 +33,10 @@ class NoneState(MachineState):
     def __init__(self, depl, name, id):
         MachineState.__init__(self, depl, name, id)
 
+    @property
+    def resource_id(self):
+        return self.vm_id
+
     def create(self, defn, check, allow_reboot, allow_recreate):
         assert isinstance(defn, NoneDefinition)
         self.set_common_state(defn)

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -50,7 +50,8 @@ class NoneState(MachineState):
             cmd = ("umask 077; "
                    "mkdir -p .ssh && cat >> .ssh/authorized_keys || exit 1")
             self._logged_exec(["ssh", "-p", str(self.ssh_port), "-l", "root",
-                               self.get_ssh_name(), cmd], stdin_string=pubkey)
+                               self.get_ssh_name(), cmd],
+                              stdin_string=pubkey.rstrip() + "\n")
 
             self._ssh_private_key, self._ssh_public_key = privkey, pubkey
             self.vm_id = "nixops-{0}-{1}".format(self.depl.uuid, self.name)

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -68,7 +68,10 @@ class NoneState(MachineState):
                 "-i", self.get_ssh_private_key_file()]
 
     def _check(self, res):
-        res.exists = True # can't really check
+        if not self.vm_id:
+            res.exists = False
+            return
+        res.exists = True
         res.is_up = nixops.util.ping_tcp_port(self.target_host, self.ssh_port)
         if res.is_up:
             MachineState._check(self, res)

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
+import os
+import sys
+import nixops.util
 
 from nixops.backends import MachineDefinition, MachineState
-import nixops.util
-import sys
+from nixops.util import attr_property, create_key_pair
+
 
 class NoneDefinition(MachineDefinition):
     """Definition of a trivial machine."""
@@ -24,6 +27,8 @@ class NoneState(MachineState):
         return "none"
 
     target_host = nixops.util.attr_property("targetHost", None)
+    _ssh_private_key = attr_property("none.sshPrivateKey", None)
+    _ssh_public_key = attr_property("none.sshPublicKey", None)
 
     def __init__(self, depl, name, id):
         MachineState.__init__(self, depl, name, id)
@@ -33,9 +38,34 @@ class NoneState(MachineState):
         self.set_common_state(defn)
         self.target_host = defn._target_host
 
+        if not self.vm_id:
+            self.log("installing new SSH keypair on machine...")
+            key_name = "NixOps client key for {0}".format(self.name)
+            privkey, pubkey = create_key_pair(key_name=key_name)
+
+            cmd = ("umask 077; "
+                   "mkdir -p .ssh && cat >> .ssh/authorized_keys || exit 1")
+            self._logged_exec(["ssh", "-p", str(self.ssh_port), "-l", "root",
+                               self.get_ssh_name(), cmd], stdin_string=pubkey)
+
+            self._ssh_private_key, self._ssh_public_key = privkey, pubkey
+            self.vm_id = "nixops-{0}-{1}".format(self.depl.uuid, self.name)
+
     def get_ssh_name(self):
         assert self.target_host
         return self.target_host
+
+    def get_ssh_private_key_file(self):
+        if self._ssh_private_key_file:
+            return self._ssh_private_key_file
+        else:
+            return self.write_ssh_private_key(self._ssh_private_key)
+
+    def get_ssh_flags(self):
+        if not self.vm_id:
+            return []
+        return ["-o", "StrictHostKeyChecking=no",
+                "-i", self.get_ssh_private_key_file()]
 
     def _check(self, res):
         res.exists = True # can't really check

--- a/tests/none-backend.nix
+++ b/tests/none-backend.nix
@@ -158,6 +158,7 @@ makeTest {
         $target1->fail("vim --version");
         $coordinator->succeed("${env} nixops deploy --build-only");
         $coordinator->succeed("${env} nixops deploy");
+        $coordinator->succeed("rm ~/.ssh/id_dsa");
         $target1->succeed("vim --version >&2");
       };
 

--- a/tests/none-backend.nix
+++ b/tests/none-backend.nix
@@ -162,6 +162,13 @@ makeTest {
         $target1->succeed("vim --version >&2");
       };
 
+      # Test whether authorized_keys file has been written correctly.
+      subtest "authorized_keys", sub {
+        $coordinator->succeed("${env} nixops ssh target1 -- " .
+                              "'(cat .ssh/authorized_keys; echo xxx) | " .
+                              "grep -q \"^xxx\"'");
+      };
+
       # Test ‘nixops info’.
       subtest "info-after", sub {
         $coordinator->succeed("${env} nixops info >&2");


### PR DESCRIPTION
This should make the "none" backend a bit more useful as we only need to provide a key _or_ passphrase on machine creation and from thereon we only use the SSH keys within NixOps' state database.

If you have a large set of "none" machines and want to export/import them, this should no longer require to move around `ssh_config`s or even entries in your hosts file.

In addition, this fixes the situation where you need to build on the target machines and the none backend wasn't able to provide a private key for the to be generated `nix.machines` file.

VM test result: https://headcounter.org/hydra/job/nixops/none-improvements/tests.none_backend/latest
(also required fixing the VM tests)

This is related to #200 and after talking to @joelton on IRC it turned out he was on Darwin, so NixOps was trying to build on the target machine(s), which in turn requires explicitly specifying a private key. As we now have the keypair in our own db, this is no longer an issue.