### PR TITLE
Add support for ssh connections via a private ip.

### DIFF
--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -27,6 +27,16 @@ let
     let props = config.deployment.ec2.physicalProperties;
     in if props == null then false else (props.allowsEbsOptimized or false);
 
+  defaultUsePrivateIpAddress =
+    let
+      assocPublicIp = config.deployment.ec2.associatePublicIpAddress;
+      subnetId = config.deployment.ec2.subnetId;
+    in
+      if assocPublicIp == false && subnetId != "" then
+        true
+      else
+        false;
+
   commonEC2Options = import ./common-ec2-options.nix { inherit lib; };
 
   ec2DiskOptions = { config, ... }: {
@@ -320,6 +330,17 @@ in
       description = ''
         If instance in a subnet/VPC, whether to associate a public
         IP address with the instance.
+      '';
+    };
+
+    deployment.ec2.usePrivateIpAddress = mkOption {
+      default = defaultUsePrivateIpAddress;
+      type = types.bool;
+      description = ''
+        If instance is in a subnet/VPC whether to use the private
+	IP address for ssh connections to this host. Defaults to
+	true in the case that you are deploying into a subnet but
+	not associating a public ip address.
       '';
     };
 

--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -90,10 +90,10 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
     # We need to store this in machine state so wait_for_ip knows what to wait for
     # Really it seems like this whole class should be parameterized by its definition.
     # (or the state shouldn't be doing the polling)
-    use_private_ip_address = nixops.util.attr_property("usePrivateIpAddress", False, type=bool)
     public_ipv4 = nixops.util.attr_property("publicIpv4", None)
     private_ipv4 = nixops.util.attr_property("privateIpv4", None)
     public_dns_name = nixops.util.attr_property("publicDnsName", None)
+    use_private_ip_address = nixops.util.attr_property("ec2.usePrivateIpAddress", False, type=bool)
     associate_public_ip_address = nixops.util.attr_property("ec2.associatePublicIpAddress", False, type=bool)
     elastic_ipv4 = nixops.util.attr_property("ec2.elasticIpv4", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)

--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -90,11 +90,11 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
     # We need to store this in machine state so wait_for_ip knows what to wait for
     # Really it seems like this whole class should be parameterized by its definition.
     # (or the state shouldn't be doing the polling)
-    wants_public_ip_address = nixops.util.attr_property("wantsPublicIpAddress", False, type=bool)
     use_private_ip_address = nixops.util.attr_property("usePrivateIpAddress", False, type=bool)
     public_ipv4 = nixops.util.attr_property("publicIpv4", None)
     private_ipv4 = nixops.util.attr_property("privateIpv4", None)
     public_dns_name = nixops.util.attr_property("publicDnsName", None)
+    associate_public_ip_address = nixops.util.attr_property("ec2.associatePublicIpAddress", False, type=bool)
     elastic_ipv4 = nixops.util.attr_property("ec2.elasticIpv4", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     region = nixops.util.attr_property("ec2.region", None)
@@ -132,7 +132,7 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
         """Discard all state pertaining to an instance."""
         with self.depl._db:
             self.state = MachineState.MISSING
-            self.wants_public_ip_address = None
+            self.associate_public_ip_address = None
             self.use_private_ip_address = None
             self.vm_id = None
             self.public_ipv4 = None
@@ -306,7 +306,7 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
 
         def _instance_ip_ready(ins):
             ready = True
-            if self.wants_public_ip_address and not ins.ip_address:
+            if self.associate_public_ip_address and not ins.ip_address:
                 ready = False
             if self.use_private_ip_address and not ins.private_ip_address:
                 ready = False
@@ -914,10 +914,10 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
 
         with self.depl._db:
             self.use_private_ip_address = defn.use_private_ip_address
-            self.wants_public_ip_address = defn.associate_public_ip_address
+            self.associate_public_ip_address = defn.associate_public_ip_address
 
         # Wait for the IP address.
-        if (self.wants_public_ip_address and not self.public_ipv4) \
+        if (self.associate_public_ip_address and not self.public_ipv4) \
            or \
            (self.use_private_ip_address and not self.private_ipv4) \
            or \


### PR DESCRIPTION
Edit: 

It seems there has been some discussion on this issue in NixOS/nixops#221. I seem to have implemented it as was being discussed there. 

This fixes the behavior of ec2.associatePublicIpAddress which
cannot safely be set to false when deploying inside a subnet before this commit.

Add a new option ec2.usePrivateIpAddress which will default to
true in the case that associatePublicIpAddress is false and you are
deploying to a subnet.

Add supporting code in the ec2 backend to support this option. This required
storing some state from the defn in the machine state, but it seems that's already
being done for other things like the spot instance price so this seems consistent.