### PR TITLE
Add support for non-machine IP resources in /etc/hosts

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -242,9 +242,9 @@ class MachineState(nixops.resources.ResourceState):
     def private_ipv4(self):
         return None
 
-    def address_to(self, m):
-        """Return the IP address to be used to access machone "m" from this machine."""
-        ip = m.public_ipv4
+    def address_to(self, r):
+        """Return the IP address to be used to access resource "r" from this machine."""
+        ip = getattr(r, 'public_ipv4', None)
         if ip: return ip
         return None
 

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -388,7 +388,7 @@ class Deployment(object):
             attrs_list = attrs_per_resource[m.name]
 
             # Emit configuration to realise encrypted peer-to-peer links.
-            for m2 in active_machines.itervalues():
+            for m2 in active_resources.itervalues():
                 ip = m.address_to(m2)
                 if ip:
                     hosts[m.name][ip] += [m2.name, m2.name + "-unencrypted"]


### PR DESCRIPTION
There exist non-machine resouces, such as gce_forwarding_rule and gce_static_ip, that have IP addresses associated with them and are routable.
This change extends the generation of the hosts files to, by default, all resources that have a public_ipv4 attribute.

This addresses part (1) of issue #312 and would close the issue.