### PR TITLE
Control the subnet that an instance is started in

### DIFF
--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -324,6 +324,32 @@ in
       '';
     };
 
+    deployment.ec2.securityGroupIds = mkOption {
+      type = types.listOf types.str;
+      description = ''
+        Security Group IDs for the instance. Necessary if starting
+        an instance inside a VPC/subnet. In the non-default VPC, security
+        groups needs to be specified by ID and not name.
+      '';
+    };
+
+    deployment.ec2.subnetId = mkOption {
+      example = "subnet-9d4a7b6c";
+      type = types.str;
+      description = ''
+        The subnet inside a VPC to launch the instance in.
+      '';
+    };
+
+    deployment.ec2.associatePublicIpAddress = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        If instance in a subnet/VPC, whether to associate a public
+        IP address with the instance.
+      '';
+    };
+
     deployment.ec2.placementGroup = mkOption {
       default = "";
       example = "my-cluster";

--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -10,6 +10,7 @@ import getpass
 import shutil
 import boto.ec2
 import boto.ec2.blockdevicemapping
+import boto.ec2.networkinterface
 from nixops.backends import MachineDefinition, MachineState
 from nixops.nix_expr import Function, RawValue
 from nixops.resources.ebs_volume import EBSVolumeState
@@ -51,6 +52,9 @@ class EC2Definition(MachineDefinition):
         self.root_disk_size = int(x.find("attr[@name='ebsInitialRootDiskSize']/int").get("value"))
         self.spot_instance_price = int(x.find("attr[@name='spotInstancePrice']/int").get("value"))
         self.ebs_optimized = x.find("attr[@name='ebsOptimized']/bool").get("value") == "true"
+        self.subnet_id = x.find("attr[@name='subnetId']/string").get("value")
+        self.associate_public_ip_address = x.find("attr[@name='associatePublicIpAddress']/bool").get("value") == "true"
+        self.security_group_ids = [e.get("value") for e in x.findall("attr[@name='securityGroupIds']/list/string")]
 
         def f(xml):
             return {'disk': xml.find("attrs/attr[@name='disk']/string").get("value"),
@@ -109,6 +113,7 @@ class EC2State(MachineState):
     client_token = nixops.util.attr_property("ec2.clientToken", None)
     spot_instance_request_id = nixops.util.attr_property("ec2.spotInstanceRequestId", None)
     spot_instance_price = nixops.util.attr_property("ec2.spotInstancePrice", None)
+    subnet_id = nixops.util.attr_property("ec2.subnetId", None)
 
     def __init__(self, depl, name, id):
         MachineState.__init__(self, depl, name, id)
@@ -141,6 +146,7 @@ class EC2State(MachineState):
             self.backups = {}
             self.dns_hostname = None
             self.dns_ttl = None
+            self.subnet_id = None
 
 
     def get_ssh_name(self):
@@ -542,23 +548,36 @@ class EC2State(MachineState):
                     self.ssh_pinged = False
 
 
+    def _get_network_interfaces(self, defn):
+        return boto.ec2.networkinterface.NetworkInterfaceCollection(
+            boto.ec2.networkinterface.NetworkInterfaceSpecification(
+                subnet_id=defn.subnet_id,
+                associate_public_ip_address=defn.associate_public_ip_address,
+                groups=defn.security_group_ids
+            )
+        )
 
     def create_instance(self, defn, zone, devmap, user_data, ebs_optimized):
         common_args = dict(
             instance_type=defn.instance_type,
             placement=zone,
             key_name=defn.key_pair,
-            security_groups=defn.security_groups,
             placement_group=defn.placement_group,
             block_device_map=devmap,
             user_data=user_data,
             image_id=defn.ami,
             ebs_optimized=ebs_optimized
         )
+
         if defn.instance_profile.startswith("arn:") :
             common_args['instance_profile_arn'] = defn.instance_profile
         else:
             common_args['instance_profile_name'] = defn.instance_profile
+
+        if defn.subnet_id:
+            common_args['network_interfaces'] = self._get_network_interfaces(defn)
+        else:
+            common_args['security_groups'] = defn.security_groups
 
         if defn.spot_instance_price:
             request = nixops.ec2_utils.retry(


### PR DESCRIPTION
- Specify the Subnet that an instance is in
- Specify SecurityGroupIds (you can't use security group names with the
  non-default VPC)
- Specify whether instance should have a public IP assigned (by default
  in the non-default VPC this is not the case)
