### PR TITLE
Fix circular references to pkgs.lib.

### DIFF
--- a/doc/manual/dummy.nix
+++ b/doc/manual/dummy.nix
@@ -5,9 +5,9 @@
 # allowed.  So this module, which defines them, is included only for
 # the generation of the manual.
 
-{ config, pkgs, ... }:
+{ config, lib, ... }:
 
-with pkgs.lib;
+with lib;
 
 {
 

--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -2,8 +2,8 @@
 
 { config, pkgs, lib, utils, ... }:
 
-with lib;
 with utils;
+with lib;
 with import ./lib.nix lib;
 
 let


### PR DESCRIPTION
For `dummy.nix` it's quite obvious, but `ec2.nix` actually causes the recursive reference, because the lib attribute is passed to ./lib.nix from _utils_ instead of the lib attribute passed by the module system.

These circular references became visible since the merge of NixOS/nixpkgs#6794.