### PR TITLE
Avoid "nixops destroy" crash when self.host=None

### DIFF
--- a/nixops/backends/container.py
+++ b/nixops/backends/container.py
@@ -111,7 +111,7 @@ class ContainerState(MachineState):
 
     def create_after(self, resources, defn):
         host = defn.host if defn else self.host
-        if host.startswith("__machine-"):
+        if host and host.startswith("__machine-"):
             return {self.depl.get_machine(host[10:])}
         else:
             return {}


### PR DESCRIPTION
I have a somewhat broken nixops setup, when deploying to nixos-containers fails pretty early. This fix avoids hitting an error when trying to destroy the not-very-deployed nixops network.

    [nix-shell:~/nixops]$ which nixops
    /root/nixops/scripts/nixops

    [nix-shell:~/nixops]$ git status
    On branch master
    Your branch is up-to-date with 'origin/master'.
    nothing to commit, working directory clean

    [nix-shell:~/nixops]$ nixops destroy -d zkc
    error: 'NoneType' object has no attribute 'startswith'

    [nix-shell:~/nixops]$ git checkout avoid-error
    Switched to branch 'avoid-error'

    [nix-shell:~/nixops]$ nixops destroy -d zkc

    [nix-shell:~/nixops]$ 