### PR TITLE
Change sbin/mount.vboxsf to bin/mount.vboxsf

### DIFF
--- a/nix/virtualbox.nix
+++ b/nix/virtualbox.nix
@@ -124,7 +124,7 @@ in
       kernelModules = [ "vboxsf" ];
 
       extraUtilsCommands = ''
-        cp -v ${pkgs.linuxPackages.virtualboxGuestAdditions}/sbin/mount.vboxsf \
+        cp -v ${pkgs.linuxPackages.virtualboxGuestAdditions}/bin/mount.vboxsf \
           $out/bin/
       '';
     };


### PR DESCRIPTION
The virtualbox package no longer has mount.vboxsf under sbin.
