### PR TITLE
Respect deployment.virtualbox.disks.*.size for images with a baseImage

### DIFF
--- a/nix/virtualbox.nix
+++ b/nix/virtualbox.nix
@@ -131,7 +131,7 @@ in
 
     deployment.virtualbox.disks.disk1 =
       { port = 0;
-        size = 0;
+        size = mkDefault 0;
         baseImage = mkDefault (
           let
             unpack = name: sha256: pkgsNative.runCommand "virtualbox-nixops-${name}.vdi" {}

--- a/nixops/backends/virtualbox.py
+++ b/nixops/backends/virtualbox.py
@@ -289,6 +289,8 @@ class VirtualBoxState(MachineState):
                              "-o", "{0}/vbox-image-{1}".format(self.depl.tempdir, self.name)],
                             capture_stdout=True).rstrip()
                     self._logged_exec(["VBoxManage", "clonehd", base_image, disk_path])
+                    if disk_def['size'] != 0:
+                        self._logged_exec(["VBoxManage", "modifyhd", disk_path, "--resize", str(disk_def['size'])])
                 else:
                     # Create an empty disk.
                     if disk_def['size'] <= 0:


### PR DESCRIPTION
This goes together with NixOS/nixpkgs#12625, and requires a rebuild of the VirtualBox images with that to be useful.