### PR TITLE
Add support for publicIPv4 for GCE resources.

### DIFF
--- a/nix/gce-forwarding-rule.nix
+++ b/nix/gce-forwarding-rule.nix
@@ -31,6 +31,16 @@ with import ./lib.nix lib;
       '';
     };
 
+    publicIPv4 = mkOption {
+      default = null;
+      type = types.uniq (types.nullOr types.str);
+      description = ''
+        The assigned IP address of this forwarding rule.
+        This is set by NixOps to the ephemeral IP address of the resource if
+        ipAddress wasn't set, otherwise it should be the same as ipAddress.
+      '';
+    };
+
     protocol = mkOption {
       example = "TCP";
       type = types.addCheck types.str

--- a/nix/gce-static-ip.nix
+++ b/nix/gce-static-ip.nix
@@ -36,6 +36,15 @@ with import ./lib.nix lib;
       '';
     };
 
+    publicIPv4 = mkOption {
+      default = null;
+      type = types.uniq (types.nullOr types.str);
+      description = ''
+        The static IP address assigned.
+        This is set by NixOps to the ephemeral IP address of the resource if
+        ipAddress wasn't set, otherwise it should be the same as ipAddress.
+      '';
+    };
   };
 
   config._type = "gce-static-ip";

--- a/nixops/resources/gce_forwarding_rule.py
+++ b/nixops/resources/gce_forwarding_rule.py
@@ -63,6 +63,12 @@ class GCEForwardingRuleState(ResourceState):
         if self.state == self.UP: s = "{0} [{1}]".format(s, self.region)
         return s
 
+    def prefix_definition(self, attr):
+        return {('resources', 'gceForwardingRules'): attr}
+
+    def get_physical_spec(self):
+        return {'publicIPv4': self.public_ipv4}
+
     @property
     def resource_id(self):
         return self.forwarding_rule_name

--- a/nixops/resources/gce_static_ip.py
+++ b/nixops/resources/gce_static_ip.py
@@ -64,6 +64,12 @@ class GCEStaticIPState(ResourceState):
     def public_ipv4(self):
         return self.ip_address
 
+    def prefix_definition(self, attr):
+        return {('resources', 'gceStaticIPs'): attr}
+
+    def get_physical_spec(self):
+        return {'publicIPv4': self.public_ipv4}
+
     def create(self, defn, check, allow_reboot, allow_recreate):
         self.no_change(defn.ip_address and self.ip_address != defn.ip_address, 'address')
         self.no_project_change(defn)


### PR DESCRIPTION
Configuration option publicIPv4 are added to both resources.gceForwardingRules and resources.gceStaticIPs.
These options are filled in by NixOps with the IP addresses assigned to these resources.

