### PR TITLE
Delete orphaned keys

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -188,6 +188,13 @@ class MachineState(nixops.resources.ResourceState):
         self.warn("machine ‘{0}’ doesn't have a rescue"
                   " system.".format(self.name))
 
+    def delete_old_keys(self):
+        key_names = self.get_keys().keys()
+        self.run_command("find /run/keys -type f "
+                         + "-not -name done "
+                         + "".join(["-not -name '{0}' ".format(k) for k in key_names])
+                         + "-printf 'deleting %p\n' -delete"
+                        )
     def send_keys(self):
         if self.state == self.RESCUE:
             # Don't send keys when in RESCUE state, because we're most likely
@@ -213,6 +220,7 @@ class MachineState(nixops.resources.ResourceState):
                 chmod.format(opts['permissions'])
             ]))
             os.remove(tmp)
+        self.delete_old_keys()
         self.run_command("touch /run/keys/done")
 
     def get_keys(self):


### PR DESCRIPTION
Other option is 

```nix
{
# ...
system.activationScripts.cleanKeys = ''
      ${pkgs.findutils}/bin/find ${runkeys} -type f \
        -not -name 'done' \
        ${concatMapStringsSep " " (k: "-not -name '${k}'") (attrNames keys)} \
        -printf 'deleting %p\n' -delete
    '';
# ...
}
```