### PR TITLE
Make sure the correct SSH port (-p) option is always used

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -167,8 +167,7 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
 
     def get_ssh_flags(self, scp=False):
         file = self.get_ssh_private_key_file()
-        return ["-i", file] if file else []
-
+        return super(EC2State, self).get_ssh_flags(scp) + (["-i", file] if file else [])
 
     def get_physical_spec(self):
         block_device_mapping = {}

--- a/nixops/backends/gce.py
+++ b/nixops/backends/gce.py
@@ -783,4 +783,4 @@ class GCEState(MachineState, ResourceState):
         return self._ssh_private_key_file or self.write_ssh_private_key(self.private_client_key)
 
     def get_ssh_flags(self, scp=False):
-        return [ "-i", self.get_ssh_private_key_file() ]
+        return super(GCEState, self).get_ssh_flags(scp) + [ "-i", self.get_ssh_private_key_file() ]

--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -156,16 +156,17 @@ class HetznerState(MachineState):
             return self.write_ssh_private_key(self.main_ssh_private_key)
 
     def get_ssh_flags(self, scp=False):
-        if self.state == self.RESCUE:
-            return ["-o", "LogLevel=quiet"]
-        else:
-            # XXX: Disabling strict host key checking will only impact the
-            # behaviour on *new* keys, so it should be "reasonably" safe to do
-            # this until we have a better way of managing host keys in
-            # ssh_util. So far this at least avoids to accept every damn host
-            # key on a large deployment.
-            return ["-o", "StrictHostKeyChecking=no",
-                    "-i", self.get_ssh_private_key_file()]
+        return super(HetznerState, self).get_ssh_flags(scp) + (
+          ["-o", "LogLevel=quiet"]
+          if self.state == self.RESCUE else
+          # XXX: Disabling strict host key checking will only impact the
+          # behaviour on *new* keys, so it should be "reasonably" safe to do
+          # this until we have a better way of managing host keys in
+          # ssh_util. So far this at least avoids to accept every damn host
+          # key on a large deployment.
+          ["-o", "StrictHostKeyChecking=no",
+           "-i", self.get_ssh_private_key_file()]
+        )
 
     def _wait_for_rescue(self, ip):
         if not TEST_MODE:

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -51,7 +51,7 @@ class LibvirtdState(MachineState):
         return self._ssh_private_key_file or self.write_ssh_private_key(self.client_private_key)
 
     def get_ssh_flags(self, scp=False):
-        return [ "-o", "StrictHostKeyChecking=no", "-i", self.get_ssh_private_key_file() ]
+        return super(LibvirtdState, self).get_ssh_flags(scp) + [ "-o", "StrictHostKeyChecking=no", "-i", self.get_ssh_private_key_file() ]
 
     def _vm_id(self):
         return "nixops-{0}-{1}".format(self.depl.uuid, self.name)


### PR DESCRIPTION
When the `deployment.targetPort option` is different then the default of 22 the `nixops ssh` command failed to connect to the machine since the `-p` option wasn't specified.

This patch makes sure that the `get_ssh_flags method` of each specific `MachineState` always returns the flags from its super class.