### PR TITLE
Don't crash when none targets have an unknown targetHost

### DIFF
--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -34,6 +34,7 @@ class NoneState(MachineState):
         self.target_host = defn._target_host
 
     def get_ssh_name(self):
+        assert self.public_ipv4
         return self.public_ipv4
 
     @property

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -38,7 +38,6 @@ class NoneState(MachineState):
 
     @property
     def public_ipv4(self):
-        assert self.target_host
         return self.target_host
 
     def _check(self, res):


### PR DESCRIPTION
@ktosiek @rbvermaa I think cb186cfe579dbeb4ac2a9d8b9ae0e547f0067615 caused an assertion error at https://github.com/NixOS/nixops/blob/master/nixops/deployment.py#L454 when your network as `none` target machines which haven't been deployed yet.