### PR TITLE
Add default to ebsVolumnes accessKeyId to mark it non-required.

### DIFF
--- a/nix/ebs-volume.nix
+++ b/nix/ebs-volume.nix
@@ -30,6 +30,7 @@ with pkgs.lib;
 
     accessKeyId = mkOption {
       type = types.str;
+      default = "";
       description = "The AWS Access Key ID.";
     };
 


### PR DESCRIPTION
This will be read from the environment as well.