### PR TITLE
Allow new keys & users/groups to be created in the same deploy

### DIFF
--- a/doc/manual/nixops.xml
+++ b/doc/manual/nixops.xml
@@ -575,8 +575,9 @@ $ nixops delete -d foo</screen>
 specification described by the Nix expressions given in the preceding
 <command>nixops create</command> call.  It creates missing virtual
 machines, builds each machine configuration, copies the closure of
-each configuration to the corresponding machine, and activates
-them.</para>
+each configuration to the corresponding machine, uploads any keys
+described in <varname>deployment.keys</varname>, and activates
+the new configuration.</para>
 
 </refsection>
 
@@ -1872,6 +1873,68 @@ input.  See <command>nixops export</command> for examples.</para>
 
 </refsection>
 
+</refsection>
+
+
+<refsection>
+  <title>Command <option>nixops send-keys</option></title>
+
+  <refsection>
+    <title>Synopsis</title>
+    <cmdsynopsis>
+      <command>nixops send-keys</command>
+      <arg>
+        <option>--include</option>
+        <arg choice='plain' rep='repeat'><replaceable>machine-name</replaceable></arg>
+      </arg>
+      <arg>
+        <option>--exclude</option>
+        <arg choice='plain' rep='repeat'><replaceable>machine-name</replaceable></arg>
+      </arg>
+    </cmdsynopsis>
+  </refsection>
+
+  <refsection>
+    <title>Description</title>
+    <para>
+      This command uploads the keys described in <varname>deployment.keys</varname>
+      to remote machines in the <literal>/run/keys/</literal> directory.
+    </para>
+    <para>
+      Keys are <emphasis>not</emphasis> persisted across reboots by default.
+      If a machine reboot is triggered from outside <literal>nixops</literal>, it will
+      need <command>nixops send-keys</command> to repopulate its keys.
+    </para>
+    <para>
+      Note that <command>nixops deploy</command> does an implicit <command>send-keys</command>
+      where appropriate, so manually sending keys is only necessary after unattended reboots.
+    </para>
+  </refsection>
+
+  <refsection>
+    <title>Options</title>
+    <variablelist>
+      <varlistentry>
+        <term>
+          <option>--include</option> <replaceable>machine-name...</replaceable>
+        </term>
+        <listitem>
+          <para>Only operate on the machines explicitly mentioned
+          here, excluding other machines.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
+          <option>--exclude</option> <replaceable>machine-name...</replaceable>
+        </term>
+        <listitem>
+          <para>Only operate on the machines that are
+          <emphasis>not</emphasis> mentioned here.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsection>
 </refsection>
 
 

--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -1562,6 +1562,88 @@ deploy the new configuration.
 
 </section>
 
+<section>
+  <title>Managing keys</title>
+
+  <para>
+    Files in <filename>/nix/store/</filename> are readable by every
+    user on that host, so storing secret keys embedded in nix derivations
+    is insecure. To address this, nixops provides the configuration
+    option <varname>deployment.keys</varname>, which nixops manages
+    separately from the main configuration derivation for each machine.
+  </para>
+
+  <para>
+    Add a key to a machine like so.
+
+    <screen>
+{
+  machine =
+    { config, pkgs, ... }:
+    {
+      deployment.keys.my-secret.text = "shhh this is a secret";
+      deployment.keys.my-secret.user = "myuser";
+      deployment.keys.my-secret.group = "wheel";
+      deployment.keys.my-secret.permissions = "0640";
+    };
+}
+    </screen>
+
+    This will create a file <filename>/run/keys/my-secret</filename>
+    with the specified contents, ownership, and permissions.
+  </para>
+
+  <para>
+    Among the key options, only <varname>text</varname> is required. The
+    <varname>user</varname> and <varname>group</varname> options both default
+    to <literal>"root"</literal>, and <varname>permissions</varname> defaults
+    to <literal>"0600"</literal>.
+  </para>
+
+  <para>
+    Keys from <varname>deployment.keys</varname> are stored under <filename>/run/</filename>
+    on a temporary filesystem and will not persist across a reboot.
+    To send a rebooted machine its keys, use <command>nixops send-keys</command>. Note that all
+    <command>nixops</command> commands implicitly upload keys when appropriate,
+    so manually sending keys should only be necessary after an unattended reboot.
+  </para>
+
+  <para>
+    If you have a custom service that depends on a key from <varname>deployment.keys</varname>,
+    you can opt to let systemd track that dependency. Each key gets a corresponding
+    systemd service <literal>"${keyname}-key.service"</literal> which is active
+    while the key is present, and otherwise inactive when the key is absent. See
+    <xref linkend="key-dependency.nix" /> for how to set this up.
+
+    <example xml:id="key-dependency.nix">
+      <title><filename>key-dependency.nix</filename>: track key dependence with systemd</title>
+      <programlisting>
+{
+  machine =
+    { config, pkgs, ... }:
+    {
+      deployment.keys.my-secret.text = "shhh this is a secret";
+
+      systemd.services.my-service = {
+        after = [ "my-secret-key.service" ];
+        wants = [ "my-secret-key.service" ];
+        script = ''
+          export MY_SECRET=$(cat /run/keys/my-secret)
+          run-my-program
+        '';
+      };
+    };
+}
+      </programlisting>
+    </example>
+
+    These dependencies will ensure that the service is only started when the keys it
+    requires are present. For example, after a reboot, the services will be delayed
+    until the keys are available, and <command>systemctl status</command> and friends
+    will lead you to the cause.
+  </para>
+</section>
+
 <!--
 
 <para>EC2 logical.nix</para>

--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -91,15 +91,20 @@ in
       apply = mapAttrs convertOldKeyType;
 
       description = ''
-        The set of keys to be deployed to the machine.  Each attribute
+        <para>The set of keys to be deployed to the machine.  Each attribute
         maps a key name to a file that can be accessed as
         <filename>/run/keys/<replaceable>name</replaceable></filename>.
         Thus, <literal>{ password.text = "foobar"; }</literal> causes a
         file <filename>/run/keys/password</filename> to be created
         with contents <literal>foobar</literal>.  The directory
         <filename>/run/keys</filename> is only accessible to root and
-        the <literal>keys</literal> group.  So keep in mind to add any
-        users that need to have access to a particular key to this group.
+        the <literal>keys</literal> group, so keep in mind to add any
+        users that need to have access to a particular key to this group.</para>
+
+        <para>Each key also gets a systemd service <literal><replaceable>name</replaceable>-key.service</literal>
+        which is active while the key is present and inactive while the key
+        is absent.  Thus, <literal>{ password.text = "foobar"; }</literal> gets
+        a <literal>password-key.service</literal>.</para>
       '';
     };
 

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -215,12 +215,25 @@ class MachineState(nixops.resources.ResourceState):
             outfile_esc = "'" + outfile.replace("'", r"'\''") + "'"
             self.run_command("rm -f " + outfile_esc)
             self.upload_file(tmp, outfile)
-            chmod = "chmod '{0}' " + outfile_esc
-            chown = "chown '{0}:{1}' " + outfile_esc
-            self.run_command(' && '.join([
-                chown.format(opts['user'], opts['group']),
-                chmod.format(opts['permissions'])
-            ]))
+            self.run_command(
+              ' '.join([
+                # chown only if user and group exist,
+                # else leave root:root owned
+                "(",
+                " getent passwd '{1}' >/dev/null &&",
+                " getent group '{2}' >/dev/null &&",
+                " chown '{1}:{2}' {0}",
+                ");",
+                # chmod either way
+                "chmod '{3}' {0}",
+              ])
+              .format(
+                outfile_esc,
+                opts['user'],
+                opts['group'],
+                opts['permissions']
+              )
+            )
             os.remove(tmp)
         self.run_command("touch /run/keys/done")
 


### PR DESCRIPTION
### Delay chown of keys until user/group both exist

Instead of chowning keys to their user/group every time they are sent,
only attempt the chown during send-keys if the user and group both
exist, and again do a chown during activation after the users and groups
have been created.

One result is that if a key and its user and/or group are to be created
in the same `nixops deploy`, the key will first be uploaded and owned
by root:root, then chmod'd, then late in activation the key will be
chowned to the newly created user/group. This includes a node's first
deploy, when it has neither keys nor users/groups.

Another result is that between send-keys and the next deploy (often,
but not necessarily, in the same `nixops deploy`), a key may
have its permissions set as configured, but _not_ be owned by the
configured user/group (instead root:root), which is presumed safe 
(**is it really though?**).
### Add service per key to track key dependencies

If a user service wants to block until `deployment.keys.mysecret` exists
to start up, it can now do so by adding `"mysecret-key.service"` to
its `requires` and `after` lists.

I tried doing this first via a systemd mount unit and a systemd path unit.
I couldn't get the mount to work (I have little experience configuring
filesystems). The path unit only supports unit _activation_, and only for
a single unit, and besides that it's extra fiddly to configure. 

For the per-key services, the `preStart` script will block until the key exists, 
and then the `script` will block until the key no longer exists. Permissions
aren't checked, only existence, as permissions are assumed to be correctly
set during activation.
