### PR TITLE
Add support for VPC security groups in EC2

### DIFF
--- a/examples/ec2-vpc-security-group.nix
+++ b/examples/ec2-vpc-security-group.nix
@@ -1,0 +1,16 @@
+let
+  accessKeyId = builtins.getEnv "NIXOPS_TEST_ACCESS_KEY_ID";
+  vpcId = builtins.getEnv "NIXOPS_TEST_VPC_ID";
+  region = builtins.getEnv "NIXOPS_TEST_REGION";
+in
+{
+  resources.ec2SecurityGroups.nixops-test = {
+    inherit accessKeyId region vpcId;
+    description = "Testing NixOps extensions to create security groups inside VPC";
+    rules = [ {
+      fromPort = 22;
+      toPort = 22;
+      sourceIp = "0.0.0.0/0";
+    } ];
+  };
+}

--- a/nix/ec2-security-group.nix
+++ b/nix/ec2-security-group.nix
@@ -5,7 +5,6 @@ with lib;
 {
 
   options = {
-
     name = mkOption {
       default = "charon-${uuid}-${name}";
       type = types.str;
@@ -33,6 +32,13 @@ with lib;
       default = null;
       type = types.uniq (types.nullOr types.str);
       description = "The security group ID. This is set by NixOps.";
+    };
+
+    vpcId = mkOption {
+      default = null;
+      type = types.nullOr types.str;
+      description = "The VPC ID for which to create security group.";
+      example = "vpc-a01106c2";
     };
 
     rules = mkOption {


### PR DESCRIPTION
New ec2SecurityGroup type attribute defined named vpcId.
See examples/ec2-vpc-security-group.nix for example.

Testing:
I did the following `nixops` flow:

* `nixops create ...` [create.log](https://gist.github.com/mbbx6spp/6b89cb700353c32af776#file-create-log)
* `nixops deploy ...` [deploy.log](https://gist.github.com/mbbx6spp/6b89cb700353c32af776#file-deploy-log)
* `nixops deploy ...` [deploy2.log](https://gist.github.com/mbbx6spp/6b89cb700353c32af776#file-deploy2-log)
* `nixops destroy ...` [destroy.log](https://gist.github.com/mbbx6spp/6b89cb700353c32af776#file-destroy-log)
* `nixops deploy ...` [deploy3.log](https://gist.github.com/mbbx6spp/6b89cb700353c32af776#file-deploy3-log)
* checked via `awscli` that the security group created was created for the VPC ID given. [secgrp.json](https://gist.github.com/mbbx6spp/6b89cb700353c32af776#file-secgrp-json)
* `nixops destroy ...` [destroy2.log](https://gist.github.com/mbbx6spp/6b89cb700353c32af776#file-destroy2-log)
* checked via `awscli` that the security group created originally no longer existed. [secgrp.log](https://gist.github.com/mbbx6spp/6b89cb700353c32af776#file-secgrp-log)
* `nixops delete ...` [delete.log](https://gist.github.com/mbbx6spp/6b89cb700353c32af776#file-delete-log)

Ran a similar flow for non-VPC security group and ensured after deploy it was not created inside a VPC in my account.

All runs above were successful.