### PR TITLE
hetzner-bootstrap: fix for multiple outputs

### DIFF
--- a/nix/hetzner-bootstrap.nix
+++ b/nix/hetzner-bootstrap.nix
@@ -1,4 +1,4 @@
-with import <nixpkgs> { system = "x86_64-linux"; config.packageOverrides = pkgs : { nix = pkgs.nixUnstable; }; };
+with import <nixpkgs> { system = "x86_64-linux"; config.packageOverrides = pkgs : { nix = pkgs.nixUnstable.out; }; };
 
 let
   pkgsNative = import <nixpkgs> {};


### PR DESCRIPTION
I have error when deploying to hetzner from current head (nixops and nixpkgs):
```
hetznerIron> sending reboot command... done.
hetznerIron> waiting for rescue system...Connection to 138.201.65.42 closed by remote host.
[down]...................................................................[up]
hetznerIron> building Nix bootstrap installer... these derivations will be built:
  /nix/store/akrjra7z0gi4b42avr52hnzq25jbg6xz-hetzner-nixops-installer.drv
building path(s) ‘/nix/store/pjxr3m4l1nsl10x2rcmyjk9mrv7bxz7z-hetzner-nixops-installer’
touch: failed to get attributes of '/nix/store/fnzddvcaw6dnxprgqah2p407czvk58pl-nix-1.12pre4523_3b81b26-dev/bin/nix-store': No such file or directory
builder for ‘/nix/store/akrjra7z0gi4b42avr52hnzq25jbg6xz-hetzner-nixops-installer.drv’ failed with exit code 1
error: build of ‘/nix/store/akrjra7z0gi4b42avr52hnzq25jbg6xz-hetzner-nixops-installer.drv’ failed
error: Command '['nix-build', '/nix/store/3xfnds9mdbs95vn95nz3yc6xwlcdq24s-nixops-1.3.2pre0_abcdef/share/nix/nixops/hetzner-bootstrap.nix', '--no-out-link']' returned non-zero exit status 100
```

This is second fix for hetznerBootstrap (first one is in nixpkgs  https://github.com/NixOS/nixpkgs/pull/15359)