### PR TITLE
Add support for additional EBS volume types

### DIFF
--- a/nix/common-ebs-options.nix
+++ b/nix/common-ebs-options.nix
@@ -33,12 +33,14 @@ with lib;
 
     volumeType = mkOption {
       default = if config.iops == 0 then "standard" else "io1";
-      type = types.enum [ "standard" "io1" "gp2" ];
+      type = types.enum [ "standard" "io1" "gp2" "st1" "sc1" ];
       description = ''
         The volume type for the EBS volume, which must be one of
         <literal>"standard"</literal> (a magnetic volume),
         <literal>"io1"</literal> (a provisioned IOPS SSD volume) or
         <literal>"gp2"</literal> (a general purpose SSD volume).
+        <literal>"st1"</literal> (a throughput optimized HDD volume).
+        <literal>"sc1"</literal> (a cold HDD volume).
       '';
     };
 


### PR DESCRIPTION
This adds the missing EBS volume types `st1` and `sc1`. See also [EBS product details](https://aws.amazon.com/ebs/details/).