### PR TITLE
Use IPv6 capable socket to check if SSH is available

### DIFF
--- a/nixops/util.py
+++ b/nixops/util.py
@@ -149,7 +149,7 @@ def make_non_blocking(fd):
 
 
 def ping_tcp_port(ip, port, timeout=1, ensure_timeout=False):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
     s.settimeout(timeout)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
     try:


### PR DESCRIPTION
Use an AF_INET6 instead of an AF_INET socket to probe the SSH TCP port. This also works for IPv4.

Previously, nixops would wait forever for SSH to become available on an IPv6-only machine.