### PR TITLE
Add a container's host as an extra host as part of its physical spec.

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -227,6 +227,11 @@ class MachineState(nixops.resources.ResourceState):
     def get_ssh_for_copy_closure(self):
         return self.ssh
 
+    def getExtraHosts(self):
+        # No extra hosts by default.
+        extraHosts = []
+        return extraHosts
+
     @property
     def public_ipv4(self):
         return None

--- a/nixops/backends/container.py
+++ b/nixops/backends/container.py
@@ -42,6 +42,21 @@ class ContainerState(MachineState):
     def resource_id(self):
         return self.vm_id
 
+    def _getHostPrivateIp(self):
+        # This is kind of hackish but should return what's expected. I'm not
+        # sure there are any better way of retrieving the host's ip address.
+        hostIp = self.private_ipv4.split('.')[:-1]
+
+        # Host always at ip ending in "1".
+        hostIp.append("1")
+
+        return ".".join(hostIp)
+
+    def getExtraHosts(self):
+        # As a convenience, a container backend adds the container's host as an extra host.
+        extraHosts = [(self._getHostPrivateIp(), ["container-host", "container-host-private"])]
+        return extraHosts
+
     def address_to(self, m):
         if isinstance(m, ContainerState) and self.host == m.host:
             return m.private_ipv4

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -464,6 +464,12 @@ class Deployment(object):
             # than for the canonical name!
             hosts[m.name][index_to_private_ip(m.index)].append(m.name + "-encrypted")
 
+            backendExtraHosts = m.getExtraHosts()
+
+            # Add backend specific extra hosts.
+            for ip, hs in backendExtraHosts:
+                hosts[m.name][ip] += hs
+
         def do_machine(m):
             defn = self.definitions[m.name]
             attrs_list = attrs_per_resource[m.name]


### PR DESCRIPTION
Tested machine base class's default and container class's specialization which adds its host to
its extra hosts section. 

Everything seemed to work fine.
