### PR TITLE
hetzner-bootstrap: Remove obsolete udevSoMajor.

### DIFF
--- a/nix/hetzner-bootstrap.nix
+++ b/nix/hetzner-bootstrap.nix
@@ -5,7 +5,6 @@ let
 
   nixpart = pythonPackages.nixpart0.override {
     useNixUdev = false;
-    udevSoMajor = 0;
   };
 
   generateConfig = (import <nixpkgs/nixos> {


### PR DESCRIPTION
Since NixOS/nixpkgs@3bf3d19, udevSoMajor is no longer needed, as this is now properly determined at runtime.

For older revisions, it's still defaulting to `0`, so we shouldn't break older versions of `<nixpkgs>`.