### PR TITLE
nix/libvirtd-image.nix: use 'out' output for 'config.nix.package'.

### DIFF
--- a/nix/libvirtd-image.nix
+++ b/nix/libvirtd-image.nix
@@ -66,10 +66,10 @@ in pkgs.vmTools.runInLinuxVM (
 
       # Register the paths in the Nix database.
       printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \
-          chroot /mnt ${config.nix.package}/bin/nix-store --load-db
+          chroot /mnt ${config.nix.package.out}/bin/nix-store --load-db
 
       # Create the system profile to allow nixos-rebuild to work.
-      chroot /mnt ${config.nix.package}/bin/nix-env \
+      chroot /mnt ${config.nix.package.out}/bin/nix-env \
           -p /nix/var/nix/profiles/system --set ${config.system.build.toplevel}
 
       # `nixos-rebuild' requires an /etc/NIXOS.


### PR DESCRIPTION
This fixes issue #448, likely introduced by nixos/nixpkgs@21a2f2ba3bc8962845f0b45cacac4e47557ebf13