### PR TITLE
libvirtd: If baseImage default is null, the option type must allow it.

### DIFF
--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -66,7 +66,7 @@ in
     deployment.libvirtd.baseImage = mkOption {
       default = null;
       example = "/home/alice/base-disk.qcow2";
-      type = types.path;
+      type = with types; nullOr path;
       description = ''
         The disk is created using the specified
         disk image as a base.


### PR DESCRIPTION
@rbvermaa This fixes the following nixops runtime error for me (introduced by 9d41f59e827f25ca9d693753dcfd281ce3ab6615, I guess):

```
The option value `deployment.libvirtd.baseImage' in `/nix/store/zhf89zp8w0hf85yvr1k1zs4ix3f0r0df-nixops-1.3pre0_abcdef/share/nix/nixops/libvirtd.nix' is not a path.
```