### PR TITLE
Fix container's deploy when used with keys.

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -236,6 +236,10 @@ class MachineState(nixops.resources.ResourceState):
         else:
             return ["-p", str(self.ssh_port)]
 
+    def adapt_ssh_flag_for_use_with_scp(self, flags):
+      # For scp, the "-P" flag is used to specify the port. "-p"
+      # attempt to preserve file attributes.
+      return (map (lambda x: '-P' if x == '-p' else x, flags))
 
     def get_ssh_password(self):
         return None
@@ -353,7 +357,7 @@ class MachineState(nixops.resources.ResourceState):
 
     def upload_file(self, source, target, recursive=False):
         master = self.ssh.get_master()
-        cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
+        cmdline = ["scp"] + self.get_ssh_flags(True) + self.adapt_ssh_flag_for_use_with_scp(master.opts)
         if recursive:
             cmdline += ['-r']
         cmdline += [source, "root@" + self.get_ssh_name() + ":" + target]
@@ -361,7 +365,7 @@ class MachineState(nixops.resources.ResourceState):
 
     def download_file(self, source, target, recursive=False):
         master = self.ssh.get_master()
-        cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
+        cmdline = ["scp"] + self.get_ssh_flags(True) + self.adapt_ssh_flag_for_use_with_scp(master.opts)
         if recursive:
             cmdline += ['-r']
         cmdline += ["root@" + self.get_ssh_name() + ":" + source, target]

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -39,7 +39,7 @@ class MachineState(nixops.resources.ResourceState):
     ssh_pinged = nixops.util.attr_property("sshPinged", False, bool)
     ssh_port = nixops.util.attr_property("targetPort", 22, int)
     public_vpn_key = nixops.util.attr_property("publicVpnKey", None)
-    store_keys_on_machine = nixops.util.attr_property("storeKeysOnMachine", True, bool)
+    store_keys_on_machine = nixops.util.attr_property("storeKeysOnMachine", False, bool)
     keys = nixops.util.attr_property("keys", {}, 'json')
     owners = nixops.util.attr_property("owners", [], 'json')
 

--- a/nixops/backends/container.py
+++ b/nixops/backends/container.py
@@ -63,9 +63,9 @@ class ContainerState(MachineState):
         flags = super(ContainerState, self).get_ssh_flags(*args, **kwargs)
         flags += ["-i", self.get_ssh_private_key_file()]
         if self.host == "localhost":
-            flags.extend(MachineState.get_ssh_flags(self))
+            flags.extend(MachineState.get_ssh_flags(self, *args, **kwargs))
         else:
-            cmd = "ssh -x -a root@{0} {1} nc -c {2} {3}".format(self.get_host_ssh(), " ".join(self.get_host_ssh_flags()), self.private_ipv4, self.ssh_port)
+            cmd = "ssh -x -a root@{0} {1} nc -c {2} {3}".format(self.get_host_ssh(), " ".join(self.get_host_ssh_flags(*args, **kwargs)), self.private_ipv4, self.ssh_port)
             flags.extend(["-o", "ProxyCommand=" + cmd])
         return flags
 
@@ -87,12 +87,12 @@ class ContainerState(MachineState):
         else:
             return self.host
 
-    def get_host_ssh_flags(self):
+    def get_host_ssh_flags(self, *args, **kwargs):
         if self.host.startswith("__machine-"):
             m = self.depl.get_machine(self.host[10:])
             if not m.started:
                 raise Exception("host machine ‘{0}’ of container ‘{1}’ is not up".format(m.name, self.name))
-            return m.get_ssh_flags()
+            return m.get_ssh_flags(*args, **kwargs)
         else:
             return []
 


### PR DESCRIPTION
Fundamentally there was this missing `self.set_common_state(defn)`
that wasn't called on `create` which is essential to retrieve
keys.

This should also fix an issue I had when `storeKeysOnMachine`
was not set explicitly which caused the keys not to be sent.

Attempted to fix the use of `stop`/`start` when there are keys.
There remain some underlying problem I couldn't understand yet.
