### PR TITLE
backends/hetzner: Create nixbld group in rescue.

### DIFF
--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -194,6 +194,11 @@ class HetznerState(MachineState):
         bootstrap = os.path.join(bootstrap_out, 'bin/hetzner-bootstrap')
         self.log_end("done. ({0})".format(bootstrap))
 
+        self.log_start("creating nixbld group in rescue system...")
+        self.run_command("getent group nixbld > /dev/null || "
+                         "groupadd -g 30000 nixbld")
+        self.log_end("done.")
+
         self.log_start("checking if tmpfs in rescue system is large enough...")
         dfstat = self.run_command("stat -f -c '%a:%S' /", capture_stdout=True)
         df, bs = dfstat.split(':')


### PR DESCRIPTION
This is basically a no-op when using `reboot --rescue` but it is crucial for the bootstrap process, where we bind-mount `/etc/group` to `/mnt/etc/group`. Nix (1.8) won't find the nixbld group and will bail out within the chroot.