### PR TITLE
GCE: Use private ip if possible

### DIFF
--- a/nixops/backends/gce.py
+++ b/nixops/backends/gce.py
@@ -146,6 +146,13 @@ class GCEState(MachineState, ResourceState):
     def node(self):
        return self.connect().ex_get_node(self.machine_name, self.region)
 
+    def address_to(self, resource):
+        """Return the IP address to be used to access "resource" from this machine."""
+        if isinstance(resource, GCEState) and resource.network == self.network:
+            return resource.private_ipv4
+        else:
+            return MachineState.address_to(self, resource)
+
     def full_metadata(self, metadata):
         result = metadata.copy()
         result.update({


### PR DESCRIPTION
Use a private ip address if the other resource is a GCE machine, and is
in the same network.

Quoting the documention on this topic:

  "Any communication between instances in different networks, even
   within the same project, must be through external IP addresses."

https://cloud.google.com/compute/docs/networking#networks

This fixes #337

<hr>
Given that there were no integration tests (at least, I could not find any), I have tested this change manually by creating the a deployment from the following expression:

```nix
let 
  zones = ["b" "c" "d"];
  credentials = {
    project = "nixops-test";
    serviceAccount = "xxxxxxxxxxxx@xxxxxxxxxxxx.iam.gserviceaccount.com";
    accessKey = "gce.pem";
  };
  shared_gce =  credentials // {
    instanceType = "n1-standard-1";
    scheduling.automaticRestart = true;
    scheduling.onHostMaintenance = "MIGRATE";
  };
  makeMachine = zone: {
    name = "machine-${zone}";
    value = {
      deployment.targetEnv = "gce";
      deployment.gce = shared_gce // {
        region = "europe-west1-${zone}";
      };

      imports = [ ./examples/nix-homepage.nix];
    };
  };
  machines = map makeMachine zones;
in
  rec {

    other-network = {resources, ...}: {
      deployment.targetEnv = "gce";
      deployment.gce = shared_gce // {
        region = "europe-west1-d";
        network = resources.gceNetworks.othernet;
      };
      imports = [ ./examples/nix-homepage.nix];
    };

    resources.gceNetworks.othernet = credentials // {
      addressRange = "192.168.123.0/24";
      firewall = {
        allow-http = {
          allowed.tcp = [ 80 ];
        };
      };
    };

  } // builtins.listToAttrs machines
```

After deploying the machines, the `/etc/host` files are populated correctly:

```
[root@machine-b:~]# cat /etc/hosts 
127.0.0.1 localhost
::1 localhost

169.254.169.254 metadata.google.internal metadata

10.132.0.3 machine-b machine-b-unencrypted
127.0.0.1 machine-b-encrypted
10.132.0.2 machine-c machine-c-unencrypted
10.132.0.4 machine-d machine-d-unencrypted
146.148.119.242 other-network other-network-unencrypted

[root@machine-b:~]# curl -s machine-b | wc -l
267

[root@machine-b:~]# curl -s other-network | wc -l
267
```