### PR TITLE
Fix tests for the "none" backend

### DIFF
--- a/tests/none-backend.nix
+++ b/tests/none-backend.nix
@@ -21,6 +21,7 @@ let
             boot.loader.grub.enable = false;
             # Should NixOps fill in extraHosts for the "none" backend?
             networking.extraHosts = "192.168.1.3 target2\n";
+            virtualisation.writableStore = true;
           };
 
         target2 = target1;

--- a/tests/none-backend.nix
+++ b/tests/none-backend.nix
@@ -80,9 +80,15 @@ makeTest {
   nodes =
     { coordinator =
         { config, pkgs, ... }:
-        { environment.systemPackages =
-            [ nixops pkgs.stdenv pkgs.vim pkgs.apacheHttpd pkgs.busybox
-              pkgs.module_init_tools pkgs.perlPackages.ArchiveCpio ];
+        { environment.systemPackages = [ nixops ];
+          # This is needed to make sure the coordinator can build the
+          # deployment without network availability.
+          environment.etc.nix-references.source = let
+            refs = [
+              pkgs.stdenv pkgs.vim pkgs.apacheHttpd pkgs.busybox
+              pkgs.module_init_tools pkgs.perlPackages.ArchiveCpio
+            ];
+          in pkgs.writeText "refs" (concatStringsSep "\n" refs);
           networking.firewall.enable = false;
           virtualisation.writableStore = true;
         };

--- a/tests/none-backend.nix
+++ b/tests/none-backend.nix
@@ -45,7 +45,10 @@ let
               services.httpd.adminAddr = "e.dolstra@tudelft.nl";
             ''}
             ${optionalString (n == 3) ''
-              services.httpd.extraModules = ["proxy_balancer"];
+              services.httpd.extraModules = [
+                "proxy_balancer"
+                "lbmethod_byrequests"
+              ];
               services.httpd.extraConfig =
                 "
                   <Proxy balancer://cluster>

--- a/tests/none-backend.nix
+++ b/tests/none-backend.nix
@@ -96,12 +96,10 @@ makeTest {
         { environment.systemPackages = [ nixops ];
           # This is needed to make sure the coordinator can build the
           # deployment without network availability.
-          environment.etc.nix-references.source = let
-            refs = [
-              pkgs.stdenv pkgs.vim pkgs.apacheHttpd pkgs.busybox
-              pkgs.module_init_tools pkgs.perlPackages.ArchiveCpio
-            ];
-          in pkgs.writeText "refs" (concatStringsSep "\n" refs);
+          system.extraDependencies = [
+            pkgs.stdenv pkgs.vim pkgs.apacheHttpd pkgs.busybox
+            pkgs.module_init_tools pkgs.perlPackages.ArchiveCpio
+          ];
           networking.firewall.enable = false;
           virtualisation.writableStore = true;
         };

--- a/tests/none-backend.nix
+++ b/tests/none-backend.nix
@@ -22,6 +22,7 @@ let
             # Should NixOps fill in extraHosts for the "none" backend?
             networking.extraHosts = "192.168.1.3 target2\n";
             virtualisation.writableStore = true;
+            networking.firewall.enable = false;
           };
 
         target2 = target1;
@@ -36,7 +37,6 @@ let
         target1 =
           { config, pkgs, ... }:
           { services.openssh.enable = true;
-            networking.firewall.enable = false;
             users.extraUsers.root.openssh.authorizedKeys.keyFiles = [ ./id_test.pub ];
             ${optionalString (n == 1) ''
               environment.systemPackages = [ pkgs.vim ];
@@ -65,7 +65,6 @@ let
         target2 =
           { config, pkgs, ... }:
           { services.openssh.enable = true;
-            networking.firewall.enable = false;
             users.extraUsers.root.openssh.authorizedKeys.keyFiles = [ ./id_test.pub ];
             ${optionalString (n == 3) ''
               services.httpd.enable = true;

--- a/tests/none-backend.nix
+++ b/tests/none-backend.nix
@@ -38,6 +38,11 @@ let
           { config, pkgs, ... }:
           { services.openssh.enable = true;
             users.extraUsers.root.openssh.authorizedKeys.keyFiles = [ ./id_test.pub ];
+            # Ugly again: Replicates assignIPAddresses from build-vms.nix.
+            networking.interfaces.eth1.ip4 = [ {
+              address = "192.168.1.2";
+              prefixLength = 24;
+            } ];
             ${optionalString (n == 1) ''
               environment.systemPackages = [ pkgs.vim ];
             ''}
@@ -66,6 +71,11 @@ let
           { config, pkgs, ... }:
           { services.openssh.enable = true;
             users.extraUsers.root.openssh.authorizedKeys.keyFiles = [ ./id_test.pub ];
+            # Ugly again: Replicates assignIPAddresses from build-vms.nix.
+            networking.interfaces.eth1.ip4 = [ {
+              address = "192.168.1.3";
+              prefixLength = 24;
+            } ];
             ${optionalString (n == 3) ''
               services.httpd.enable = true;
               services.httpd.adminAddr = "e.dolstra@tudelft.nl";


### PR DESCRIPTION
While this solves the problem with the unavailable store paths, the activation of the target systems still fail with something like:

```
Failed to stop nix-.rw-store.mount: Unit nix-.rw-store.mount not loaded.
```

We need to look for the origin of this failure and fix it either here or in `<nixpkgs>`.