### PR TITLE
Record's TTL is required to delete a RecordSet

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -1036,7 +1036,7 @@ class EC2State(MachineState):
                 change.add_value(",".join(prevrr.resource_records))
         if len(prev_cname_rrs) > 0:
             for prevrr in prev_cname_rrs:
-                change = changes.add_change("DELETE", self.dns_hostname, "CNAME")
+                change = changes.add_change("DELETE", prevrr.name, "CNAME", ttl=prevrr.ttl)
                 change.add_value(",".join(prevrr.resource_records))
 
         change = changes.add_change("CREATE", self.dns_hostname, record_type, ttl=self.dns_ttl)


### PR DESCRIPTION
If the previous record set has a non-default TTL set, the Route53 API
will refuse to honor the DELETE request if the TTL isn't included in the
change. This change uses the exact values from the ResourceRecordSet
that is being replaced.
