### PR TITLE
Fix evaluation and build of manual with latest nixpkgs master

### DIFF
--- a/doc/manual/default.nix
+++ b/doc/manual/default.nix
@@ -11,7 +11,7 @@ let
                  };
 
   optionsXML = builtins.toFile "options.xml" (builtins.unsafeDiscardStringContext
-    (builtins.toXML (pkgs.lib.optionAttrSetToDocList systemModule.options)));
+    (builtins.toXML (pkgs.lib.optionAttrSetToDocList {} systemModule.options)));
 
   optionsDocBook = pkgs.runCommand "options-db.xml" {} ''
     ${pkgs.libxslt}/bin/xsltproc \

--- a/doc/manual/resource.nix
+++ b/doc/manual/resource.nix
@@ -8,7 +8,7 @@ let
     { inherit pkgs; utils = {}; name = "<name>"; uuid = "<uuid>"; };
 
   optionsXML = builtins.toFile "options.xml" (builtins.unsafeDiscardStringContext
-    (builtins.toXML (pkgs.lib.optionAttrSetToDocList systemModule.options)));
+    (builtins.toXML (pkgs.lib.optionAttrSetToDocList {} systemModule.options)));
 
   optionsDocBook = pkgs.runCommand "options-db.xml" {} ''
     ${pkgs.libxslt}/bin/xsltproc \

--- a/nix/container.nix
+++ b/nix/container.nix
@@ -6,6 +6,7 @@ let
 
   machine = mkOptionType {
     name = "a machine";
+    typerep = "(machine)";
     check = x: x._type or "" == "machine";
     merge = mergeOneOption;
   };

--- a/nix/gce-target-pool.nix
+++ b/nix/gce-target-pool.nix
@@ -7,6 +7,7 @@ let
 
   machine = mkOptionType {
     name = "GCE machine";
+    typerep = "(GCEMachine)";
     check = x: x ? gce;
     merge = mergeOneOption;
   };

--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -53,6 +53,7 @@ let
 
   keyType = mkOptionType {
     name = "string or key options";
+    typerep = "(keyType)";
     check = v: isString v || keyOptionsType.check v;
     merge = loc: defs: let
       convert = def: def // {

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -6,6 +6,7 @@ with lib;
 
   resource = type: mkOptionType {
     name = "resource of type ‘${type}’";
+    typerep = "(resourceOf${type.typerep})";
     check = x: x._type or "" == type;
     merge = mergeOneOption;
   };


### PR DESCRIPTION
First of all, `optionAttrSetToDocList` now has an additional argument for specifying the internal `_module` attributes. Unfortunately, `toXML` silently ignores function calls so we don't get an error at this point.

In addition to this, we now have to specify type representations if we create a new option type with `mkOptionType`, so let's add those to the NixOps specific option types.

Both of these issues are caused by NixOS/nixpkgs@cad8957.

I'm not merging this right now, because it breaks backwards-compatibility with release `15.09` and possibly also with `16.03`.

Cc: @edolstra, @rbvermaa
