### PR TITLE
Adding a notification when the copying of closures ends

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -654,6 +654,7 @@ class Deployment(object):
         nixops.parallel.run_tasks(
             nr_workers=max_concurrent_copy,
             tasks=self.active.itervalues(), worker_fun=worker)
+        self.logger.log(ansi_success("{0}> Closures copied successfully".format(self.name), outfile=self.logger._log_file))
 
 
     def activate_configs(self, configs_path, include, exclude, allow_reboot,

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -654,7 +654,7 @@ class Deployment(object):
         nixops.parallel.run_tasks(
             nr_workers=max_concurrent_copy,
             tasks=self.active.itervalues(), worker_fun=worker)
-        self.logger.log(ansi_success("{0}> Closures copied successfully".format(self.name), outfile=self.logger._log_file))
+        self.logger.log(ansi_success("{0}> closures copied successfully".format(self.name), outfile=self.logger._log_file))
 
 
     def activate_configs(self, configs_path, include, exclude, allow_reboot,


### PR DESCRIPTION
This is useful when we have --copy-only flag set, and the deployment is running in a nohup for example.
We will be able to know that the closures were successfully copied just by looking to the logs.