### PR TITLE
deploy: Enable read-write-mode by default.

### DIFF
--- a/scripts/nixops
+++ b/scripts/nixops
@@ -77,7 +77,7 @@ def open_deployment():
     if args.keep_going: depl.extra_nix_flags.append("--keep-going")
     if args.keep_failed: depl.extra_nix_flags.append("--keep-failed")
     if args.show_trace: depl.extra_nix_flags.append("--show-trace")
-    if args.read_write_mode: depl.extra_nix_eval_flags.append("--read-write-mode")
+    if not args.read_only_mode: depl.extra_nix_eval_flags.append("--read-write-mode")
 
     return depl
 
@@ -641,7 +641,7 @@ def add_subparser(name, help):
     subparser.add_argument("--keep-failed", '-K', action='store_true', help='keep temporary directories of failed builds')
     subparser.add_argument('--show-trace', action='store_true', help='print a Nix stack trace if evaluation fails')
     subparser.add_argument('--option', nargs=2, action="append", dest="nix_options", metavar=('NAME', 'VALUE'), help='set a Nix option')
-    subparser.add_argument('--read-write-mode', action='store_true', help='run Nix evaluations in read-write mode')
+    subparser.add_argument('--read-only-mode', action='store_true', help='run Nix evaluations in read-only mode')
 
     return subparser
 


### PR DESCRIPTION
Useful to actually allow imports from derivations and it's the default behaviour for nix-build anyway, so why don't we enable it by default here as well for consistency?

Did this a while ago and I'm already using it for all deployments since them.