### PR TITLE
MachineState: Don't send keys within state.RESCUE.

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -174,6 +174,12 @@ class MachineState(nixops.resources.ResourceState):
                   " system.".format(self.name))
 
     def send_keys(self):
+        if self.state == self.RESCUE:
+            # Don't send keys when in RESCUE state, because we're most likely
+            # bootstrapping plus we probably don't have /run mounted properly
+            # so keys will probably end up being written to DISK instead of
+            # into memory.
+            return
         if self.store_keys_on_machine: return
         self.run_command("mkdir -m 0700 -p /run/keys")
         for k, v in self.get_keys().items():


### PR DESCRIPTION
This will store keys on the machine's disk when you try to deploy a machine expression that has `deployment.keys` set, because in rescue state we don't have `/run` mounted.

If you want to manually get rid of `/run/keys` from your disk you can access the files that are covered by another mount using a bind mount of the parent directory, so you can delete the keys using something like this:

``` sh
mkdir /delkeys
mount --bind / /delkeys
rm -r /delkeys/run/keys
umount /delkeys
rmdir /delkeys
```

But that's no longer necessary since release `14.04`, because the stage 2 init script does a `rm -rf /run/keys` on bootup already.
