### PR TITLE
Make `public_ipv4` the same as targetHost for "none" target

### DIFF
--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -34,6 +34,10 @@ class NoneState(MachineState):
         self.target_host = defn._target_host
 
     def get_ssh_name(self):
+        return self.public_ipv4
+
+    @property
+    def public_ipv4(self):
         assert self.target_host
         return self.target_host
 


### PR DESCRIPTION
This enables using ssh tunnels between "none" targets.
Without it the {{hostname}}-unencrypted entry in /etc/hosts was never created, which made ssh-tunnel-{{hostname}}.service fail.