### PR TITLE
libvirt: use /root/.Xauthority

### DIFF
--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -145,7 +145,7 @@ class LibvirtdState(MachineState):
             '      <target dev="hda"/>',
             '    </disk>',
             '\n'.join([iface(n) for n in defn.networks]),
-            '    <graphics type="sdl" display=":0.0"/>' if not defn.headless else "",
+            '    <graphics type="sdl" display=":0.0" xauth="/root/.Xauthority" />' if not defn.headless else "",
             '    <input type="keyboard" bus="usb"/>',
             '    <input type="mouse" bus="usb"/>',
             defn.extra_devices,


### PR DESCRIPTION
Currently libvirt backend doesn't work on NixOS because of X permissions.

I found a solution to get it working, but it would be NixOS specific.

It works together with `$ xauth extract /root/.Xauthority ":0.0"` before libvirtd startup.
