### PR TITLE
Add note regarding virtualbox deployments on headless hosts

### DIFF
--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -49,7 +49,10 @@ documentation of the Valgrind package.</para>
 options that tell NixOps to what environment it should be deployed.
 <xref linkend="ex-physical-vbox.nix" /> specifies that
 <literal>webserver</literal> should be deployed as a VirtualBox
-instance. Note that for this to work the <literal>vboxnet0</literal> network has to exist - you can add it in the VirtualBox general settings under <emphasis>Networks - Host-only Networks</emphasis> if necessary.</para>
+instance. Note that for this to work the <literal>vboxnet0</literal> network has to exist - you can add it in the VirtualBox general settings under <emphasis>Networks - Host-only Networks</emphasis> if necessary.
+If you are running NixOps in a headless environment, then you should also add the option
+<code>deployment.virtualbox.headless = true;</code>
+to the configuration. Otherwise, VirtualBox will fail when it tries to open a graphical display on the host's desktop.</para>
 
 <example xml:id="ex-physical-vbox.nix">
   <title><filename>trivial-vbox.nix</filename>: VirtualBox physical network specification</title>


### PR DESCRIPTION
I was logged into to my desktop via ssh and following guide in manual to get familiar with NixOps, when I got this error trying to deploy the machine from the first example:
```
webserver> VM "nixops-9fe3df3d-1b9a-11e5-9719-56847afe9799-webserver" has been successfully started.
error: command ‘['VBoxManage', 'startvm', u'nixops-9fe3df3d-1b9a-11e5-9719-56847afe9799-webserver']’ failed on machine ‘webserver’ (exit code 1)
```
It took me a while to figure out that VBoxManage was trying to open a graphical display and failing, and that I needed to add `deployment.virtualbox.headless = true;` to the configuration.

I thought it might be worth adding a note about this to the guide, so that others getting started with NixOps don't encounter the same issue.