### PR TITLE
Use env(1) to pass environment variables

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -665,7 +665,7 @@ class Deployment(object):
 
             try:
                 # Set the system profile to the new configuration.
-                daemon_var = '' if m.state == m.RESCUE else 'NIX_REMOTE=daemon '
+                daemon_var = '' if m.state == m.RESCUE else 'env NIX_REMOTE=daemon '
                 setprof = daemon_var + 'nix-env -p /nix/var/nix/profiles/system --set "{0}"'
                 if always_activate or self.definitions[m.name].always_activate:
                     m.run_command(setprof.format(m.new_toplevel))


### PR DESCRIPTION
This allows deploying to work even if the login shell isn't bash-compatible
(for example, fish)