### PR TITLE
Fix #362: chown the key using the uid and gid

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -26,6 +26,10 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
                 elem = x.find("attrs/attr[@name='{0}']/string".format(key))
                 if elem is not None:
                     opts[key] = elem.get("value")
+            for key in ('uid', 'gid'):
+                elem = x.find("attrs/attr[@name='{0}']/int".format(key))
+                if elem is not None:
+                    opts[key] = elem.get("value")
             return opts
 
         self.keys = {k.get("name"): _extract_key_options(k) for k in
@@ -209,7 +213,7 @@ class MachineState(nixops.resources.ResourceState):
             chmod = "chmod '{0}' " + outfile_esc
             chown = "chown '{0}:{1}' " + outfile_esc
             self.run_command(' && '.join([
-                chown.format(opts['user'], opts['group']),
+                chown.format(opts['uid'], opts['gid']),
                 chmod.format(opts['permissions'])
             ]))
             os.remove(tmp)


### PR DESCRIPTION
Previously the owner of the uploaded key would be set to the specified user name and group name. However, when the configuration which defines this user and group is not yet activated the chown operation will fail because the user or group might not be present.

What we now do instead is set the owner of the key using the UID and GID computed from the configuration.

This does enable a small attack window after the chown UID:GID and before the activation of the new configuration which adds the new user and group. If there's an existing user or group with the specified UID or GID respectively he might be able to read the key during that short window.

I also realise this doesn't yet work when `users.mutableUsers` is set the `true`. Ideally we would fall back to changing the ownership based on the user and group name when `users.mutableUsers` is set to`true`.