### PR TITLE
Add option to use private IPv4 for route53

### DIFF
--- a/nix/route53.nix
+++ b/nix/route53.nix
@@ -60,6 +60,16 @@ with lib;
       '';
     };
 
+    deployment.route53.usePrivateIp = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Whether to use the private or public IPv4 address when creating an A record.
+        Note: if this option is set to true, setting the option usePublicDNSName wont have any effect.
+      '';
+    };
+
+
   };
 
 


### PR DESCRIPTION
This option makes it possible to set the private IPv4 address of the instance in the DNS record of route53.

Due to the policies of my company we are not allowed to use public IPs for internal infrastructure servers. That’s why we need to associate private IPs with a route53 hostname.

I’m not sure about the option name. From a user perspective I would probably prefer a single option where you can specify whether to use public ip, private ip or public DNS name but that would be a breaking change, so I decided to introduce a second separate option.
