### PR TITLE
Use the right SSH port when setting up ssh tunnels

### DIFF
--- a/nix/ssh-tunnel.nix
+++ b/nix/ssh-tunnel.nix
@@ -26,6 +26,11 @@ with lib;
           type = types.str;
           description = "Host name or IP address of the remote machine.";
         };
+        targetPort = mkOption {
+          type = types.int;
+          default = 22;
+          description = "Port on the remote machine that ssh listens to.";
+        };
         privateKey = mkOption {
           type = types.path;
           description = "Path to the private key file used to connect to the remote machine.";
@@ -77,7 +82,7 @@ with lib;
         "ssh -i ${v.privateKey} -x"
         + " -o StrictHostKeyChecking=no -o PermitLocalCommand=yes -o ServerAliveInterval=20"
         + " -o LocalCommand='ifconfig tun${toString v.localTunnel} ${v.localIPv4} pointopoint ${v.remoteIPv4} netmask 255.255.255.255; route add ${v.remoteIPv4}/32 dev tun${toString v.localTunnel}'"
-        + " -w ${toString v.localTunnel}:${toString v.remoteTunnel} ${v.target}"
+        + " -w ${toString v.localTunnel}:${toString v.remoteTunnel} ${v.target} -p ${toString v.targetPort}"
         + " 'ifconfig tun${toString v.remoteTunnel} ${v.remoteIPv4} pointopoint ${v.localIPv4} netmask 255.255.255.255; route add ${v.localIPv4}/32 dev tun${toString v.remoteTunnel}'";
       serviceConfig =
         { Restart = "always";

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -482,9 +482,11 @@ class Deployment(object):
                 remote_ipv4 = index_to_private_ip(m2.index)
                 local_tunnel = 10000 + m2.index
                 remote_tunnel = 10000 + m.index
+
                 attrs_list.append({
                     ('networking', 'p2pTunnels', 'ssh', m2.name): {
                         'target': '{0}-unencrypted'.format(m2.name),
+                        'targetPort': m2.ssh_port,
                         'localTunnel': local_tunnel,
                         'remoteTunnel': remote_tunnel,
                         'localIPv4': local_ipv4,


### PR DESCRIPTION
This commit allows to use `nixops ssh` for machines which run sshd on a non-standard port.