### PR TITLE
Use openssh with ed25519 support in dev-shell

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -92,7 +92,7 @@ rec {
       # For "nix-build --run-env".
       shellHook = ''
         export PYTHONPATH=$(pwd):$PYTHONPATH
-        export PATH=$(pwd)/scripts:$PATH
+        export PATH=$(pwd)/scripts:${openssh}/bin:$PATH
       '';
 
       doCheck = true;


### PR DESCRIPTION
I was hacking on nixops for hetzner deploy, and got this failure:
```
hetznerIron> sending hard reset to robot... done.
hetznerIron> waiting for rescue system...[down]................................................................[up]
hetznerIron> building Nix bootstrap installer... done. (/nix/store/a2kkc9p54k6ppi0f677w4f7pgv7lkykh-hetzner-nixops-installer/bin/hetzner-bootstrap)
hetznerIron> creating nixbld group in rescue system... done.
hetznerIron> checking if tmpfs in rescue system is large enough... yes: 32085 MB
hetznerIron> copying bootstrap files to rescue system... done.
hetznerIron> partitioning disks... done.
hetznerIron> bind-mounting special filesystems... /proc.../dev.../dev/shm.../sys...done.
hetznerIron> creating missing directories... done.
hetznerIron> bind-mounting files in /etc... resolv.conf...passwd...group...done.
unknown key type ed25519
error: unable to generate an SSH key

[nix-shell:~/nixops]$ 
```

Quickly figured out, that my `ssh-config` doesn't support `ed25519`.
This is fix in spirit of https://github.com/NixOS/nixops/blob/f019666dabeffa854bd0cd6150718365df69b0bc/release.nix#L116.