### PR TITLE
Add m4 & c4 instance type physical properties

### DIFF
--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -489,6 +489,11 @@ in
           "m4.2xlarge"  = { cores = 8;  memory = 32768;  allowsEbsOptimized = true;  };
           "m4.xlarge"   = { cores = 4;  memory = 16384;  allowsEbsOptimized = true;  };
           "m4.large"    = { cores = 2;  memory = 8192;   allowsEbsOptimized = true;  };
+          "c4.8xlarge"  = { cores = 36; memory = 61440;  allowsEbsOptimized = true;  };
+          "c4.4xlarge"  = { cores = 16; memory = 30720;  allowsEbsOptimized = true;  };
+          "c4.2xlarge"  = { cores = 8;  memory = 15360;  allowsEbsOptimized = true;  };
+          "c4.xlarge"   = { cores = 4;  memory = 7680;   allowsEbsOptimized = true;  };
+          "c4.large"    = { cores = 2;  memory = 3840;   allowsEbsOptimized = true;  };
           "c1.medium"   = { cores = 2;  memory = 1697;   allowsEbsOptimized = false; };
           "c1.xlarge"   = { cores = 8;  memory = 6953;   allowsEbsOptimized = true;  };
           "cc1.4xlarge" = { cores = 16; memory = 21542;  allowsEbsOptimized = false; };

--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -484,6 +484,11 @@ in
           "m2.4xlarge"  = { cores = 8;  memory = 68557;  allowsEbsOptimized = true;  };
           "m3.xlarge"   = { cores = 4;  memory = 14985;  allowsEbsOptimized = true;  };
           "m3.2xlarge"  = { cores = 8;  memory = 30044;  allowsEbsOptimized = true;  };
+          "m4.10xlarge" = { cores = 40; memory = 163840; allowsEbsOptimized = true;  };
+          "m4.4xlarge"  = { cores = 16; memory = 65536;  allowsEbsOptimized = true;  };
+          "m4.2xlarge"  = { cores = 8;  memory = 32768;  allowsEbsOptimized = true;  };
+          "m4.xlarge"   = { cores = 4;  memory = 16384;  allowsEbsOptimized = true;  };
+          "m4.large"    = { cores = 2;  memory = 8192;   allowsEbsOptimized = true;  };
           "c1.medium"   = { cores = 2;  memory = 1697;   allowsEbsOptimized = false; };
           "c1.xlarge"   = { cores = 8;  memory = 6953;   allowsEbsOptimized = true;  };
           "cc1.4xlarge" = { cores = 16; memory = 21542;  allowsEbsOptimized = false; };


### PR DESCRIPTION
The problem this attempts to solve is to get the default EBS optimized EC2
attribute set appropriately for m4 instances. Currently despite m4 instance
types supposedly being EBS-optimized by default, without these entries nixops
will create them unoptimized.