### PR TITLE
Use preferLocalBuild for decompressing the VirtualBox image

### DIFF
--- a/nix/virtualbox.nix
+++ b/nix/virtualbox.nix
@@ -134,7 +134,7 @@ in
         size = mkDefault 0;
         baseImage = mkDefault (
           let
-            unpack = name: sha256: pkgsNative.runCommand "virtualbox-nixops-${name}.vdi" {}
+            unpack = name: sha256: pkgsNative.runCommand "virtualbox-nixops-${name}.vdi" { preferLocalBuild = true; allowSubstitutes = false; }
               ''
                 xz -d < ${pkgsNative.fetchurl {
                   url = "http://nixos.org/releases/nixos/virtualbox-nixops-images/virtualbox-nixops-${name}.vdi.xz";


### PR DESCRIPTION
Redirecting this to a build server is both pointless and *incredibly*
slow.