### PR TITLE
Fix typos in manual

### DIFF
--- a/doc/manual/introduction.xml
+++ b/doc/manual/introduction.xml
@@ -6,7 +6,7 @@
 
 <para>NixOps is a tool for deploying NixOS machines in a network or
 cloud.  It takes as input a declarative specification of a set of
-“logical” machines and then performs any necessary steps actions to
+“logical” machines and then performs any necessary steps or actions to
 realise that specification: instantiate cloud machines, build and
 download dependencies, stop and start services, and so on.  NixOps has
 several nice properties:</para>

--- a/doc/manual/nixops.xml
+++ b/doc/manual/nixops.xml
@@ -129,7 +129,7 @@ cloud.</para>
   <varlistentry><term><envar>NIXOPS_DEPLOYMENT</envar></term>
 
     <listitem><para>UUID or symbolic name of the deployment on which
-    to operate.  Can be overriden using the <option>-d</option>
+    to operate.  Can be overridden using the <option>-d</option>
     option.</para></listitem>
 
   </varlistentry>
@@ -376,7 +376,7 @@ while <option>-n</option> specifies its new name.</para>
 
 <refsection><title>Description</title>
 
-<para>This command clones an existing deployment; that is, it create a
+<para>This command clones an existing deployment; that is, it creates a
 new deployment that has the same deployment specification and
 parameters, but a different UUID and (optionally) name.  Note that
 <command>nixops clone</command> does not currently clone the state of
@@ -1085,7 +1085,7 @@ machine> instance state is ‘stopped’</screen>
 <refsection><title>Description</title>
 
 <para>This command opens an SSH connection to the specified machine
-and executes the specified command.  If no command if specified, an
+and executes the specified command.  If no command is specified, an
 interactive shell is started.</para>
 
 </refsection>

--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -699,19 +699,19 @@ $ openssl pkcs12 -in pkey.pkcs12 -passin pass:notasecret -nodes -nocerts | opens
 
   <para>Another important difference is that NixOps attempts to replicate the last known
   state of the instance(attached disks, tags). Thus, if the state was modified
-  manually(eg via gcloud tool), such changes are lost in a start/stop cycle.</para>
+  manually (e.g. via gcloud tool), such changes are lost in a start/stop cycle.</para>
 
-  <para>Consider rebooting instead which doesn't have these limitation and, in addition, is faster.
+  <para>Consider rebooting instead which doesn't have these limitations and, in addition, is faster.
   </para></listitem>
 
   <listitem><para>Creation, modification and deletion of resources and instances are
   not idempotent in GCE.</para>
 
   <para>In practice, this means that if you hit Ctrl+C or an error happens, while NixOps is
-  creating, destrying or otherwise changing the state a resource, the state of the
+  creating, destroying or otherwise changing the state of a resource, the state of the
   resource expected by NixOps and the actual state may diverge.</para>
 
-  <para>Usually, this doesn't cause too much troubles, but a good practice is to follow
+  <para>Usually, this doesn't cause too much trouble, but a good practice is to follow
   each failed or aborted deployment operation with a <literal>deploy --check</literal>
   run to detect and fix any state mismatch(es).</para></listitem>
 
@@ -726,7 +726,7 @@ $ openssl pkcs12 -in pkey.pkcs12 -passin pass:notasecret -nodes -nocerts | opens
 
 </para>
 
-<para>Migration of resources between zones and putting previosly-existing resources
+<para>Migration of resources between zones and putting previously-existing resources
 under NixOps control.
 
 <itemizedlist>
@@ -818,7 +818,7 @@ This will install NixOS on a machine with the main IP
 <replaceable>1.2.3.4</replaceable>, using a swap partition for each drive and
 use everything else for a single btrfs volume.</para>
 
-<para>In the previous example, there is no occurence of
+<para>In the previous example, there is no occurrence of
 <varname>deployment.hetzner.robotUser</varname> and
 <varname>deployment.hetzner.robotPass</varname>, you can set the credentials to
 your main Robot account there, however it is recommended to use the environment


### PR DESCRIPTION
I found a few typos/spelling errors while reading through the manual.