### PR TITLE
ec2: Assign public ip by default

### DIFF
--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -325,7 +325,7 @@ in
     };
 
     deployment.ec2.associatePublicIpAddress = mkOption {
-      default = false;
+      default = true;
       type = types.bool;
       description = ''
         If instance in a subnet/VPC, whether to associate a public


### PR DESCRIPTION
How else is instance able to access internet, except maybe if you are running deticated NAT instance.
