### PR TITLE
Create /etc/hosts with none backend.

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -141,6 +141,7 @@ rec {
               // { disks = mapAttrs (n: v: v //
                 { baseImage = if isDerivation v.baseImage then "drv" else toString v.baseImage; }) cfg.disks; });
           libvirtd = v.config.deployment.libvirtd;
+          publicIPv4 = v.config.networking.publicIPv4;
         }
       );
 

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -116,8 +116,9 @@ in
     };
 
     networking.publicIPv4 = mkOption {
+      default = null;
       example = "198.51.100.123";
-      type = types.str;
+      type = types.nullOr types.str;
       description = ''
         Publicly routable IPv4 address of this machine.
       '';

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -18,6 +18,8 @@ class NoneDefinition(MachineDefinition):
         MachineDefinition.__init__(self, xml, config)
         self._target_host = xml.find("attrs/attr[@name='targetHost']/string").get("value")
 
+        public_ipv4 = xml.find("attrs/attr[@name='publicIPv4']/string")
+        self._public_ipv4 = None if public_ipv4 is None else public_ipv4.get("value")
 
 class NoneState(MachineState):
     """State of a trivial machine."""
@@ -27,6 +29,7 @@ class NoneState(MachineState):
         return "none"
 
     target_host = nixops.util.attr_property("targetHost", None)
+    public_ipv4 = nixops.util.attr_property("publicIpv4", None)
     _ssh_private_key = attr_property("none.sshPrivateKey", None)
     _ssh_public_key = attr_property("none.sshPublicKey", None)
     _ssh_public_key_deployed = attr_property("none.sshPublicKeyDeployed", False, bool)
@@ -48,6 +51,7 @@ class NoneState(MachineState):
         assert isinstance(defn, NoneDefinition)
         self.set_common_state(defn)
         self.target_host = defn._target_host
+        self.public_ipv4 = defn._public_ipv4
 
         if not self.vm_id:
             self.log_start("generating new SSH keypair...")


### PR DESCRIPTION
I'm not sure whether the ip to use should default to `deployHost` or not but this seems safer plus `deployHost` might be a hostname. This uses the value of `networking.publicIPv4`.

Fixes #373 
