### PR TITLE
Choose system in dev-shell dynamically

### DIFF
--- a/dev-shell
+++ b/dev-shell
@@ -1,2 +1,3 @@
 #! /bin/sh -e
-exec nix-shell release.nix -A build.x86_64-linux --exclude tarball "$@"
+SYSTEM=$(nix-instantiate --eval --expr "builtins.currentSystem")
+exec nix-shell release.nix -A build.$SYSTEM --exclude tarball "$@"


### PR DESCRIPTION
Determine the current system from `builtins.currentSystem` via `nix-instantiate` so that dev-shell can also be used from OSX.