### PR TITLE
Fixup and refactor Hetzner backend tests

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -113,7 +113,7 @@ rec {
     system = "x86_64-linux";
   }).test;
 
-#  tests.hetzner_backend = (import ./tests/hetzner-backend.nix {
+#  tests.hetzner_backend = (import ./tests/hetzner-backend {
 #    nixops = build.x86_64-linux;
 #    system = "x86_64-linux";
 #  }).test;

--- a/release.nix
+++ b/release.nix
@@ -113,8 +113,8 @@ rec {
     system = "x86_64-linux";
   }).test;
 
-#  tests.hetzner_backend = (import ./tests/hetzner-backend {
-#    nixops = build.x86_64-linux;
-#    system = "x86_64-linux";
-#  }).test;
+  tests.hetzner_backend = (import ./tests/hetzner-backend {
+    nixops = build.x86_64-linux;
+    system = "x86_64-linux";
+  }).test;
 }

--- a/tests/hetzner-backend/backdoor.nix
+++ b/tests/hetzner-backend/backdoor.nix
@@ -1,0 +1,104 @@
+{ pkgs, diskImageFun }:
+
+let
+  plain = text: { inherit text; type = "plain"; };
+  executable = text: { inherit text; type = "exec"; };
+
+  fileMap = {
+    backdoor = executable ''
+      #!/bin/sh
+      export USER=root
+      export HOME=/root
+      . /etc/profile
+      cd /tmp
+      exec < /dev/hvc0 > /dev/hvc0
+      while ! exec 2> /dev/ttyS0; do sleep 0.1; done
+      echo "connecting to host..." >&2
+      stty -F /dev/hvc0 raw -echo
+      echo
+      PS1= exec /bin/sh
+    '';
+
+    debian.install = plain ''
+      backdoor usr/sbin
+    '';
+
+    debian.compat = plain "9";
+    debian.source.format = plain "3.0 (native)";
+
+    debian.changelog = plain ''
+      backdoor (1-1) unstable; urgency=low
+
+        * Dummy changelog for snakeoil key.
+
+       -- Mr. Robot <evil@backdoor>  Thu, 01 Jan 1970 00:00:01 +0000
+    '';
+
+    debian.control = plain ''
+      Source: backdoor
+      Section: misc
+      Priority: optional
+      Maintainer: Mr. Robot <evil@backdoor>
+      Build-Depends: debhelper (>= 9), dh-systemd
+      Standards-Version: 3.9.6
+
+      Package: backdoor
+      Architecture: all
+      Depends: ''${misc:Depends}
+      Description: Backdoor For VM testing
+    '';
+
+    debian.rules = executable ''
+      #!/usr/bin/make -f
+      %:
+      ${"\t"}dh $@ --with=systemd
+    '';
+
+    debian.service = plain ''
+      [Unit]
+      Description=Backdoor
+      Requires=dev-hvc0.device
+      Requires=dev-ttyS0.device
+      After=dev-hvc0.device
+      After=dev-ttyS0.device
+
+      [Service]
+      ExecStart=/usr/sbin/backdoor
+      KillSignal=SIGHUP
+
+      [Install]
+      WantedBy=multi-user.target
+    '';
+  };
+
+  genFile = path: name: { type ? null, text ? "", ... }@attrs: with pkgs.lib;
+    if type == null
+    then concatStrings (mapAttrsToList (genFile (path ++ [name])) attrs)
+    else ''
+      ${optionalString (path != []) ''
+        mkdir -p "${concatStringsSep "/" path}"
+      ''}
+      cat > "${concatStringsSep "/" (path ++ [name])}" <<'EOF'
+      ${text}
+      EOF
+      ${optionalString (type == "exec") ''
+        chmod +x "${concatStringsSep "/" (path ++ [name])}"
+      ''}
+    '';
+
+in pkgs.vmTools.runInLinuxImage (pkgs.stdenv.mkDerivation {
+  name = "backdoor.deb";
+
+  diskImage = diskImageFun {
+    extraPackages = [ "build-essential" "debhelper" "dh-systemd" ];
+  };
+
+  buildCommand = ''
+    mkdir backdoor
+    cd backdoor
+    ${with pkgs.lib; concatStrings (mapAttrsToList (genFile []) fileMap)}
+    dpkg-buildpackage -b
+    rmdir "$out" || :
+    mv -vT ../*.deb "$out" # */
+  '';
+})

--- a/tests/hetzner-backend/default.nix
+++ b/tests/hetzner-backend/default.nix
@@ -5,35 +5,8 @@ with import <nixpkgs/nixos/lib/qemu-flags.nix>;
 with pkgs.lib;
 
 let
+  rescueISO = import ./rescue-image.nix { inherit pkgs; };
   rescuePasswd = "abcd1234";
-
-  rescueDiskImageFun = pkgs.vmTools.diskImageFuns.debian8x86_64;
-  rescueDebDistro = pkgs.vmTools.debDistros.debian8x86_64;
-  rescueDebCodename = "jessie";
-
-  live-build = pkgs.stdenv.mkDerivation rec {
-    name = "live-build-${version}";
-    version = "5.0_a11";
-
-    src = pkgs.fetchgit {
-      url = "git://live.debian.net/git/live-build.git";
-      rev = "refs/tags/debian/${version}-1";
-      sha256 = "0c3kqqsw4pxrnmjqphs8ifcm78yly6zdvnylg9s6njga7mb951g9";
-    };
-
-    dontPatchShebangs = true;
-
-    postPatch = ''
-      find -type f -exec sed -i \
-        -e 's,/usr/lib/live,'"$out"'/lib/live,g' \
-        -e 's,/usr/share/live,'"$out"'/share/live,g' \
-        {} +
-      sed -i \
-        -e 's,/usr/bin,'"$out"'/bin,' \
-        -e 's,/usr/share,'"$out"'/share,' \
-        Makefile
-    '';
-  };
 
   network = pkgs.writeText "network.nix" ''
     let
@@ -103,108 +76,6 @@ let
       };
     }
   '';
-
-  # Packages needed by live-build
-  rescuePackages = [
-    "apt" "hostname" "tasksel" "makedev" "locales" "kbd" "linux-image-amd64"
-    "console-setup" "console-common" "eject" "file" "user-setup" "sudo"
-    "squashfs-tools" "syslinux-common" "syslinux" "isolinux" "genisoimage"
-    "live-boot" "zsync" "librsvg2-bin" "dctrl-tools" "xorriso" "live-config"
-    "live-config-systemd"
-  ];
-
-  # Packages to be explicitly installed into the live system.
-  additionalRescuePackages = [
-    "openssh-server" "e2fsprogs" "mdadm" "btrfs-tools" "dmsetup" "iproute"
-    "net-tools"
-  ];
-
-  backdoorDeb = import ./backdoor.nix {
-    inherit pkgs;
-    diskImageFun = rescueDiskImageFun;
-  };
-
-  aptRepository = import ./repository.nix {
-    inherit pkgs;
-    diskImageFun = rescueDiskImageFun;
-    debianDistro = rescueDebDistro;
-    debianCodename = rescueDebCodename;
-    debianPackages = rescuePackages ++ additionalRescuePackages;
-    extraPackages = [ backdoorDeb ];
-  };
-
-  # This more or less resembles an image of the Hetzner's rescue system.
-  rescueISO = pkgs.vmTools.runInLinuxImage (pkgs.stdenv.mkDerivation {
-    name = "hetzner-fake-rescue-image";
-    diskImage = rescueDiskImageFun {
-      extraPackages = [ "debootstrap" "apt" ];
-    };
-    memSize = 768;
-
-    inherit additionalRescuePackages;
-
-    bootOptions = [
-      "boot=live"
-      "config"
-      "console=ttyS0"
-      "hostname=rescue"
-      "timezone=Europe/Berlin"
-      "noeject"
-      "quickreboot"
-    ];
-
-    buildCommand = ''
-      # Operate on the temporary root filesystem instead of the tmpfs.
-      mkdir -p /build_fake_rescue
-      cd /build_fake_rescue
-
-      PATH="${pkgs.gnupg}/bin:${live-build}/bin:${pkgs.cpio}/bin:$PATH"
-
-      ${aptRepository.serve}
-
-      lb config --memtest none \
-                --apt-secure false \
-                --apt-source-archives false \
-                --binary-images iso \
-                --distribution "${rescueDebCodename}" \
-                --debconf-frontend noninteractive \
-                --debootstrap-options "--include=snakeoil-archive-keyring" \
-                --bootappend-live "$bootOptions" \
-                --mirror-bootstrap http://127.0.0.1 \
-                --mirror-binary http://127.0.0.1 \
-                --debian-installer false \
-                --security false \
-                --updates false \
-                --backports false \
-                --source false \
-                --firmware-binary false \
-                --firmware-chroot false
-
-      mkdir -p config/includes.chroot/etc/systemd/journald.conf.d
-      echo rescue > config/includes.chroot/etc/hostname
-      cat > config/includes.chroot/etc/systemd/journald.conf.d/log.conf <<EOF
-      [Journal]
-      ForwardToConsole=yes
-      MaxLevelConsole=debug
-      EOF
-
-      echo $additionalRescuePackages \
-        > config/package-lists/additional.list.chroot
-      echo backdoor \
-        > config/package-lists/custom.list.chroot
-
-      cp -rT "${live-build}/share/live/build/bootloaders" \
-        config/bootloaders
-      sed -i -e 's/timeout 0/timeout 1/' \
-        config/bootloaders/isolinux/isolinux.cfg
-
-      lb build
-
-      kill -TERM $(< repo.pid)
-      chmod 0644 live-image-*.iso
-      mv live-image-*.iso "$out/rescue.iso"
-    '';
-  });
 
   env = "NIX_PATH=nixos=${<nixpkgs>}/nixos:nixpkgs=${<nixpkgs>}"
       + " HETZNER_ROBOT_USER=none HETZNER_ROBOT_PASS=none";

--- a/tests/hetzner-backend/default.nix
+++ b/tests/hetzner-backend/default.nix
@@ -193,9 +193,10 @@ let
       echo backdoor \
         > config/package-lists/custom.list.chroot
 
-      cat > config/hooks/1000-isolinux_timeout.binary <<ISOLINUX
-      sed -i -e 's/timeout 0/timeout 1/' binary/isolinux/isolinux.cfg
-      ISOLINUX
+      cp -rT "${live-build}/share/live/build/bootloaders" \
+        config/bootloaders
+      sed -i -e 's/timeout 0/timeout 1/' \
+        config/bootloaders/isolinux/isolinux.cfg
 
       lb build
 

--- a/tests/hetzner-backend/default.nix
+++ b/tests/hetzner-backend/default.nix
@@ -158,7 +158,7 @@ let
       mkdir -p /build_fake_rescue
       cd /build_fake_rescue
 
-      PATH="${pkgs.gnupg}/bin:${live-build}/bin:$PATH"
+      PATH="${pkgs.gnupg}/bin:${live-build}/bin:${pkgs.cpio}/bin:$PATH"
 
       ${aptRepository.serve}
 
@@ -179,6 +179,14 @@ let
                 --source false \
                 --firmware-binary false \
                 --firmware-chroot false
+
+      mkdir -p config/includes.chroot/etc/systemd/journald.conf.d
+      echo rescue > config/includes.chroot/etc/hostname
+      cat > config/includes.chroot/etc/systemd/journald.conf.d/log.conf <<EOF
+      [Journal]
+      ForwardToConsole=yes
+      MaxLevelConsole=debug
+      EOF
 
       echo $additionalRescuePackages \
         > config/package-lists/additional.list.chroot

--- a/tests/hetzner-backend/default.nix
+++ b/tests/hetzner-backend/default.nix
@@ -180,10 +180,6 @@ let
                 --firmware-binary false \
                 --firmware-chroot false
 
-      cat > config/hooks/1000-root_password.chroot <<ROOTPW
-      echo "root:${rescuePasswd}" | chpasswd
-      ROOTPW
-
       echo $additionalRescuePackages \
         > config/package-lists/additional.list.chroot
       echo backdoor \
@@ -282,6 +278,7 @@ in makeTest {
       $target1->succeed("mkdir -p /nix && mount /dev/vdc /nix");
       $target1->succeed("ifconfig eth1 192.168.1.2");
       $target1->succeed("modprobe dm-mod");
+      $target1->succeed("echo 'root:${rescuePasswd}' | chpasswd");
     };
 
     my $target2 = createMachine({
@@ -299,6 +296,7 @@ in makeTest {
       $target2->succeed("mkdir -p /nix && mount /dev/vdc /nix");
       $target2->succeed("ifconfig eth1 192.168.1.3");
       $target2->succeed("modprobe dm-mod");
+      $target2->succeed("echo 'root:${rescuePasswd}' | chpasswd");
       # XXX: Work around failure on mkfs.btrfs
       $target2->succeed("mkdir -p /live/medium/live/filesystem.squashfs");
     };

--- a/tests/hetzner-backend/default.nix
+++ b/tests/hetzner-backend/default.nix
@@ -99,29 +99,29 @@ let
 in makeTest {
   nodes.coordinator = {
     networking.firewall.enable = false;
-    environment.systemPackages = let
-      testNixops = overrideDerivation nixops (o: {
-        postPatch = ''
-          sed -i -e 's/^TEST_MODE.*/TEST_MODE = True/' \
-            nixops/backends/hetzner.py
-        '';
-      });
-      # XXX: Workaround to prepopulate the Nix store of the coordinator.
-      collection = pkgs.myEnvFun {
-        name = "prepopulate";
-        buildInputs = [
-          # This is to have the bootstrap installer prebuilt inside the Nix
-          # store of the target machine.
-          (import ../../nix/hetzner-bootstrap.nix)
-          # ... and this is for other requirements for a basic deployment.
-          pkgs.stdenv pkgs.busybox pkgs.module_init_tools pkgs.grub2
-          pkgs.xfsprogs pkgs.btrfsProgs pkgs.docbook_xsl_ns pkgs.libxslt
-          pkgs.docbook5 pkgs.ntp pkgs.perlPackages.ArchiveCpio
-          # Firmware used in <nixpkgs/nixos/modules/installer/scan/not-detected.nix>
-          pkgs.firmwareLinuxNonfree
-        ];
-      };
-    in [ testNixops collection ];
+    environment.systemPackages = singleton (overrideDerivation nixops (o: {
+      postPatch = ''
+        sed -i -e 's/^TEST_MODE.*/TEST_MODE = True/' \
+          nixops/backends/hetzner.py
+      '';
+    }));
+
+    # This is needed to make sure the coordinator can build the
+    # deployment without network availability.
+    environment.etc.nix-references.source = let
+      refs = [
+        # This is to have the bootstrap installer prebuilt inside the Nix
+        # store of the target machine.
+        (import ../../nix/hetzner-bootstrap.nix)
+        # ... and this is for other requirements for a basic deployment.
+        pkgs.stdenv pkgs.busybox pkgs.module_init_tools pkgs.grub2
+        pkgs.xfsprogs pkgs.btrfsProgs pkgs.docbook_xsl_ns pkgs.libxslt
+        pkgs.docbook5 pkgs.ntp pkgs.perlPackages.ArchiveCpio
+        # Firmware used in <nixpkgs/nixos/modules/installer/scan/not-detected.nix>
+        pkgs.firmwareLinuxNonfree
+      ];
+    in pkgs.writeText "refs" (concatStringsSep "\n" refs);
+
     virtualisation.writableStore = true;
     virtualisation.writableStoreUseTmpfs = false;
     virtualisation.memorySize = 2048;

--- a/tests/hetzner-backend/default.nix
+++ b/tests/hetzner-backend/default.nix
@@ -258,7 +258,7 @@ in makeTest {
         buildInputs = [
           # This is to have the bootstrap installer prebuilt inside the Nix
           # store of the target machine.
-          (import ../nix/hetzner-bootstrap.nix)
+          (import ../../nix/hetzner-bootstrap.nix)
           # ... and this is for other requirements for a basic deployment.
           pkgs.stdenv pkgs.busybox pkgs.module_init_tools pkgs.grub2
           pkgs.xfsprogs pkgs.btrfsProgs pkgs.docbook_xsl_ns pkgs.libxslt

--- a/tests/hetzner-backend/default.nix
+++ b/tests/hetzner-backend/default.nix
@@ -146,7 +146,7 @@ let
     bootOptions = [
       "boot=live"
       "config"
-      "console=ttyS0,9600"
+      "console=ttyS0"
       "hostname=rescue"
       "timezone=Europe/Berlin"
       "noeject"

--- a/tests/hetzner-backend/default.nix
+++ b/tests/hetzner-backend/default.nix
@@ -274,6 +274,9 @@ in makeTest {
         $node->succeed("ifconfig eth1 $ip");
         $node->succeed("modprobe dm-mod");
         $node->succeed("echo 'root:${rescuePasswd}' | chpasswd");
+        my $re = 's/^(PermitRootLogin|PasswordAuthentication) .*/\\1 yes/';
+        $node->succeed("sed -i -re '$re' /etc/ssh/sshd_config");
+        $node->succeed("systemctl restart ssh");
       });
       return $node;
     };

--- a/tests/hetzner-backend/default.nix
+++ b/tests/hetzner-backend/default.nix
@@ -266,7 +266,7 @@ in makeTest {
         qemuFlags => $qemuFlags,
         allowReboot => 1,
       });
-      $node->nest("setting up rescue system", sub {
+      $node->nest("setting up rescue system for $name", sub {
         $node->start;
         $node->succeed("echo 2 > /proc/sys/vm/panic_on_oom");
         $node->succeed("mkfs.ext4 /dev/vdc");

--- a/tests/hetzner-backend/repository.nix
+++ b/tests/hetzner-backend/repository.nix
@@ -1,4 +1,6 @@
-{ pkgs, diskImageFun, debianDistro, debianCodename, debianPackages }:
+{ pkgs, diskImageFun, debianDistro, debianCodename, debianPackages
+, extraPackages ? []
+}:
 
 let
   reprepro = pkgs.stdenv.mkDerivation rec {
@@ -137,7 +139,7 @@ let
 
       # Create APT repository
       echo -n "Creating APT repository..." >&2
-      for debfile in $toInclude ${keyringPackage}; do
+      for debfile in $toInclude ${keyringPackage} ${toString extraPackages}; do
         REPREPRO_BASE_DIR="$out" ${reprepro}/bin/reprepro includedeb \
           "${debianCodename}" "$debfile" > /dev/null
       done

--- a/tests/hetzner-backend/repository.nix
+++ b/tests/hetzner-backend/repository.nix
@@ -1,0 +1,157 @@
+{ pkgs, diskImageFun, debianDistro, debianCodename, debianPackages }:
+
+let
+  reprepro = pkgs.stdenv.mkDerivation rec {
+    name = "reprepro-${version}";
+    version = "4.16.0";
+
+    src = pkgs.fetchurl {
+      url = "https://alioth.debian.org/frs/download.php/file/"
+          + "4109/reprepro_${version}.orig.tar.gz";
+      sha256 = "14gmk16k9n04xda4446ydfj8cr5pmzsmm4il8ysf69ivybiwmlpx";
+    };
+
+    buildInputs = with pkgs; [ makeWrapper db gpgme libarchive bzip2 xz zlib ];
+
+    postInstall = ''
+      wrapProgram "$out/bin/reprepro" --prefix PATH : "${pkgs.gnupg}/bin"
+    '';
+  };
+
+  repoKeys = pkgs.vmTools.runInLinuxVM (pkgs.stdenv.mkDerivation {
+    name = "snakeoil-repository-keys";
+
+    outputs = [ "out" "publicKey" "publicKeyId" "secretKeyId" ];
+
+    buildCommand = ''
+      export GNUPGHOME="$out"
+      mkdir -p "$GNUPGHOME"
+      rm -f /dev/random
+      ln -s urandom /dev/random
+      mknod /dev/console c 5 1
+
+      cat > template <<EOF
+      %echo Generating a repository signing key
+      %transient-key
+      %no-protection
+      Key-Type: DSA
+      Key-Usage: sign
+      Name-Real: Snake Oil
+      Name-Email: snake@oil
+      Expire-Date: 0
+      %commit
+      %echo Repository key created
+      EOF
+
+      ${pkgs.gnupg}/bin/gpg2 --batch --gen-key template
+
+      ${pkgs.gnupg}/bin/gpg2 --list-secret-keys | \
+        sed -n -re 's,^sec +[^/]*/([^ ]+).*,\1,p' \
+        > "$secretKeyId"
+      ${pkgs.gnupg}/bin/gpg2 --list-public-keys | \
+        sed -n -re 's,^pub +[^/]*/([^ ]+).*,\1,p' \
+        > "$publicKeyId"
+      ${pkgs.gnupg}/bin/gpg2 --export \
+        "$(< "$publicKeyId")" \
+        > "$publicKey"
+    '';
+  });
+
+  keyringPackage = pkgs.vmTools.runInLinuxImage (pkgs.stdenv.mkDerivation {
+    name = "snakeoil-archive-keyring.deb";
+
+    diskImage = diskImageFun {
+      extraPackages = [ "build-essential" "gnupg" "apt" "debhelper" ];
+    };
+
+    GNUPGHOME = repoKeys;
+
+    buildCommand = ''
+      mkdir snakeoil-archive-keyring
+      cd snakeoil-archive-keyring
+      cat "${repoKeys.publicKey}" > snakeoil-archive-keyring.gpg
+      mkdir -p debian/source
+      echo 9 > debian/compat
+      echo '3.0 (native)' > debian/source/format
+      cp "${pkgs.writeText "install" ''
+        snakeoil-archive-keyring.gpg /usr/share/keyrings
+        snakeoil-archive-keyring.gpg /etc/apt/trusted.gpg.d
+      ''}" debian/install
+      cp "${pkgs.writeScript "rules" ''
+        #!/usr/bin/make -f
+        %:
+        ${"\t"}dh $@
+      ''}" debian/rules
+      cp "${pkgs.writeText "changelog" ''
+        snakeoil-archive-keyring (1-1) unstable; urgency=low
+
+          * Dummy changelog for snakeoil key.
+
+         -- Snake Oil <snake@oil>  Thu, 01 Jan 1970 00:00:01 +0000
+      ''}" debian/changelog
+      cp "${pkgs.writeText "control" ''
+        Source: snakeoil-archive-keyring
+        Section: misc
+        Priority: optional
+        Maintainer: Snake Oil <snake@oil>
+        Build-Depends: debhelper (>= 9), gnupg, apt
+        Standards-Version: 3.9.6
+
+        Package: snakeoil-archive-keyring
+        Architecture: all
+        Depends: ''${misc:Depends}
+        Description: Snakeoil archive signing key
+      ''}" debian/control
+      dpkg-buildpackage -b
+      rmdir "$out" || :
+      mv -vT ../*.deb "$out" # */
+    '';
+  });
+
+  repository = pkgs.stdenv.mkDerivation {
+    name = "apt-repository";
+
+    toInclude = let
+      expr = pkgs.vmTools.debClosureGenerator {
+        packages = debianDistro.packages ++ debianPackages;
+        inherit (debianDistro) name urlPrefix;
+        packagesLists = [ debianDistro.packagesList ];
+      };
+    in import expr {
+      inherit (pkgs) fetchurl;
+    };
+
+    GNUPGHOME = repoKeys;
+
+    buildCommand = ''
+      mkdir -p "$out"/{conf,dists,incoming,indices,logs,pool,project,tmp}
+      cat > "$out/conf/distributions" <<RELEASE
+      Origin: Debian
+      Label: Debian
+      Codename: ${debianCodename}
+      Architectures: amd64
+      Components: main
+      Description: Debian package cache
+      SignWith: $(< "${repoKeys.secretKeyId}")
+      RELEASE
+
+      # Create APT repository
+      echo -n "Creating APT repository..." >&2
+      for debfile in $toInclude ${keyringPackage}; do
+        REPREPRO_BASE_DIR="$out" ${reprepro}/bin/reprepro includedeb \
+          "${debianCodename}" "$debfile" > /dev/null
+      done
+      echo " done." >&2
+    '';
+
+    passthru.serve = pkgs.writeScript "serve-debian-repo" ''
+      #!${pkgs.stdenv.shell}
+      exec ${pkgs.thttpd}/sbin/thttpd -d "${repository}" \
+                                      -l /dev/null \
+                                      -i "$(pwd)/repo.pid"
+    '';
+
+    passthru.publicKey = repoKeys.publicKey;
+  };
+
+in repository

--- a/tests/hetzner-backend/rescue-image.nix
+++ b/tests/hetzner-backend/rescue-image.nix
@@ -1,0 +1,132 @@
+{ pkgs }:
+
+let
+  rescueDiskImageFun = pkgs.vmTools.diskImageFuns.debian8x86_64;
+  rescueDebDistro = pkgs.vmTools.debDistros.debian8x86_64;
+  rescueDebCodename = "jessie";
+
+  live-build = pkgs.stdenv.mkDerivation rec {
+    name = "live-build-${version}";
+    version = "5.0_a11";
+
+    src = pkgs.fetchgit {
+      url = "git://live.debian.net/git/live-build.git";
+      rev = "refs/tags/debian/${version}-1";
+      sha256 = "0c3kqqsw4pxrnmjqphs8ifcm78yly6zdvnylg9s6njga7mb951g9";
+    };
+
+    dontPatchShebangs = true;
+
+    postPatch = ''
+      find -type f -exec sed -i \
+        -e 's,/usr/lib/live,'"$out"'/lib/live,g' \
+        -e 's,/usr/share/live,'"$out"'/share/live,g' \
+        {} +
+      sed -i \
+        -e 's,/usr/bin,'"$out"'/bin,' \
+        -e 's,/usr/share,'"$out"'/share,' \
+        Makefile
+    '';
+  };
+
+  # Packages needed by live-build
+  rescuePackages = [
+    "apt" "hostname" "tasksel" "makedev" "locales" "kbd" "linux-image-amd64"
+    "console-setup" "console-common" "eject" "file" "user-setup" "sudo"
+    "squashfs-tools" "syslinux-common" "syslinux" "isolinux" "genisoimage"
+    "live-boot" "zsync" "librsvg2-bin" "dctrl-tools" "xorriso" "live-config"
+    "live-config-systemd"
+  ];
+
+  # Packages to be explicitly installed into the live system.
+  additionalRescuePackages = [
+    "openssh-server" "e2fsprogs" "mdadm" "btrfs-tools" "dmsetup" "iproute"
+    "net-tools"
+  ];
+
+  backdoorDeb = import ./backdoor.nix {
+    inherit pkgs;
+    diskImageFun = rescueDiskImageFun;
+  };
+
+  aptRepository = import ./repository.nix {
+    inherit pkgs;
+    diskImageFun = rescueDiskImageFun;
+    debianDistro = rescueDebDistro;
+    debianCodename = rescueDebCodename;
+    debianPackages = rescuePackages ++ additionalRescuePackages;
+    extraPackages = [ backdoorDeb ];
+  };
+
+  # This more or less resembles an image of the Hetzner's rescue system.
+in pkgs.vmTools.runInLinuxImage (pkgs.stdenv.mkDerivation {
+  name = "hetzner-fake-rescue-image";
+  diskImage = rescueDiskImageFun {
+    extraPackages = [ "debootstrap" "apt" ];
+  };
+  memSize = 768;
+
+  inherit additionalRescuePackages;
+
+  bootOptions = [
+    "boot=live"
+    "config"
+    "console=ttyS0"
+    "hostname=rescue"
+    "timezone=Europe/Berlin"
+    "noeject"
+    "quickreboot"
+  ];
+
+  buildCommand = ''
+    # Operate on the temporary root filesystem instead of the tmpfs.
+    mkdir -p /build_fake_rescue
+    cd /build_fake_rescue
+
+    PATH="${pkgs.gnupg}/bin:${live-build}/bin:${pkgs.cpio}/bin:$PATH"
+
+    ${aptRepository.serve}
+
+    lb config --memtest none \
+              --apt-secure false \
+              --apt-source-archives false \
+              --binary-images iso \
+              --distribution "${rescueDebCodename}" \
+              --debconf-frontend noninteractive \
+              --debootstrap-options "--include=snakeoil-archive-keyring" \
+              --bootappend-live "$bootOptions" \
+              --mirror-bootstrap http://127.0.0.1 \
+              --mirror-binary http://127.0.0.1 \
+              --debian-installer false \
+              --security false \
+              --updates false \
+              --backports false \
+              --source false \
+              --firmware-binary false \
+              --firmware-chroot false
+
+    mkdir -p config/includes.chroot/etc/systemd/journald.conf.d
+    echo rescue > config/includes.chroot/etc/hostname
+    cat > config/includes.chroot/etc/systemd/journald.conf.d/log.conf <<EOF
+    [Journal]
+    ForwardToConsole=yes
+    MaxLevelConsole=debug
+    EOF
+
+    echo $additionalRescuePackages \
+      > config/package-lists/additional.list.chroot
+    echo backdoor \
+      > config/package-lists/custom.list.chroot
+
+    cp -rT "${live-build}/share/live/build/bootloaders" \
+      config/bootloaders
+    sed -i -e 's/timeout 0/timeout 1/' \
+      config/bootloaders/isolinux/isolinux.cfg
+
+    lb build
+
+    kill -TERM $(< repo.pid)
+    chmod 0644 live-image-*.iso
+    mv live-image-*.iso "$out/rescue.iso"
+  '';
+})


### PR DESCRIPTION
These tests were broken since 209aa199c3b2d64b5bb9263760b579c465af9451.

Also, this switches the rescue image to Debian Jessie, so it doesn't reflect the `current` situation but the upcoming situation. I've asked the Hetzner staff about a date of the switch, but they still have issues to solve on their own, so they couldn't provide a specific date but a "by the end of the year".

The main reason for the switch was that Debian Jessie has some major changes, which includes their switch to `systemd`. I found it not worth the work to refactor it and patch it up just so that we have a VM test that uses Debian Wheezy.