### PR TITLE
Fix use of targetPort for scp commands

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -214,8 +214,12 @@ class MachineState(nixops.resources.ResourceState):
     def get_ssh_name(self):
         assert False
 
-    def get_ssh_flags(self):
-        return ["-p", str(self.ssh_port)]
+    def get_ssh_flags(self, scp=False):
+        if scp:
+            return ["-P", str(self.ssh_port)]
+        else:
+            return ["-p", str(self.ssh_port)]
+
 
     def get_ssh_password(self):
         return None
@@ -329,7 +333,7 @@ class MachineState(nixops.resources.ResourceState):
 
     def upload_file(self, source, target, recursive=False):
         master = self.ssh.get_master()
-        cmdline = ["scp"] + self.get_ssh_flags() + master.opts
+        cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
         if recursive:
             cmdline += ['-r']
         cmdline += [source, "root@" + self.get_ssh_name() + ":" + target]
@@ -337,7 +341,7 @@ class MachineState(nixops.resources.ResourceState):
 
     def download_file(self, source, target, recursive=False):
         master = self.ssh.get_master()
-        cmdline = ["scp"] + self.get_ssh_flags() + master.opts
+        cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
         if recursive:
             cmdline += ['-r']
         cmdline += ["root@" + self.get_ssh_name() + ":" + source, target]

--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -160,7 +160,7 @@ class EC2State(MachineState):
         return None
 
 
-    def get_ssh_flags(self):
+    def get_ssh_flags(self, scp=False):
         file = self.get_ssh_private_key_file()
         return ["-i", file] if file else []
 

--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -155,7 +155,7 @@ class HetznerState(MachineState):
         else:
             return self.write_ssh_private_key(self.main_ssh_private_key)
 
-    def get_ssh_flags(self):
+    def get_ssh_flags(self, scp=False):
         if self.state == self.RESCUE:
             return ["-o", "LogLevel=quiet"]
         else:

--- a/nixops/backends/virtualbox.py
+++ b/nixops/backends/virtualbox.py
@@ -78,7 +78,7 @@ class VirtualBoxState(MachineState):
     def get_ssh_private_key_file(self):
         return self._ssh_private_key_file or self.write_ssh_private_key(self._client_private_key)
 
-    def get_ssh_flags(self):
+    def get_ssh_flags(self, scp=False):
         return ["-o", "StrictHostKeyChecking=no", "-i", self.get_ssh_private_key_file()]
 
     def get_physical_spec(self):


### PR DESCRIPTION
We must treat scp commands specially, since the port option is -P for scp,
not -p.
