### PR TITLE
hetzner-bootstrap: Fix evaluation for latest <nixpkgs>.

### DIFF
--- a/nix/hetzner-bootstrap.nix
+++ b/nix/hetzner-bootstrap.nix
@@ -12,6 +12,7 @@ let
     config = {};
     inherit pkgs;
     modulesPath = "";
+    lib = pkgs.lib;
   }).config.system.build.nixos-generate-config;
 
   base = stdenv.mkDerivation {


### PR DESCRIPTION
The commit NixOS/nixpkgs@b3cfb90 added a `lib` argument to the function attrset of `<nixpkgs/nixos/modules/installer/tools/tools.nix>`, so we need to pass it on our side as well.

This change should be backwards-compatible, because the lib argument isn't used for `nixos-generate-config`.
