### PR TITLE
Datadog integration

### DIFF
--- a/doc/manual/manual.xml
+++ b/doc/manual/manual.xml
@@ -411,6 +411,34 @@
 
     </section>
 
+    <section>
+      <title>Datadog Resources</title>
+      <section>
+        <title>Datadog Monitor Resource</title>
+        <para>A Datadog monitor is defined by setting
+        <literal>resources.datadogMonitors.<replaceable>name</replaceable></literal>
+        to an attribute set containing values for the following
+        options.</para>
+        <xi:include href="datadog-monitor-options.xml" />
+      </section>
+      <section>
+        <title>Datadog Timeboard Resource</title>
+        <para>A Datadog timeboard is defined by setting
+        <literal>resources.dataogTimeboards.<replaceable>name</replaceable></literal>
+        to an attribute set containing values for the following
+        options.</para>
+        <xi:include href="datadog-timeboard-options.xml" />
+      </section>
+      <section>
+        <title>Datadog Screenboard Resource</title>
+        <para>A Datadog screenboard is defined by setting
+        <literal>resources.dataogScreenboards.<replaceable>name</replaceable></literal>
+        to an attribute set containing values for the following
+        options.</para>
+        <xi:include href="datadog-screenboard-options.xml" />
+      </section>
+    </section>
+
   </appendix>
 
   <xi:include href="hacking.xml" />

--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -1449,6 +1449,88 @@ and libvirtd specification <literal>example-libvirtd.nix</literal>:
 
 </section>
 
+<section><title>Deploying Datadog resources</title>
+<para>NixOps allows deploying Datadog resources (monitors, timeboards, screenboards)
+using a declarative description. Before deploying Datadog resources, you need to
+generate an api_key and app_key from
+<link xlink:href="https://app.datadoghq.com/account/settings#api">here</link>.
+The following is a minimal specification of a datadog resource deployment which takes a host as an argument
+</para>
+<warning>
+<para>
+  Note that if you don't specify the api_key/app_key options, they will be defaulted to the environment variables DATADOG_API_KEY and DATADOG_APP_KEY.
+</para>
+</warning>
+<example xml:id="datadog-timeboard.nix">
+  <title><filename>datadog-timeboard.nix</filename>: Datadog timeboard specification</title>
+<programlisting>
+  { host
+   , ...
+  }:
+  let
+    app_key = "...";
+    api_key = "...";
+  in
+  {
+    resources.datadogTimeboards.host-timeboard = { config, ...}:
+    {
+      appKey = app_key;
+      apiKey = api_key;
+      title = "Timeboard created using NixOps";
+      description = "Timeboard created using NixOps";
+      templateVariables = [
+        {
+          name = "host";
+          prefix = "host";
+          default = "${host}";
+        }
+      ];
+      graphs = [
+        {
+          title = "system.disk.free";
+          definition = builtins.toJSON {
+            requests= [
+              {
+                type= "line";
+                conditional_formats= [];
+                aggregator= "avg";
+                q= "avg:system.disk.free{device:/dev/dm-0,host:${host}}";
+              }
+            ];
+            viz= "timeseries";
+          };
+        }
+      ];
+    };
+  }
+</programlisting>
+</example>
+<para>
+  In this example, the graph definition is a JSON string, which can be customized by following the JSON graphing
+   <link xlink:href="http://docs.datadoghq.com/graphingjson/">documentation</link>.
+  This is similar for the monitor options and screenboard widgets which are defined using a JSON string as well.
+</para>
+<para>
+  Once deployed, the deployment specification would be:
+  <programlisting>
+$ nixops deploy -d timeboards
+host-timeboard> creating datadog timeboard 'Timeboard created using NixOps...'
+building all machine configurations...
+timeboards> closures copied successfully
+timeboards> deployment finished successfully
+
+$ nixops info -d timeboards
+...
+Nix arguments: host = "myhost"
+
++----------------+-----------------+-------------------+--------------------------------------------------------------------------------+------------+
+| Name           |      Status     | Type              | Resource Id                                                                    | IP address |
++----------------+-----------------+-------------------+--------------------------------------------------------------------------------+------------+
+| host-timeboard | Up / Up-to-date | datadog-timeboard | Timeboard created using NixOps [ /dash/203062/timeboard-created-using-nixops ] |            |
++----------------+-----------------+-------------------+--------------------------------------------------------------------------------+------------+
+  </programlisting>
+</para>
+</section>
 
 <section><title>Accessing machines</title>
 

--- a/examples/datadog-monitor.nix
+++ b/examples/datadog-monitor.nix
@@ -1,0 +1,17 @@
+{
+  resources.datadogMonitors.bytes_rcvd_monitor = { config, ...}:
+    {
+  		app_key = "...";
+		  api_key = "...";
+		  type = "metric alert";
+  		message = "notify the user @user@example.com";
+		  renotify_interval = 20;
+		  include_tags = true;
+		  no_data_timeframe = 10;
+		  notify_audit= false;
+  		query = "avg(last_5m):sum:system.net.bytes_rcvd{host:${config.deployment.name}.machine} > 100";
+	    thresholds.ok = 10;
+  		thresholds.warning = 50;
+  		thresholds.critical = 100;
+    };
+}

--- a/examples/datadog-monitor.nix
+++ b/examples/datadog-monitor.nix
@@ -1,17 +1,17 @@
 {
   resources.datadogMonitors.bytes_rcvd_monitor = { config, ...}:
     {
-  		app_key = "...";
-		  api_key = "...";
-		  type = "metric alert";
-  		message = "notify the user @user@example.com";
-		  renotify_interval = 20;
-		  include_tags = true;
-		  no_data_timeframe = 10;
-		  notify_audit= false;
-  		query = "avg(last_5m):sum:system.net.bytes_rcvd{host:${config.deployment.name}.machine} > 100";
-	    thresholds.ok = 10;
-  		thresholds.warning = 50;
-  		thresholds.critical = 100;
+      app_key = "...";
+      api_key = "...";
+      type = "metric alert";
+      message = "notify the user @user@example.com";
+      renotify_interval = 20;
+      include_tags = true;
+      no_data_timeframe = 10;
+      notify_audit= false;
+      query = "avg(last_5m):sum:system.net.bytes_rcvd{host:${config.deployment.name}.machine} > 100";
+      thresholds.ok = 10;
+      thresholds.warning = 50;
+      thresholds.critical = 100;
     };
 }

--- a/examples/datadog-monitor.nix
+++ b/examples/datadog-monitor.nix
@@ -1,14 +1,14 @@
 {
   resources.datadogMonitors.bytes_rcvd_monitor = { config, ...}:
     {
-      app_key = "...";
-      api_key = "...";
+      appKey = "...";
+      apiKey = "...";
       type = "metric alert";
       message = "notify the user @user@example.com";
-      renotify_interval = 20;
-      include_tags = true;
-      no_data_timeframe = 10;
-      notify_audit= false;
+      renotifyInterval = 20;
+      includeTags = true;
+      noDataTimeframe = 10;
+      notifyAudit= false;
       query = "avg(last_5m):sum:system.net.bytes_rcvd{host:${config.deployment.name}.machine} > 100";
       thresholds.ok = 10;
       thresholds.warning = 50;

--- a/examples/datadog-monitor.nix
+++ b/examples/datadog-monitor.nix
@@ -5,13 +5,15 @@
       apiKey = "...";
       type = "metric alert";
       message = "notify the user @user@example.com";
-      renotifyInterval = 20;
-      includeTags = true;
-      noDataTimeframe = 10;
-      notifyAudit= false;
       query = "avg(last_5m):sum:system.net.bytes_rcvd{host:${config.deployment.name}.machine} > 100";
-      thresholds.ok = 10;
-      thresholds.warning = 50;
-      thresholds.critical = 100;
+      monitorOptions = builtins.toJSON {
+        renotify_interval = 20;
+        include_tags = true;
+        no_data_timeframe = 10;
+        notify_audit= false;
+        thresholds.ok = 10;
+        thresholds.warning = 50;
+        thresholds.critical = 100;
+      };
     };
 }

--- a/examples/datadog-screenboard.nix
+++ b/examples/datadog-screenboard.nix
@@ -1,0 +1,46 @@
+let
+  app_key = "ec0...";
+  api_key = "1b4...";
+in
+{
+  resources.datadogScreenboards.screenboard-example = { config, ...}:
+  {
+    appKey = app_key;
+    apiKey = api_key;
+    boardTitle = "Screenboard created using nixops";
+    description = "Screenboard created using NixOps";
+    templateVariables = [
+      {
+        name = "host";
+        prefix = "host";
+        default = "*";
+      }
+    ];
+    widgets = [
+      (builtins.toJSON {
+        legend= false;
+        type= "timeseries";
+        legend_size= "0";
+        x= 0;
+        y= 0;
+        timeframe= "1h";
+        title_size= 16;
+        title= true;
+        title_align= "left";
+        title_text= "CPU iowait";
+        height= 13;
+        tile_def= {
+          requests= [
+            {
+              type= "line";
+              conditional_formats= [];
+              q= "sum:system.cpu.iowait{$host}";
+            }
+          ];
+          viz= "timeseries";
+        };
+        width= 54;
+      })
+    ];
+  };
+}

--- a/examples/datadog-timeboard.nix
+++ b/examples/datadog-timeboard.nix
@@ -1,0 +1,42 @@
+let
+  app_key = "ec0d...";
+  api_key = "1b4...";
+in
+{
+  resources.datadogTimeboards.test-timeboard = { config, ...}:
+  {
+    appKey = app_key;
+    apiKey = api_key;
+    title = "Timeboard created using NixOps";
+    description = "Timeboard created using NixOps";
+    templateVariables = [
+      {
+        name = "host";
+        prefix = "host";
+        default = "*";
+      }
+    ];
+    graphs = [
+      {
+        title = "system.disk.free, system.disk.used";
+        definition = builtins.toJSON {
+          requests= [
+            {
+              type= "line";
+              conditional_formats= [];
+              aggregator= "avg";
+              q= "avg:system.disk.free{device:/dev/dm-0,host:i-494dad79}";
+            }
+            {
+              type= "line";
+              conditional_formats= [];
+              aggregator= "avg";
+              q= "avg:system.disk.used{device:/dev/dm-0,host:i-494dad79}";
+            }
+          ];
+          viz= "timeseries";
+        };
+      }
+    ];
+  };
+}

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -104,8 +104,5 @@ with lib;
             };
           };
         };
-  config = {
-    renotify_interval = mkIf (builtins.isString config.escalationMessage) (throw "renotifyInterval can't be used when the escalationMessage is set.");
-    _type = "datadog-monitor";
-  };
+  config._type = "datadog-monitor";
 }

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -33,8 +33,60 @@ with lib;
           description = "Message to send for a set of users.";
         };
         escalation_message = mkOption {
-          type = types.str;
-          description = "Re-notification in case the monitor wasn't marked as resolved.";
+          default = null;
+          type = types.nullOr (types.str);
+          description = "a message to include with a re-notification.
+          Supports the '@username' notification we allow elsewhere.
+          Not applicable if renotify_interval is set.";
+        };
+        silenced = mkOption {
+          default = null;
+          type = types.nullOr (types.str);
+          description = "dictionary of scopes to timestamps or None.
+           Each scope will be muted until the given POSIX timestamp or forever if the value is None.";
+        };
+        notify_no_data = mkOption {
+          default = false;
+          type = types.bool;
+          description = "a boolean indicating whether this monitor will notify when data stops reporting.";
+        };
+        no_data_timeframe = mkOption {
+          default = null;
+          type = types.nullOr (types.int);
+          description = "the number of minutes before a monitor will notify when data stops reporting.
+           Must be at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.";
+        };
+        timeout_h = mkOption {
+          default = null;
+          type = types.nullOr (types.int);
+          description = "the number of hours of the monitor not reporting data before it will automatically resolve from a triggered state.";
+        };
+        renotify_interval = mkOption {
+          default = null;
+          type = types.nullOr (types.int);
+          description = "the number of minutes after the last notification before a monitor will re-notify on the current status.
+          It will only re-notify if it's not resolved.";
+        };
+        require_full_window = mkOption {
+          default = null;
+          type = types.nullOr (types.bool);
+          description = "a boolean indicating whether this monitor needs a full window of data before it's evaluated.
+          We highly recommend you set this to False for sparse metrics, otherwise some evaluations will be skipped.";
+        };
+        notify_audit = mkOption {
+          default = null;
+          type = types.nullOr (types.bool);
+          description = "a boolean indicating whether tagged users will be notified on changes to this monitor.";
+        };
+        locked = mkOption {
+          default = null;
+          type = types.nullOr (types.bool);
+          description = "a boolean indicating whether changes to to this monitor should be restricted to the creator or admins.";
+        };
+        include_tags = mkOption {
+          default = null;
+          type = types.nullOr (types.bool);
+          description = "a boolean indicating whether notifications from this monitor will automatically insert its triggering tags into the title.";
         };
         thresholds =
         {
@@ -55,6 +107,8 @@ with lib;
             };
           };
         };
-
-  config._type = "datadog-monitor";
+  config = {
+    renotify_interval = mkIf (builtins.isString config.escalation_message) (throw "renotify_interval can't be used with escalation_message set.");
+    _type = "datadog-monitor";
+  };
 }

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -32,7 +32,7 @@ with lib;
           type = types.str;
           description = "Message to send for a set of users.";
         };
-        options = mkOption {
+        monitorOptions = mkOption {
           type = types.str;
           description = "A dictionary of options for the monitor.";
         };

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -1,0 +1,57 @@
+{ config, lib, uuid, name, ... }:
+
+with lib;
+
+{
+  options = {
+
+        api_key = mkOption {
+            default = "";
+            type = types.str;
+            description = "The Datadog API Key.";
+        };
+        app_key = mkOption {
+            default = "";
+            type = types.str;
+            description = "The Datadog App Key.";
+        };
+         name = mkOption {
+          default = "datadog-monitor-${uuid}-${name}";
+          type = types.str;
+          description = "Name of the datadog resource.";
+        };
+        type = mkOption {
+          type = types.str;
+          description = "Type of the datadog resource.";
+        };
+        query = mkOption {
+          type = types.str;
+          description = "The query that defines the monitor";
+        };
+        message = mkOption {
+          type = types.str;
+          description = "Message to send for a set of users.";
+        };
+        escalation_message = mkOption {
+          type = types.str;
+          description = "Re-notification in case the monitor wasn't marked as resolved.";
+        };
+        thresholds =
+        {
+            ok = mkOption {
+              type = types.int;
+              description = "";
+            };
+            warning = mkOption {
+              type = types.int;
+              description = "";
+            };
+            critical = mkOption {
+              type = types.int;
+              description = "";
+            };
+          };
+        };
+
+  config._type = "datadog-monitor";
+}

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -13,7 +13,7 @@ with lib;
         appKey = mkOption {
             default = "";
             type = types.str;
-            description = "The Datadog App Key.";
+            description = "The Datadog APP Key.";
         };
         name = mkOption {
           default = "datadog-monitor-${uuid}-${name}";
@@ -22,11 +22,15 @@ with lib;
         };
         type = mkOption {
           type = types.str;
-          description = "Type of the datadog resource.";
+          description = "Type of the datadog resource chosen from: \"metric alert\" \"service check\" \"event alert\".";
         };
         query = mkOption {
           type = types.str;
-          description = "The query that defines the monitor";
+          description = "The query that defines the monitor.
+          <para>
+          See the datadog API documentation for more details about query creation
+          <link xlink:href='http://docs.datadoghq.com/api/#monitors'/>
+          </para>";
         };
         message = mkOption {
           type = types.str;
@@ -34,13 +38,28 @@ with lib;
         };
         monitorOptions = mkOption {
           type = types.str;
-          description = "A dictionary of options for the monitor.";
+          description = "A dictionary of options for the monitor.
+          <para>
+          See the API documentation for more details about the available options
+          <link xlink:href='http://docs.datadoghq.com/api/#monitors'/>
+          </para>";
         };
         silenced = mkOption {
           default = null;
           type = types.nullOr (types.str);
           description = "dictionary of scopes to timestamps or None.
-           Each scope will be muted until the given POSIX timestamp or forever if the value is None.";
+           Each scope will be muted until the given POSIX timestamp or forever if the value is None.
+           <para>
+           Examples:
+           <para>
+           To mute the alert completely:
+           {'*': None}
+           </para>
+           <para>
+           To mute role:db for a short time:
+           {'role:db': 1412798116}
+           </para>
+           </para>";
         };
   };
   config._type = "datadog-monitor";

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -27,11 +27,11 @@ with lib;
         query = mkOption {
           type = types.str;
           description = ''
-          The query that defines the monitor.
-          <para>
-          See the datadog API documentation for more details about query creation
-          <link xlink:href='http://docs.datadoghq.com/api/#monitors'/>
-          </para>
+            The query that defines the monitor.
+            <para>
+            See the datadog API documentation for more details about query creation
+            <link xlink:href='http://docs.datadoghq.com/api/#monitors'/>
+            </para>
           '';
         };
         message = mkOption {
@@ -41,31 +41,31 @@ with lib;
         monitorOptions = mkOption {
           type = types.str;
           description = ''
-          A dictionary of options for the monitor.
-          <para>
-          See the API documentation for more details about the available options
-          <link xlink:href='http://docs.datadoghq.com/api/#monitors'/>
-          </para>
+            A dictionary of options for the monitor.
+            <para>
+            See the API documentation for more details about the available options
+            <link xlink:href='http://docs.datadoghq.com/api/#monitors'/>
+            </para>
           '';
         };
         silenced = mkOption {
           default = null;
           type = types.nullOr (types.str);
           description = ''
-          dictionary of scopes to timestamps or None.
-           Each scope will be muted until the given POSIX timestamp or forever if the value is None.
-           <para>
-           Examples:
-           <para>
-           To mute the alert completely:
-           {'*': None}
-           </para>
-           <para>
-           To mute role:db for a short time:
-           {'role:db': 1412798116}
-           </para>
-           </para>
-           '';
+            dictionary of scopes to timestamps or None.
+            Each scope will be muted until the given POSIX timestamp or forever if the value is None.
+            <para>
+            Examples:
+            <para>
+            To mute the alert completely:
+            {'*': None}
+            </para>
+            <para>
+            To mute role:db for a short time:
+            {'role:db': 1412798116}
+            </para>
+            </para>
+          '';
         };
   };
   config._type = "datadog-monitor";

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -93,17 +93,14 @@ with lib;
             ok = mkOption {
               default = null;
               type = types.nullOr (types.int);
-              description = "";
             };
             warning = mkOption {
               default = null;
               type = types.nullOr (types.int);
-              description = "";
             };
             critical = mkOption {
               default = null;
               type = types.nullOr (types.int);
-              description = "";
             };
           };
         };

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -16,7 +16,7 @@ with lib;
             description = "The Datadog App Key.";
         };
          name = mkOption {
-          default = "datadog-monitor-${uuid}-${name}";
+          default = "datadog-monitor-${name}";
           type = types.str;
           description = "Name of the datadog resource.";
         };

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -105,7 +105,7 @@ with lib;
           };
         };
   config = {
-    renotify_interval = mkIf (builtins.isString config.escalation_message) (throw "renotify_interval can't be used with escalation_message set.");
+    renotify_interval = mkIf (builtins.isString config.escalation_message) (throw "renotify_interval can't be used when the escalation_message is set.");
     _type = "datadog-monitor";
   };
 }

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -5,17 +5,17 @@ with lib;
 {
   options = {
 
-        api_key = mkOption {
+        apiKey = mkOption {
             default = "";
             type = types.str;
             description = "The Datadog API Key.";
         };
-        app_key = mkOption {
+        appKey = mkOption {
             default = "";
             type = types.str;
             description = "The Datadog App Key.";
         };
-         name = mkOption {
+        name = mkOption {
           default = "datadog-monitor-${uuid}-${name}";
           type = types.str;
           description = "Name of the datadog resource.";
@@ -32,7 +32,7 @@ with lib;
           type = types.str;
           description = "Message to send for a set of users.";
         };
-        escalation_message = mkOption {
+        escalationMessage = mkOption {
           default = null;
           type = types.nullOr (types.str);
           description = "a message to include with a re-notification.
@@ -45,35 +45,35 @@ with lib;
           description = "dictionary of scopes to timestamps or None.
            Each scope will be muted until the given POSIX timestamp or forever if the value is None.";
         };
-        notify_no_data = mkOption {
+        notifyNoData = mkOption {
           default = false;
           type = types.bool;
           description = "a boolean indicating whether this monitor will notify when data stops reporting.";
         };
-        no_data_timeframe = mkOption {
+        noDataTimeframe = mkOption {
           default = null;
           type = types.nullOr (types.int);
           description = "the number of minutes before a monitor will notify when data stops reporting.
            Must be at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.";
         };
-        timeout_h = mkOption {
+        timeoutH = mkOption {
           default = null;
           type = types.nullOr (types.int);
           description = "the number of hours of the monitor not reporting data before it will automatically resolve from a triggered state.";
         };
-        renotify_interval = mkOption {
+        renotifyInterval = mkOption {
           default = null;
           type = types.nullOr (types.int);
           description = "the number of minutes after the last notification before a monitor will re-notify on the current status.
           It will only re-notify if it's not resolved.";
         };
-        require_full_window = mkOption {
+        requireFullWindow = mkOption {
           default = null;
           type = types.nullOr (types.bool);
           description = "a boolean indicating whether this monitor needs a full window of data before it's evaluated.
           We highly recommend you set this to False for sparse metrics, otherwise some evaluations will be skipped.";
         };
-        notify_audit = mkOption {
+        notifyAudit = mkOption {
           default = null;
           type = types.nullOr (types.bool);
           description = "a boolean indicating whether tagged users will be notified on changes to this monitor.";
@@ -83,7 +83,7 @@ with lib;
           type = types.nullOr (types.bool);
           description = "a boolean indicating whether changes to to this monitor should be restricted to the creator or admins.";
         };
-        include_tags = mkOption {
+        includeTags = mkOption {
           default = null;
           type = types.nullOr (types.bool);
           description = "a boolean indicating whether notifications from this monitor will automatically insert its triggering tags into the title.";
@@ -105,7 +105,7 @@ with lib;
           };
         };
   config = {
-    renotify_interval = mkIf (builtins.isString config.escalation_message) (throw "renotify_interval can't be used when the escalation_message is set.");
+    renotify_interval = mkIf (builtins.isString config.escalationMessage) (throw "renotifyInterval can't be used when the escalationMessage is set.");
     _type = "datadog-monitor";
   };
 }

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -26,11 +26,13 @@ with lib;
         };
         query = mkOption {
           type = types.str;
-          description = "The query that defines the monitor.
+          description = ''
+          The query that defines the monitor.
           <para>
           See the datadog API documentation for more details about query creation
           <link xlink:href='http://docs.datadoghq.com/api/#monitors'/>
-          </para>";
+          </para>
+          '';
         };
         message = mkOption {
           type = types.str;
@@ -38,16 +40,19 @@ with lib;
         };
         monitorOptions = mkOption {
           type = types.str;
-          description = "A dictionary of options for the monitor.
+          description = ''
+          A dictionary of options for the monitor.
           <para>
           See the API documentation for more details about the available options
           <link xlink:href='http://docs.datadoghq.com/api/#monitors'/>
-          </para>";
+          </para>
+          '';
         };
         silenced = mkOption {
           default = null;
           type = types.nullOr (types.str);
-          description = "dictionary of scopes to timestamps or None.
+          description = ''
+          dictionary of scopes to timestamps or None.
            Each scope will be muted until the given POSIX timestamp or forever if the value is None.
            <para>
            Examples:
@@ -59,7 +64,8 @@ with lib;
            To mute role:db for a short time:
            {'role:db': 1412798116}
            </para>
-           </para>";
+           </para>
+           '';
         };
   };
   config._type = "datadog-monitor";

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -16,7 +16,7 @@ with lib;
             description = "The Datadog App Key.";
         };
          name = mkOption {
-          default = "datadog-monitor-${name}";
+          default = "datadog-monitor-${uuid}-${name}";
           type = types.str;
           description = "Name of the datadog resource.";
         };

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -39,15 +39,18 @@ with lib;
         thresholds =
         {
             ok = mkOption {
-              type = types.int;
+              default = null;
+              type = types.nullOr (types.int);
               description = "";
             };
             warning = mkOption {
-              type = types.int;
+              default = null;
+              type = types.nullOr (types.int);
               description = "";
             };
             critical = mkOption {
-              type = types.int;
+              default = null;
+              type = types.nullOr (types.int);
               description = "";
             };
           };

--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -32,12 +32,9 @@ with lib;
           type = types.str;
           description = "Message to send for a set of users.";
         };
-        escalationMessage = mkOption {
-          default = null;
-          type = types.nullOr (types.str);
-          description = "a message to include with a re-notification.
-          Supports the '@username' notification we allow elsewhere.
-          Not applicable if renotify_interval is set.";
+        options = mkOption {
+          type = types.str;
+          description = "A dictionary of options for the monitor.";
         };
         silenced = mkOption {
           default = null;
@@ -45,64 +42,6 @@ with lib;
           description = "dictionary of scopes to timestamps or None.
            Each scope will be muted until the given POSIX timestamp or forever if the value is None.";
         };
-        notifyNoData = mkOption {
-          default = false;
-          type = types.bool;
-          description = "a boolean indicating whether this monitor will notify when data stops reporting.";
-        };
-        noDataTimeframe = mkOption {
-          default = null;
-          type = types.nullOr (types.int);
-          description = "the number of minutes before a monitor will notify when data stops reporting.
-           Must be at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.";
-        };
-        timeoutH = mkOption {
-          default = null;
-          type = types.nullOr (types.int);
-          description = "the number of hours of the monitor not reporting data before it will automatically resolve from a triggered state.";
-        };
-        renotifyInterval = mkOption {
-          default = null;
-          type = types.nullOr (types.int);
-          description = "the number of minutes after the last notification before a monitor will re-notify on the current status.
-          It will only re-notify if it's not resolved.";
-        };
-        requireFullWindow = mkOption {
-          default = null;
-          type = types.nullOr (types.bool);
-          description = "a boolean indicating whether this monitor needs a full window of data before it's evaluated.
-          We highly recommend you set this to False for sparse metrics, otherwise some evaluations will be skipped.";
-        };
-        notifyAudit = mkOption {
-          default = null;
-          type = types.nullOr (types.bool);
-          description = "a boolean indicating whether tagged users will be notified on changes to this monitor.";
-        };
-        locked = mkOption {
-          default = null;
-          type = types.nullOr (types.bool);
-          description = "a boolean indicating whether changes to to this monitor should be restricted to the creator or admins.";
-        };
-        includeTags = mkOption {
-          default = null;
-          type = types.nullOr (types.bool);
-          description = "a boolean indicating whether notifications from this monitor will automatically insert its triggering tags into the title.";
-        };
-        thresholds =
-        {
-            ok = mkOption {
-              default = null;
-              type = types.nullOr (types.int);
-            };
-            warning = mkOption {
-              default = null;
-              type = types.nullOr (types.int);
-            };
-            critical = mkOption {
-              default = null;
-              type = types.nullOr (types.int);
-            };
-          };
-        };
+  };
   config._type = "datadog-monitor";
 }

--- a/nix/datadog-screenboard.nix
+++ b/nix/datadog-screenboard.nix
@@ -15,27 +15,19 @@ with lib;
             type = types.str;
             description = "The Datadog App Key.";
         };
-        title = mkOption {
+        boardTitle = mkOption {
+          default = "";
           type = types.str;
-          description = "The title of the timeboard.";
+          description = "The name of the dashboard.";
         };
         description = mkOption {
+          default = "";
           type = types.str;
-          description = "A description of the timeboard's content.";
+          description = "A description of the dashboard's content.";
         };
-        graphs = mkOption {
-          type = types.listOf types.optionSet;
-          description = "A list of graph definitions";
-          options = {
-            title = mkOption {
-              description = "The name of the graph.";
-              type = types.str;
-            };
-            definition = mkOption {
-              description = "The graph definition.";
-              type = types.str;
-            };
-          };
+        widgets = mkOption {
+          type = types.listOf types.str;
+          description = "A list of widget definitions.";
         };
         templateVariables = mkOption {
           default = [];
@@ -58,6 +50,16 @@ with lib;
             };
           };
         };
+        width = mkOption {
+          default = null;
+          type = types.nullOr (types.int);
+          description = "Screenboard width in pixels.";
+        };
+        height = mkOption {
+          default = null;
+          type = types.nullOr (types.int);
+          description = "Height in pixels.";
+        };
         readOnly = mkOption {
           default = false;
           type = types.bool;
@@ -65,5 +67,5 @@ with lib;
         };
       };
 
-  config._type = "datadog-timeboard";
+  config._type = "datadog-screenboard";
 }

--- a/nix/datadog-screenboard.nix
+++ b/nix/datadog-screenboard.nix
@@ -13,7 +13,7 @@ with lib;
         appKey = mkOption {
             default = "";
             type = types.str;
-            description = "The Datadog App Key.";
+            description = "The Datadog APP Key.";
         };
         boardTitle = mkOption {
           default = "";
@@ -27,7 +27,11 @@ with lib;
         };
         widgets = mkOption {
           type = types.listOf types.str;
-          description = "A list of widget definitions.";
+          description = "A list of widget definitions.
+          <para>
+          See the datadog screenboard API for more details on creating screenboard widgets
+          <link xlink:href='http://docs.datadoghq.com/api/screenboards/'/>
+          </para>";
         };
         templateVariables = mkOption {
           default = [];

--- a/nix/datadog-screenboard.nix
+++ b/nix/datadog-screenboard.nix
@@ -27,11 +27,13 @@ with lib;
         };
         widgets = mkOption {
           type = types.listOf types.str;
-          description = "A list of widget definitions.
+          description = ''
+          A list of widget definitions.
           <para>
           See the datadog screenboard API for more details on creating screenboard widgets
           <link xlink:href='http://docs.datadoghq.com/api/screenboards/'/>
-          </para>";
+          </para>
+          '';
         };
         templateVariables = mkOption {
           default = [];

--- a/nix/datadog-screenboard.nix
+++ b/nix/datadog-screenboard.nix
@@ -28,11 +28,11 @@ with lib;
         widgets = mkOption {
           type = types.listOf types.str;
           description = ''
-          A list of widget definitions.
-          <para>
-          See the datadog screenboard API for more details on creating screenboard widgets
-          <link xlink:href='http://docs.datadoghq.com/api/screenboards/'/>
-          </para>
+            A list of widget definitions.
+            <para>
+            See the datadog screenboard API for more details on creating screenboard widgets
+            <link xlink:href='http://docs.datadoghq.com/api/screenboards/'/>
+            </para>
           '';
         };
         templateVariables = mkOption {

--- a/nix/datadog-timeboard.nix
+++ b/nix/datadog-timeboard.nix
@@ -33,11 +33,11 @@ with lib;
             };
             definition = mkOption {
               description = ''
-              The graph definition.
-              <para>
-              See datadog JSON graphing documentation for more details
-              <link xlink:href='http://docs.datadoghq.com/graphingjson/'/>
-              </para>
+                The graph definition.
+                <para>
+                See datadog JSON graphing documentation for more details
+                <link xlink:href='http://docs.datadoghq.com/graphingjson/'/>
+                </para>
               '';
               type = types.str;
             };

--- a/nix/datadog-timeboard.nix
+++ b/nix/datadog-timeboard.nix
@@ -1,0 +1,62 @@
+{ config, lib, uuid, name, ... }:
+
+with lib;
+
+{
+  options = {
+
+        apiKey = mkOption {
+            default = "";
+            type = types.str;
+            description = "The Datadog API Key.";
+        };
+        appKey = mkOption {
+            default = "";
+            type = types.str;
+            description = "The Datadog App Key.";
+        };
+        title = mkOption {
+          type = types.str;
+          description = "The title of the timeboard.";
+        };
+        description = mkOption {
+          type = types.str;
+          description = "A description of the timeboard's content.";
+        };
+        graphs = mkOption {
+          default = {};
+          type = types.listOf types.optionSet;
+          description = "A list of graph definitions";
+          options = {
+            title = mkOption {
+              description = "The name of the graph.";
+              type = types.str;
+            };
+            definition = mkOption {
+                description = "The graph definition.";
+                type = type.str;
+            };
+          };
+        };
+        templateVariables = mkOption {
+          default = {};
+          type = types.listOf types.optionSet;
+          description = "A list of template variables for using Dashboard templating.";
+          options = {
+            name = mkOption {
+              type = types.str;
+              description = "The name of the variable.";
+            };
+            prefix = mkOption {
+              type = types.str;
+              description = "The tag prefix associated with the variable. Only tags with this prefix will appear in the variable dropdown.";
+            };
+            default = mkOption {
+              type = types.str;
+              description = "The default value for the template variable on dashboard load";
+            };
+          };
+        };
+
+  config._type = "datadog-timeboard";
+}

--- a/nix/datadog-timeboard.nix
+++ b/nix/datadog-timeboard.nix
@@ -32,11 +32,13 @@ with lib;
               type = types.str;
             };
             definition = mkOption {
-              description = "The graph definition.
+              description = ''
+              The graph definition.
               <para>
               See datadog JSON graphing documentation for more details
               <link xlink:href='http://docs.datadoghq.com/graphingjson/'/>
-              </para>";
+              </para>
+              '';
               type = types.str;
             };
           };

--- a/nix/datadog-timeboard.nix
+++ b/nix/datadog-timeboard.nix
@@ -32,7 +32,11 @@ with lib;
               type = types.str;
             };
             definition = mkOption {
-              description = "The graph definition.";
+              description = "The graph definition.
+              <para>
+              See datadog JSON graphing documentation for more details
+              <link xlink:href='http://docs.datadoghq.com/graphingjson/'/>
+              </para>";
               type = types.str;
             };
           };

--- a/nix/datadog-timeboard.nix
+++ b/nix/datadog-timeboard.nix
@@ -32,13 +32,13 @@ with lib;
               type = types.str;
             };
             definition = mkOption {
-                description = "The graph definition.";
-                type = type.str;
+              description = "The graph definition.";
+              type = types.str;
             };
           };
         };
         templateVariables = mkOption {
-          default = {};
+          default = [];
           type = types.listOf types.optionSet;
           description = "A list of template variables for using Dashboard templating.";
           options = {
@@ -47,15 +47,18 @@ with lib;
               description = "The name of the variable.";
             };
             prefix = mkOption {
-              type = types.str;
+              default = null;
+              type = types.nullOr (types.str);
               description = "The tag prefix associated with the variable. Only tags with this prefix will appear in the variable dropdown.";
             };
             default = mkOption {
-              type = types.str;
+              default = null;
+              type = types.nullOr (types.str);
               description = "The default value for the template variable on dashboard load";
             };
           };
         };
+      };
 
   config._type = "datadog-timeboard";
 }

--- a/nix/datadog-timeboard.nix
+++ b/nix/datadog-timeboard.nix
@@ -24,7 +24,6 @@ with lib;
           description = "A description of the timeboard's content.";
         };
         graphs = mkOption {
-          default = {};
           type = types.listOf types.optionSet;
           description = "A list of graph definitions";
           options = {

--- a/nix/datadog-timeboard.nix
+++ b/nix/datadog-timeboard.nix
@@ -61,7 +61,7 @@ with lib;
         readOnly = mkOption {
           default = false;
           type = types.bool;
-          description = "The read-only status of the screenboard.";
+          description = "The read-only status of the timeboard.";
         };
       };
 

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -100,7 +100,6 @@ rec {
   resources.machines = mapAttrs (n: v: v.config) nodes;
 
   # Datadog resources
-
   resources.datadogMonitors = evalResources ./datadog-monitor.nix (zipAttrs resourcesByType.datadogMonitors or []);
 
   # Azure resources

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -102,6 +102,7 @@ rec {
   # Datadog resources
   resources.datadogMonitors = evalResources ./datadog-monitor.nix (zipAttrs resourcesByType.datadogMonitors or []);
   resources.datadogTimeboards = evalResources ./datadog-timeboard.nix (zipAttrs resourcesByType.datadogTimeboards or []);
+  resources.datadogScreenboards = evalResources ./datadog-screenboard.nix (zipAttrs resourcesByType.datadogScreenboards or []);
 
   # Azure resources
   resources.azureAvailabilitySets = evalAzureResources ./azure-availability-set.nix (zipAttrs resourcesByType.azureAvailabilitySets or []);

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -99,6 +99,10 @@ rec {
   resources.elasticFileSystemMountTargets = evalResources ./elastic-file-system-mount-target.nix (zipAttrs resourcesByType.elasticFileSystemMountTargets or []);
   resources.machines = mapAttrs (n: v: v.config) nodes;
 
+  # Datadog resources
+
+  resources.datadogMonitors = evalResources ./datadog-monitor.nix (zipAttrs resourcesByType.datadogMonitors or []);
+
   # Azure resources
   resources.azureAvailabilitySets = evalAzureResources ./azure-availability-set.nix (zipAttrs resourcesByType.azureAvailabilitySets or []);
   resources.azureBlobContainers =
@@ -233,7 +237,7 @@ rec {
 
   gce_default_bootstrap_images = flip mapAttrs' gce_deployments (name: depl:
     let
-      gce = (scrubOptionValue depl).config.deployment.gce; 
+      gce = (scrubOptionValue depl).config.deployment.gce;
       images = {
         "14.12" = "gs://nixos-cloud-images/nixos-14.12.471.1f09b77-x86_64-linux.raw.tar.gz";
         "15.09" = "gs://nixos-cloud-images/nixos-15.09.425.7870f20-x86_64-linux.raw.tar.gz";

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -101,6 +101,7 @@ rec {
 
   # Datadog resources
   resources.datadogMonitors = evalResources ./datadog-monitor.nix (zipAttrs resourcesByType.datadogMonitors or []);
+  resources.datadogTimeboards = evalResources ./datadog-timeboard.nix (zipAttrs resourcesByType.datadogTimeboards or []);
 
   # Azure resources
   resources.azureAvailabilitySets = evalAzureResources ./azure-availability-set.nix (zipAttrs resourcesByType.azureAvailabilitySets or []);

--- a/nixops/datadog_utils.py
+++ b/nixops/datadog_utils.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from datadog import initialize, api
+import os
 
 def initializeDatadog(api_key, app_key):
+    if not api_key: api_key = os.environ.get('DATADOG_API_KEY')
+    if not app_key: app_key = os.environ.get('DATADOG_APP_KEY')
+    if not api_key or not app_key:
+        raise Exception("please set the datadog apiKey and appKey options (or the environment variables DATADOG_API_KEY and DATADOG_APP_KEY)")
     options = {'api_key': api_key, 'app_key': app_key}
     initialize(**options)
     return (api, options)

--- a/nixops/datadog_utils.py
+++ b/nixops/datadog_utils.py
@@ -1,0 +1,7 @@
+from datadog import initialize, api
+import sys
+
+def initializeDatadog(api_key, app_key):
+    options = {'api_key': api_key, 'app_key': app_key}
+    initialize(**options)
+    return (api, options)

--- a/nixops/datadog_utils.py
+++ b/nixops/datadog_utils.py
@@ -2,7 +2,7 @@
 
 from datadog import initialize, api
 
-def initializeDatadog(api_key, app_key):
-    options = {'api_key': api_key, 'app_key': app_key}
+def initializeDatadog(apiKey, appKey):
+    options = {'api_key': apiKey, 'app_key': appKey}
     initialize(**options)
     return (api, options)

--- a/nixops/datadog_utils.py
+++ b/nixops/datadog_utils.py
@@ -1,5 +1,6 @@
+# -*- coding: utf-8 -*-
+
 from datadog import initialize, api
-import sys
 
 def initializeDatadog(api_key, app_key):
     options = {'api_key': api_key, 'app_key': app_key}

--- a/nixops/datadog_utils.py
+++ b/nixops/datadog_utils.py
@@ -2,7 +2,7 @@
 
 from datadog import initialize, api
 
-def initializeDatadog(apiKey, appKey):
-    options = {'api_key': apiKey, 'app_key': appKey}
+def initializeDatadog(api_key, app_key):
+    options = {'api_key': api_key, 'app_key': app_key}
     initialize(**options)
     return (api, options)

--- a/nixops/datadog_utils.py
+++ b/nixops/datadog_utils.py
@@ -6,3 +6,14 @@ def initializeDatadog(api_key, app_key):
     options = {'api_key': api_key, 'app_key': app_key}
     initialize(**options)
     return (api, options)
+
+def get_template_variables(defn):
+    variables = defn.config['templateVariables']
+    template_variables = []
+    for var in variables:
+        tvariable = {}
+        tvariable['name'] = var['name']
+        tvariable['prefix'] = var['prefix']
+        tvariable['default'] = var['default']
+        template_variables.append(tvariable)
+    return template_variables

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -27,16 +27,16 @@ class DatadogMonitorDefinition(nixops.resources.ResourceDefinition):
         self.api_key = xml.find("attrs/attr[@name='apiKey']/string").get("value")
         self.app_key = xml.find("attrs/attr[@name='appKey']/string").get("value")
         self.message = xml.find("attrs/attr[@name='message']/string").get("value")
-        self.setOptionalAttr(xml=xml, name="renotifyInterval", type='int')
-        self.setOptionalAttr(xml=xml, name='silenced', type='string')
-        self.setOptionalAttr(xml=xml, name='escalationMessage', type='string')
-        self.setOptionalAttr(xml=xml, name='notify_no_data', type='bool')
-        self.setOptionalAttr(xml=xml, name='noDataTimeframe', type='int')
-        self.setOptionalAttr(xml=xml, name='timeoutH', type='int')
-        self.setOptionalAttr(xml=xml, name='requireFullWindow', type='bool')
-        self.setOptionalAttr(xml=xml, name='notifyAudit', type='bool')
-        self.setOptionalAttr(xml=xml, name='locked', type='bool')
-        self.setOptionalAttr(xml=xml, name='includeTags', type='bool')
+        self.setOptionalAttr(xml=xml, name='renotifyInterval', api_name="renotify_interval", type='int')
+        self.setOptionalAttr(xml=xml, name='silenced', api_name='silenced', type='string')
+        self.setOptionalAttr(xml=xml, name='escalationMessage', api_name='escalation_message', type='string')
+        self.setOptionalAttr(xml=xml, name='notifyNoData', api_name='notify_no_data', type='bool')
+        self.setOptionalAttr(xml=xml, name='noDataTimeframe', api_name='no_data_timeframe', type='int')
+        self.setOptionalAttr(xml=xml, name='timeoutH', api_name='timeout_h', type='int')
+        self.setOptionalAttr(xml=xml, name='requireFullWindow', api_name='require_full_window', type='bool')
+        self.setOptionalAttr(xml=xml, name='notifyAudit', api_name='notify_audit', type='bool')
+        self.setOptionalAttr(xml=xml, name='locked', api_name='locked', type='bool')
+        self.setOptionalAttr(xml=xml, name='includeTags', api_name='include_tags', type='bool')
         for alert in xml.findall("attrs/attr[@name='thresholds']/attrs/attr"):
             if alert.find("int") != None:
                 if alert.attrib.get('name') == "ok":
@@ -46,11 +46,11 @@ class DatadogMonitorDefinition(nixops.resources.ResourceDefinition):
                 if alert.attrib.get('name') == "warning":
                     self.extra_options['thresholds']['warning'] = int(alert.find("int").get("value"))
 
-    def setOptionalAttr(self,xml,name,type):
+    def setOptionalAttr(self,xml,name,api_name,type):
         attr = xml.find("attrs/attr[@name='{0}']/{1}".format(name,type))
         if attr != None:
             value = attr.get('value')
-            self.extra_options[name]= ast.literal_eval(value) if name == 'silenced' else value
+            self.extra_options[api_name]= ast.literal_eval(value) if name == 'silenced' else value
 
     def show_type(self):
         return "{0}".format(self.get_type())
@@ -155,16 +155,16 @@ class DatadogMonitorState(nixops.resources.ResourceState):
             self.monitor_type = defn.monitor_type
             self.query = defn.query
             self.message = defn.message
-            self.renotify_interval = self.getOptionIfExist(name='renotifyInterval',defn=defn)
+            self.renotifyInterval = self.getOptionIfExist(name='renotify_interval',defn=defn)
             self.silenced = self.getOptionIfExist(name='silenced',defn=defn)
-            self.escalation_message = self.getOptionIfExist(name='escalationMessage',defn=defn)
-            self.notify_no_data = self.getOptionIfExist(name='notifyNoData',defn=defn)
-            self.no_data_timeframe = self.getOptionIfExist(name='noDataTimeframe',defn=defn)
-            self.timeout_h = self.getOptionIfExist(name='timeoutH',defn=defn)
-            self.require_full_window = self.getOptionIfExist(name='requireFullWindow',defn=defn)
-            self.notify_audit = self.getOptionIfExist(name='notifyAudit',defn=defn)
+            self.escalationMessage = self.getOptionIfExist(name='escalation_message',defn=defn)
+            self.notifyNoData = self.getOptionIfExist(name='notify_no_data',defn=defn)
+            self.noDataTimeframe = self.getOptionIfExist(name='no_data_timeframe',defn=defn)
+            self.timeoutH = self.getOptionIfExist(name='timeout_h',defn=defn)
+            self.requireFullWindow = self.getOptionIfExist(name='require_full_window',defn=defn)
+            self.notifyAudit = self.getOptionIfExist(name='notify_audit',defn=defn)
             self.locked = self.getOptionIfExist(name='locked',defn=defn)
-            self.include_tags = self.getOptionIfExist(name='includeTags',defn=defn)
+            self.includeTags = self.getOptionIfExist(name='include_tags',defn=defn)
             if defn.extra_options['thresholds'] != {}:
                 thresholds = defn.extra_options['thresholds']
                 for k in thresholds:

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+
+import nixops.util
+import nixops.resources
+import nixops.datadog_utils
+import json
+
+
+class DatadogMonitorDefinition(nixops.resources.ResourceDefinition):
+    """Definition of a Datadog monitor."""
+
+    @classmethod
+    def get_type(cls):
+        return "datadog-monitor"
+
+    @classmethod
+    def get_resource_type(cls):
+        return "datadogMonitors"
+
+    def __init__(self, xml):
+        nixops.resources.ResourceDefinition.__init__(self, xml)
+        self.monitor_name = xml.find("attrs/attr[@name='name']/string").get("value")
+        self.monitor_type = xml.find("attrs/attr[@name='type']/string").get("value")
+        self.monitor_query = xml.find("attrs/attr[@name='query']/string").get("value")
+        self.api_key = xml.find("attrs/attr[@name='api_key']/string").get("value")
+        self.app_key = xml.find("attrs/attr[@name='app_key']/string").get("value")
+        self.monitor_message =  xml.find("attrs/attr[@name='message']/string").get("value")
+
+    def show_type(self):
+        return "{0}".format(self.get_type())
+
+class DatadogMonitorState(nixops.resources.ResourceState):
+    """State of a Datadog monitor"""
+
+    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    api_key = nixops.util.attr_property("api_key", None)
+    app_key = nixops.util.attr_property("app_key", None)
+    monitor_name = nixops.util.attr_property("monitor_name", None)
+    monitor_type = nixops.util.attr_property("monitor_type", None)
+    monitor_query = nixops.util.attr_property("monitor_query", None)
+    monitor_message = nixops.util.attr_property("monitor_message", None)
+    monitor_id = nixops.util.attr_property("monitor_id", None)
+
+    @classmethod
+    def get_type(cls):
+        return "datadog-monitor"
+
+
+    def __init__(self, depl, name, id):
+        nixops.resources.ResourceState.__init__(self, depl, name, id)
+        self._dd_api = None
+        self._key_options = None
+
+
+    def show_type(self):
+        s = super(DatadogMonitorState, self).show_type()
+        return s
+
+
+    @property
+    def resource_id(self):
+        return self.monitor_name
+
+
+    def get_definition_prefix(self):
+        return "resources.datadogMonitors."
+
+    def connect(self, app_key, api_key):
+        if self._dd_api: return
+        self._dd_api, self._key_options = nixops.datadog_utils.initializeDatadog(app_key=app_key, api_key=api_key)
+
+    def create(self, defn, check, allow_reboot, allow_recreate):
+        if check or self.state != self.UP:
+            self.connect(app_key=defn.app_key, api_key=defn.api_key)
+            self.log("creating Datadog monitor '{0}...'".format(defn.monitor_name))
+            response = self._dd_api.Monitor.create(
+                type=defn.monitor_type, query=defn.monitor_query, name=defn.monitor_name,
+                message=defn.monitor_message, options=self._key_options)
+            if response['errors']:
+                raise Exception(str(response['errors']))
+            else:
+                monitorId = response['id']
+
+        with self.depl._db:
+            self.state = self.UP
+            self.api_key = defn.api_key
+            self.app_key = defn.app_key
+            self.monitor_name = defn.monitor_name
+            self.monitor_type = defn.monitor_type
+            self.monitor_query = defn.monitor_query
+            self.monitor_message = defn.monitor_message
+            self.monitor_id = monitorId
+
+
+
+
+    def destroy(self, wipe=False):
+        if self.state == self.UP:
+            self.log("deleting Datadog monitor ‘{0}’...".format(self.monitor_name))
+            self.connect(self.app_key,self.api_key)
+            self._dd_api.Monitor.delete(self.monitor_id)
+
+        return True

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -131,7 +131,7 @@ class DatadogMonitorState(nixops.resources.ResourceState):
         self.connect(app_key=defn.app_key, api_key=defn.api_key)
         options = self._key_options
         if self.state != self.UP:
-            self.log("creating Datadog monitor '{0}...'".format(defn.monitor_name))
+            self.log("creating datadog monitor '{0}...'".format(defn.monitor_name))
             if defn.extra_options != {}: options.update(defn.extra_options)
             monitor_id = self.create_monitor(defn=defn, options=options)
 
@@ -185,9 +185,9 @@ class DatadogMonitorState(nixops.resources.ResourceState):
         if self.state == self.UP:
             self.connect(self.app_key,self.api_key)
             if self.monitor_exist(self.monitor_id) == False:
-                self.warn("monitor with id {0} already deleted".format(self.monitor_id))
+                self.warn("datadog monitor with id {0} already deleted".format(self.monitor_id))
             else:
-                self.log("deleting Datadog monitor ‘{0}’...".format(self.monitor_name))
+                self.log("deleting datadog monitor ‘{0}’...".format(self.monitor_name))
                 self._dd_api.Monitor.delete(self.monitor_id)
 
         return True

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -84,7 +84,7 @@ class DatadogMonitorState(nixops.resources.ResourceState):
         self.connect(app_key=defn.config['appKey'], api_key=defn.config['apiKey'])
         options = json.loads(defn.config['monitorOptions'])
         silenced = defn.config['silenced']
-        if silenced!=None: options.update(ast.literal_eval(silenced))
+        if silenced!=None: options['silenced'] = ast.literal_eval(silenced)
         options.update(self._key_options)
         if self.state != self.UP:
             self.log("creating datadog monitor '{0}...'".format(defn.config['name']))

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -71,6 +71,8 @@ class DatadogMonitorState(nixops.resources.ResourceState):
     def create(self, defn, check, allow_reboot, allow_recreate):
         if check or self.state != self.UP:
             self.connect(app_key=defn.app_key, api_key=defn.api_key)
+            if self.monitor_id != None:
+                self._dd_api.Monitor.delete(self.monitor_id)
             self.log("creating Datadog monitor '{0}...'".format(defn.monitor_name))
             response = self._dd_api.Monitor.create(
                 type=defn.monitor_type, query=defn.monitor_query, name=defn.monitor_name,

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -50,7 +50,9 @@ class DatadogMonitorState(nixops.resources.ResourceState):
         self._dd_api = None
         self._key_options = None
 
-
+    def _exists(self):
+        return self.state != self.MISSING
+    
     def show_type(self):
         s = super(DatadogMonitorState, self).show_type()
         return s

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -66,6 +66,19 @@ class DatadogMonitorState(nixops.resources.ResourceState):
     monitorQuery = nixops.util.attr_property("monitor_query", None)
     monitorMessage = nixops.util.attr_property("monitor_message", None)
     monitorId = nixops.util.attr_property("monitor_id", None)
+    renotifyInterval = nixops.util.attr_property("monitor_renotify_interval", None)
+    silenced =  nixops.util.attr_property("monitor_silenced", None)
+    escalationMessage =  nixops.util.attr_property("monitor_escalation_message", None)
+    notifyNoData =  nixops.util.attr_property("monitor_notify_no_data", None)
+    noDataTimeframe =  nixops.util.attr_property("monitor_no_data_timeframe", None)
+    timeoutH =  nixops.util.attr_property("monitor_timeout_h", None)
+    requireFullWindow =  nixops.util.attr_property("monitor_require_full_window", None)
+    notifyAudit =  nixops.util.attr_property("monitor_notify_audit", None)
+    locked =  nixops.util.attr_property("monitor_locked", None)
+    includeTags =  nixops.util.attr_property("monitor_include_tags", None)
+    thresholdsOk =  nixops.util.attr_property("monitor_thresholds_ok", None)
+    thresholdsWarning =  nixops.util.attr_property("monitor_thresholds_warning", None)
+    thresholdsCritical =  nixops.util.attr_property("monitor_thresholds_critical", None)
 
     @classmethod
     def get_type(cls):
@@ -142,9 +155,29 @@ class DatadogMonitorState(nixops.resources.ResourceState):
             self.monitorType = defn.monitorType
             self.monitorQuery = defn.monitorQuery
             self.monitorMessage = defn.monitorMessage
+            self.renotifyInterval = self.getOptionIfExist(name='renotify_interval',defn=defn)
+            self.silenced = self.getOptionIfExist(name='silenced',defn=defn)
+            self.escalationMessage = self.getOptionIfExist(name='escalation_message',defn=defn)
+            self.notifyNoData = self.getOptionIfExist(name='notify_no_data',defn=defn)
+            self.noDataTimeframe = self.getOptionIfExist(name='no_data_timeframe',defn=defn)
+            self.timeoutH = self.getOptionIfExist(name='timeout_h',defn=defn)
+            self.requireFullWindow = self.getOptionIfExist(name='require_full_window',defn=defn)
+            self.notifyAudit = self.getOptionIfExist(name='notify_audit',defn=defn)
+            self.locked = self.getOptionIfExist(name='locked',defn=defn)
+            self.includeTags = self.getOptionIfExist(name='include_tags',defn=defn)
+            if defn.extraOptions['thresholds'] != {}:
+                thresholds = defn.extraOptions['thresholds']
+                for k in thresholds:
+                    if k=='ok': self.thresholdsOk = thresholds[k]
+                    if k=='critical': self.thresholdsCritical = thresholds[k]
+                    if k=='warning': self.thresholdsWarning = thresholds[k]
             if monitorId != None: self.monitorId = monitorId
 
-
+    def getOptionIfExist(self,name,defn):
+        if name in defn.extraOptions:
+            return defn.extraOptions[name] if name != 'silenced' else str(defn.extraOptions[name])
+        else:
+            return None
 
 
 

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -19,12 +19,12 @@ class DatadogMonitorDefinition(nixops.resources.ResourceDefinition):
     def __init__(self, xml):
         nixops.resources.ResourceDefinition.__init__(self, xml)
         self.thresholds = {}
-        self.monitor_name = xml.find("attrs/attr[@name='name']/string").get("value")
-        self.monitor_type = xml.find("attrs/attr[@name='type']/string").get("value")
-        self.monitor_query = xml.find("attrs/attr[@name='query']/string").get("value")
+        self.monitorName = xml.find("attrs/attr[@name='name']/string").get("value")
+        self.monitorType = xml.find("attrs/attr[@name='type']/string").get("value")
+        self.monitorQuery = xml.find("attrs/attr[@name='query']/string").get("value")
         self.api_key = xml.find("attrs/attr[@name='api_key']/string").get("value")
         self.app_key = xml.find("attrs/attr[@name='app_key']/string").get("value")
-        self.monitor_message =  xml.find("attrs/attr[@name='message']/string").get("value")
+        self.monitorMessage =  xml.find("attrs/attr[@name='message']/string").get("value")
         for alert in xml.findall("attrs/attr[@name='thresholds']/attrs/attr"):
             if alert.attrib.get('name') == "ok":
                 self.thresholds['ok'] = int(alert.find("int").get("value"))
@@ -42,11 +42,11 @@ class DatadogMonitorState(nixops.resources.ResourceState):
     state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
     api_key = nixops.util.attr_property("api_key", None)
     app_key = nixops.util.attr_property("app_key", None)
-    monitor_name = nixops.util.attr_property("monitor_name", None)
-    monitor_type = nixops.util.attr_property("monitor_type", None)
-    monitor_query = nixops.util.attr_property("monitor_query", None)
-    monitor_message = nixops.util.attr_property("monitor_message", None)
-    monitor_id = nixops.util.attr_property("monitor_id", None)
+    monitorName = nixops.util.attr_property("monitor_name", None)
+    monitorType = nixops.util.attr_property("monitor_type", None)
+    monitorQuery = nixops.util.attr_property("monitor_query", None)
+    monitorMessage = nixops.util.attr_property("monitor_message", None)
+    monitorId = nixops.util.attr_property("monitor_id", None)
 
     @classmethod
     def get_type(cls):
@@ -56,7 +56,7 @@ class DatadogMonitorState(nixops.resources.ResourceState):
     def __init__(self, depl, name, id):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._dd_api = None
-        self._key_options = None
+        self._keyOptions = None
 
     def _exists(self):
         return self.state != self.MISSING
@@ -68,7 +68,7 @@ class DatadogMonitorState(nixops.resources.ResourceState):
 
     @property
     def resource_id(self):
-        return self.monitor_name
+        return self.monitorName
 
 
     def get_definition_prefix(self):
@@ -76,19 +76,19 @@ class DatadogMonitorState(nixops.resources.ResourceState):
 
     def connect(self, app_key, api_key):
         if self._dd_api: return
-        self._dd_api, self._key_options = nixops.datadog_utils.initializeDatadog(app_key=app_key, api_key=api_key)
+        self._dd_api, self._keyOptions = nixops.datadog_utils.initializeDatadog(app_key=app_key, api_key=api_key)
 
     def create(self, defn, check, allow_reboot, allow_recreate):
         if check or self.state != self.UP:
             self.connect(app_key=defn.app_key, api_key=defn.api_key)
-            if self.monitor_id != None:
-                self._dd_api.Monitor.delete(self.monitor_id)
-            self.log("creating Datadog monitor '{0}...'".format(defn.monitor_name))
-            options = self._key_options
+            if self.monitorId != None:
+                self._dd_api.Monitor.delete(self.monitorId)
+            self.log("creating Datadog monitor '{0}...'".format(defn.monitorName))
+            options = self._keyOptions
             if defn.thresholds != {}: options.update(defn.thresholds)
             response = self._dd_api.Monitor.create(
-                type=defn.monitor_type, query=defn.monitor_query, name=defn.monitor_name,
-                message=defn.monitor_message, options=options)
+                type=defn.monitorType, query=defn.monitorQuery, name=defn.monitorName,
+                message=defn.monitorMessage, options=options)
             if 'errors' in response:
                 raise Exception(str(response['errors']))
             else:
@@ -98,19 +98,19 @@ class DatadogMonitorState(nixops.resources.ResourceState):
             self.state = self.UP
             self.api_key = defn.api_key
             self.app_key = defn.app_key
-            self.monitor_name = defn.monitor_name
-            self.monitor_type = defn.monitor_type
-            self.monitor_query = defn.monitor_query
-            self.monitor_message = defn.monitor_message
-            self.monitor_id = monitorId
+            self.monitorName = defn.monitorName
+            self.monitorType = defn.monitorType
+            self.monitorQuery = defn.monitorQuery
+            self.monitorMessage = defn.monitorMessage
+            self.monitorId = monitorId
 
 
 
 
     def destroy(self, wipe=False):
         if self.state == self.UP:
-            self.log("deleting Datadog monitor ‘{0}’...".format(self.monitor_name))
+            self.log("deleting Datadog monitor ‘{0}’...".format(self.monitorName))
             self.connect(self.app_key,self.api_key)
-            self._dd_api.Monitor.delete(self.monitor_id)
+            self._dd_api.Monitor.delete(self.monitorId)
 
         return True

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -131,11 +131,11 @@ class DatadogMonitorState(nixops.resources.ResourceState):
 
     def destroy(self, wipe=False):
         if self.state == self.UP:
-            self.log("deleting Datadog monitor ‘{0}’...".format(self.monitorName))
             self.connect(self.app_key,self.api_key)
             if self.monitor_exist(self.monitorId) == False:
                 self.warn("monitor with id {0} already deleted".format(self.monitorId))
             else:
+                self.log("deleting Datadog monitor ‘{0}’...".format(self.monitorName))
                 self._dd_api.Monitor.delete(self.monitorId)
 
         return True

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -75,7 +75,7 @@ class DatadogMonitorState(nixops.resources.ResourceState):
             response = self._dd_api.Monitor.create(
                 type=defn.monitor_type, query=defn.monitor_query, name=defn.monitor_name,
                 message=defn.monitor_message, options=self._key_options)
-            if response['errors']:
+            if 'errors' in response:
                 raise Exception(str(response['errors']))
             else:
                 monitorId = response['id']

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -23,20 +23,20 @@ class DatadogMonitorDefinition(nixops.resources.ResourceDefinition):
         self.extraOptions['thresholds']= {};
         self.monitorName = xml.find("attrs/attr[@name='name']/string").get("value")
         self.monitorType = xml.find("attrs/attr[@name='type']/string").get("value")
-        self.monitorQuery = xml.find("attrs/attr[@name='query']/string").get("value")
-        self.api_key = xml.find("attrs/attr[@name='api_key']/string").get("value")
-        self.app_key = xml.find("attrs/attr[@name='app_key']/string").get("value")
-        self.monitorMessage = xml.find("attrs/attr[@name='message']/string").get("value")
-        self.setOptionalAttr(xml=xml,name='renotify_interval',type='int')
-        self.setOptionalAttr(xml=xml,name='silenced',type='string')
-        self.setOptionalAttr(xml=xml,name='escalation_message',type='string')
-        self.setOptionalAttr(xml=xml,name='notify_no_data',type='bool')
-        self.setOptionalAttr(xml=xml,name='no_data_timeframe',type='int')
-        self.setOptionalAttr(xml=xml,name='timeout_h',type='int')
-        self.setOptionalAttr(xml=xml,name='require_full_window',type='bool')
-        self.setOptionalAttr(xml=xml,name='notify_audit',type='bool')
-        self.setOptionalAttr(xml=xml,name='locked',type='bool')
-        self.setOptionalAttr(xml=xml,name='include_tags',type='bool')
+        self.query = xml.find("attrs/attr[@name='query']/string").get("value")
+        self.apiKey = xml.find("attrs/attr[@name='apiKey']/string").get("value")
+        self.appKey = xml.find("attrs/attr[@name='appKey']/string").get("value")
+        self.message = xml.find("attrs/attr[@name='message']/string").get("value")
+        self.setOptionalAttr(xml=xml, name='renotifyInterval', api_name="renotify_interval", type='int')
+        self.setOptionalAttr(xml=xml, name='silenced', api_name='silenced', type='string')
+        self.setOptionalAttr(xml=xml, name='escalationMessage', api_name='escalation_message', type='string')
+        self.setOptionalAttr(xml=xml, name='notifyNoData', api_name='notify_no_data', type='bool')
+        self.setOptionalAttr(xml=xml, name='noDataTimeframe', api_name='no_data_timeframe', type='int')
+        self.setOptionalAttr(xml=xml, name='timeoutH', api_name='timeout_h', type='int')
+        self.setOptionalAttr(xml=xml, name='requireFullWindow', api_name='require_full_window', type='bool')
+        self.setOptionalAttr(xml=xml, name='notifyAudit', api_name='notify_audit', type='bool')
+        self.setOptionalAttr(xml=xml, name='locked', api_name='locked', type='bool')
+        self.setOptionalAttr(xml=xml, name='includeTags', api_name='include_tags', type='bool')
         for alert in xml.findall("attrs/attr[@name='thresholds']/attrs/attr"):
             if alert.find("int") != None:
                 if alert.attrib.get('name') == "ok":
@@ -46,11 +46,11 @@ class DatadogMonitorDefinition(nixops.resources.ResourceDefinition):
                 if alert.attrib.get('name') == "warning":
                     self.extraOptions['thresholds']['warning'] = int(alert.find("int").get("value"))
 
-    def setOptionalAttr(self,xml,name,type):
+    def setOptionalAttr(self,xml,name,api_name,type):
         attr = xml.find("attrs/attr[@name='{0}']/{1}".format(name,type))
         if attr != None:
             value = attr.get('value')
-            self.extraOptions[name]= ast.literal_eval(value) if name == 'silenced' else value
+            self.extraOptions[api_name]= ast.literal_eval(value) if name == 'silenced' else value
 
     def show_type(self):
         return "{0}".format(self.get_type())
@@ -59,26 +59,26 @@ class DatadogMonitorState(nixops.resources.ResourceState):
     """State of a Datadog monitor"""
 
     state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
-    api_key = nixops.util.attr_property("api_key", None)
-    app_key = nixops.util.attr_property("app_key", None)
-    monitorName = nixops.util.attr_property("monitor_name", None)
-    monitorType = nixops.util.attr_property("monitor_type", None)
-    monitorQuery = nixops.util.attr_property("monitor_query", None)
-    monitorMessage = nixops.util.attr_property("monitor_message", None)
-    monitorId = nixops.util.attr_property("monitor_id", None)
-    renotifyInterval = nixops.util.attr_property("monitor_renotify_interval", None)
-    silenced =  nixops.util.attr_property("monitor_silenced", None)
-    escalationMessage =  nixops.util.attr_property("monitor_escalation_message", None)
-    notifyNoData =  nixops.util.attr_property("monitor_notify_no_data", None)
-    noDataTimeframe =  nixops.util.attr_property("monitor_no_data_timeframe", None)
-    timeoutH =  nixops.util.attr_property("monitor_timeout_h", None)
-    requireFullWindow =  nixops.util.attr_property("monitor_require_full_window", None)
-    notifyAudit =  nixops.util.attr_property("monitor_notify_audit", None)
-    locked =  nixops.util.attr_property("monitor_locked", None)
-    includeTags =  nixops.util.attr_property("monitor_include_tags", None)
-    thresholdsOk =  nixops.util.attr_property("monitor_thresholds_ok", None)
-    thresholdsWarning =  nixops.util.attr_property("monitor_thresholds_warning", None)
-    thresholdsCritical =  nixops.util.attr_property("monitor_thresholds_critical", None)
+    apiKey = nixops.util.attr_property("apiKey", None)
+    appKey = nixops.util.attr_property("appKey", None)
+    monitorName = nixops.util.attr_property("name", None)
+    monitorType = nixops.util.attr_property("type", None)
+    query = nixops.util.attr_property("query", None)
+    message = nixops.util.attr_property("message", None)
+    monitorId = nixops.util.attr_property("monitorId", None)
+    renotifyInterval = nixops.util.attr_property("renotifyInterval", None)
+    silenced =  nixops.util.attr_property("silenced", None)
+    escalationMessage =  nixops.util.attr_property("escalationMessage", None)
+    notifyNoData =  nixops.util.attr_property("notifyNoData", None)
+    noDataTimeframe =  nixops.util.attr_property("noDataTimeframe", None)
+    timeoutH =  nixops.util.attr_property("timeoutH", None)
+    requireFullWindow =  nixops.util.attr_property("requireFullWindow", None)
+    notifyAudit =  nixops.util.attr_property("notifyAudit", None)
+    locked =  nixops.util.attr_property("locked", None)
+    includeTags =  nixops.util.attr_property("include_tags", None)
+    thresholdsOk =  nixops.util.attr_property("thresholds.ok", None)
+    thresholdsWarning =  nixops.util.attr_property("thresholds.warning", None)
+    thresholdsCritical =  nixops.util.attr_property("thresholds.critical", None)
 
     @classmethod
     def get_type(cls):
@@ -106,14 +106,14 @@ class DatadogMonitorState(nixops.resources.ResourceState):
     def get_definition_prefix(self):
         return "resources.datadogMonitors."
 
-    def connect(self, app_key, api_key):
+    def connect(self, appKey, apiKey):
         if self._dd_api: return
-        self._dd_api, self._keyOptions = nixops.datadog_utils.initializeDatadog(app_key=app_key, api_key=api_key)
+        self._dd_api, self._keyOptions = nixops.datadog_utils.initializeDatadog(appKey=appKey, apiKey=apiKey)
 
     def create_monitor(self, defn, options):
         response = self._dd_api.Monitor.create(
-            type=defn.monitorType, query=defn.monitorQuery, name=defn.monitorName,
-            message=defn.monitorMessage, options=options)
+            type=defn.monitorType, query=defn.query, name=defn.monitorName,
+            message=defn.message, options=options)
         if 'errors' in response:
             raise Exception(str(response['errors']))
         else:
@@ -128,7 +128,7 @@ class DatadogMonitorState(nixops.resources.ResourceState):
 
     def create(self, defn, check, allow_reboot, allow_recreate):
         monitorId = None
-        self.connect(app_key=defn.app_key, api_key=defn.api_key)
+        self.connect(appKey=defn.appKey, apiKey=defn.apiKey)
         options = self._keyOptions
         if self.state != self.UP:
             self.log("creating Datadog monitor '{0}...'".format(defn.monitorName))
@@ -142,19 +142,19 @@ class DatadogMonitorState(nixops.resources.ResourceState):
                 monitorId = self.create_monitor(defn=defn, options=options)
             else:
                 response = self._dd_api.Monitor.update(
-                self.monitorId, query=defn.monitorQuery, name=defn.monitorName,
-                message=defn.monitorMessage, options=options)
+                self.monitorId, query=defn.query, name=defn.monitorName,
+                message=defn.message, options=options)
                 if 'errors' in response:
                     raise Exception(str(response['errors']))
 
         with self.depl._db:
             self.state = self.UP
-            self.api_key = defn.api_key
-            self.app_key = defn.app_key
+            self.apiKey = defn.apiKey
+            self.appKey = defn.appKey
             self.monitorName = defn.monitorName
             self.monitorType = defn.monitorType
-            self.monitorQuery = defn.monitorQuery
-            self.monitorMessage = defn.monitorMessage
+            self.query = defn.query
+            self.message = defn.message
             self.renotifyInterval = self.getOptionIfExist(name='renotify_interval',defn=defn)
             self.silenced = self.getOptionIfExist(name='silenced',defn=defn)
             self.escalationMessage = self.getOptionIfExist(name='escalation_message',defn=defn)
@@ -183,7 +183,7 @@ class DatadogMonitorState(nixops.resources.ResourceState):
 
     def destroy(self, wipe=False):
         if self.state == self.UP:
-            self.connect(self.app_key,self.api_key)
+            self.connect(self.appKey,self.apiKey)
             if self.monitor_exist(self.monitorId) == False:
                 self.warn("monitor with id {0} already deleted".format(self.monitorId))
             else:

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -3,7 +3,6 @@
 import nixops.util
 import nixops.resources
 import nixops.datadog_utils
-import json
 
 
 class DatadogMonitorDefinition(nixops.resources.ResourceDefinition):

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -26,12 +26,13 @@ class DatadogMonitorDefinition(nixops.resources.ResourceDefinition):
         self.app_key = xml.find("attrs/attr[@name='app_key']/string").get("value")
         self.monitorMessage =  xml.find("attrs/attr[@name='message']/string").get("value")
         for alert in xml.findall("attrs/attr[@name='thresholds']/attrs/attr"):
-            if alert.attrib.get('name') == "ok":
-                self.thresholds['ok'] = int(alert.find("int").get("value"))
-            if alert.attrib.get('name') == "critical":
-                self.thresholds['critical'] = int(alert.find("int").get("value"))
-            if alert.attrib.get('name') == "warning":
-                self.thresholds['warning'] = int(alert.find("int").get("value"))
+            if alert.find("int") != None:
+                if alert.attrib.get('name') == "ok":
+                    self.thresholds['ok'] = int(alert.find("int").get("value"))
+                if alert.attrib.get('name') == "critical":
+                    self.thresholds['critical'] = int(alert.find("int").get("value"))
+                if alert.attrib.get('name') == "warning":
+                    self.thresholds['warning'] = int(alert.find("int").get("value"))
 
     def show_type(self):
         return "{0}".format(self.get_type())

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -19,38 +19,38 @@ class DatadogMonitorDefinition(nixops.resources.ResourceDefinition):
 
     def __init__(self, xml):
         nixops.resources.ResourceDefinition.__init__(self, xml)
-        self.extraOptions = {}
-        self.extraOptions['thresholds']= {};
-        self.monitorName = xml.find("attrs/attr[@name='name']/string").get("value")
-        self.monitorType = xml.find("attrs/attr[@name='type']/string").get("value")
+        self.extra_options = {}
+        self.extra_options['thresholds']= {};
+        self.monitor_name = xml.find("attrs/attr[@name='name']/string").get("value")
+        self.monitor_type = xml.find("attrs/attr[@name='type']/string").get("value")
         self.query = xml.find("attrs/attr[@name='query']/string").get("value")
-        self.apiKey = xml.find("attrs/attr[@name='apiKey']/string").get("value")
-        self.appKey = xml.find("attrs/attr[@name='appKey']/string").get("value")
+        self.api_key = xml.find("attrs/attr[@name='apiKey']/string").get("value")
+        self.app_key = xml.find("attrs/attr[@name='appKey']/string").get("value")
         self.message = xml.find("attrs/attr[@name='message']/string").get("value")
-        self.setOptionalAttr(xml=xml, name='renotifyInterval', api_name="renotify_interval", type='int')
-        self.setOptionalAttr(xml=xml, name='silenced', api_name='silenced', type='string')
-        self.setOptionalAttr(xml=xml, name='escalationMessage', api_name='escalation_message', type='string')
-        self.setOptionalAttr(xml=xml, name='notifyNoData', api_name='notify_no_data', type='bool')
-        self.setOptionalAttr(xml=xml, name='noDataTimeframe', api_name='no_data_timeframe', type='int')
-        self.setOptionalAttr(xml=xml, name='timeoutH', api_name='timeout_h', type='int')
-        self.setOptionalAttr(xml=xml, name='requireFullWindow', api_name='require_full_window', type='bool')
-        self.setOptionalAttr(xml=xml, name='notifyAudit', api_name='notify_audit', type='bool')
-        self.setOptionalAttr(xml=xml, name='locked', api_name='locked', type='bool')
-        self.setOptionalAttr(xml=xml, name='includeTags', api_name='include_tags', type='bool')
+        self.setOptionalAttr(xml=xml, name="renotifyInterval", type='int')
+        self.setOptionalAttr(xml=xml, name='silenced', type='string')
+        self.setOptionalAttr(xml=xml, name='escalationMessage', type='string')
+        self.setOptionalAttr(xml=xml, name='notify_no_data', type='bool')
+        self.setOptionalAttr(xml=xml, name='noDataTimeframe', type='int')
+        self.setOptionalAttr(xml=xml, name='timeoutH', type='int')
+        self.setOptionalAttr(xml=xml, name='requireFullWindow', type='bool')
+        self.setOptionalAttr(xml=xml, name='notifyAudit', type='bool')
+        self.setOptionalAttr(xml=xml, name='locked', type='bool')
+        self.setOptionalAttr(xml=xml, name='includeTags', type='bool')
         for alert in xml.findall("attrs/attr[@name='thresholds']/attrs/attr"):
             if alert.find("int") != None:
                 if alert.attrib.get('name') == "ok":
-                    self.extraOptions['thresholds']['ok'] = int(alert.find("int").get("value"))
+                    self.extra_options['thresholds']['ok'] = int(alert.find("int").get("value"))
                 if alert.attrib.get('name') == "critical":
-                    self.extraOptions['thresholds']['critical'] = int(alert.find("int").get("value"))
+                    self.extra_options['thresholds']['critical'] = int(alert.find("int").get("value"))
                 if alert.attrib.get('name') == "warning":
-                    self.extraOptions['thresholds']['warning'] = int(alert.find("int").get("value"))
+                    self.extra_options['thresholds']['warning'] = int(alert.find("int").get("value"))
 
-    def setOptionalAttr(self,xml,name,api_name,type):
+    def setOptionalAttr(self,xml,name,type):
         attr = xml.find("attrs/attr[@name='{0}']/{1}".format(name,type))
         if attr != None:
             value = attr.get('value')
-            self.extraOptions[api_name]= ast.literal_eval(value) if name == 'silenced' else value
+            self.extra_options[name]= ast.literal_eval(value) if name == 'silenced' else value
 
     def show_type(self):
         return "{0}".format(self.get_type())
@@ -59,26 +59,26 @@ class DatadogMonitorState(nixops.resources.ResourceState):
     """State of a Datadog monitor"""
 
     state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
-    apiKey = nixops.util.attr_property("apiKey", None)
-    appKey = nixops.util.attr_property("appKey", None)
-    monitorName = nixops.util.attr_property("name", None)
-    monitorType = nixops.util.attr_property("type", None)
+    api_key = nixops.util.attr_property("apiKey", None)
+    app_key = nixops.util.attr_property("appKey", None)
+    monitor_name = nixops.util.attr_property("name", None)
+    monitor_type = nixops.util.attr_property("type", None)
     query = nixops.util.attr_property("query", None)
     message = nixops.util.attr_property("message", None)
-    monitorId = nixops.util.attr_property("monitorId", None)
-    renotifyInterval = nixops.util.attr_property("renotifyInterval", None)
+    monitor_id = nixops.util.attr_property("monitorId", None)
+    renotify_interval = nixops.util.attr_property("renotify_interval", None)
     silenced =  nixops.util.attr_property("silenced", None)
-    escalationMessage =  nixops.util.attr_property("escalationMessage", None)
-    notifyNoData =  nixops.util.attr_property("notifyNoData", None)
-    noDataTimeframe =  nixops.util.attr_property("noDataTimeframe", None)
-    timeoutH =  nixops.util.attr_property("timeoutH", None)
-    requireFullWindow =  nixops.util.attr_property("requireFullWindow", None)
-    notifyAudit =  nixops.util.attr_property("notifyAudit", None)
+    escalation_message =  nixops.util.attr_property("escalation_message", None)
+    notify_no_data =  nixops.util.attr_property("notify_no_data", None)
+    no_data_timeframe =  nixops.util.attr_property("no_data_timeframe", None)
+    timeout_h =  nixops.util.attr_property("timeout_h", None)
+    require_full_window =  nixops.util.attr_property("require_full_window", None)
+    notify_audit =  nixops.util.attr_property("notify_audit", None)
     locked =  nixops.util.attr_property("locked", None)
-    includeTags =  nixops.util.attr_property("include_tags", None)
-    thresholdsOk =  nixops.util.attr_property("thresholds.ok", None)
-    thresholdsWarning =  nixops.util.attr_property("thresholds.warning", None)
-    thresholdsCritical =  nixops.util.attr_property("thresholds.critical", None)
+    include_tags =  nixops.util.attr_property("include_tags", None)
+    thresholds_ok =  nixops.util.attr_property("thresholds.ok", None)
+    thresholds_warning =  nixops.util.attr_property("thresholds.warning", None)
+    thresholds_critical =  nixops.util.attr_property("thresholds.critical", None)
 
     @classmethod
     def get_type(cls):
@@ -88,7 +88,7 @@ class DatadogMonitorState(nixops.resources.ResourceState):
     def __init__(self, depl, name, id):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._dd_api = None
-        self._keyOptions = None
+        self._key_options = None
 
     def _exists(self):
         return self.state != self.MISSING
@@ -100,19 +100,19 @@ class DatadogMonitorState(nixops.resources.ResourceState):
 
     @property
     def resource_id(self):
-        return self.monitorName
+        return self.monitor_name
 
 
     def get_definition_prefix(self):
         return "resources.datadogMonitors."
 
-    def connect(self, appKey, apiKey):
+    def connect(self, app_key, api_key):
         if self._dd_api: return
-        self._dd_api, self._keyOptions = nixops.datadog_utils.initializeDatadog(appKey=appKey, apiKey=apiKey)
+        self._dd_api, self._key_options = nixops.datadog_utils.initializeDatadog(app_key=app_key, api_key=api_key)
 
     def create_monitor(self, defn, options):
         response = self._dd_api.Monitor.create(
-            type=defn.monitorType, query=defn.query, name=defn.monitorName,
+            type=defn.monitor_type, query=defn.query, name=defn.monitor_name,
             message=defn.message, options=options)
         if 'errors' in response:
             raise Exception(str(response['errors']))
@@ -127,55 +127,55 @@ class DatadogMonitorState(nixops.resources.ResourceState):
             return True
 
     def create(self, defn, check, allow_reboot, allow_recreate):
-        monitorId = None
-        self.connect(appKey=defn.appKey, apiKey=defn.apiKey)
-        options = self._keyOptions
+        monitor_id = None
+        self.connect(app_key=defn.app_key, api_key=defn.api_key)
+        options = self._key_options
         if self.state != self.UP:
-            self.log("creating Datadog monitor '{0}...'".format(defn.monitorName))
-            if defn.extraOptions != {}: options.update(defn.extraOptions)
-            monitorId = self.create_monitor(defn=defn, options=options)
+            self.log("creating Datadog monitor '{0}...'".format(defn.monitor_name))
+            if defn.extra_options != {}: options.update(defn.extra_options)
+            monitor_id = self.create_monitor(defn=defn, options=options)
 
         if self.state == self.UP:
-            if defn.extraOptions != {}: options.update(defn.extraOptions)
-            if self.monitor_exist(self.monitorId) == False:
-                self.warn("monitor with id {0} doesn't exist anymore.. recreating ...".format(self.monitorId))
-                monitorId = self.create_monitor(defn=defn, options=options)
+            if defn.extra_options != {}: options.update(defn.extra_options)
+            if self.monitor_exist(self.monitor_id) == False:
+                self.warn("monitor with id {0} doesn't exist anymore.. recreating ...".format(self.monitor_id))
+                monitor_id = self.create_monitor(defn=defn, options=options)
             else:
                 response = self._dd_api.Monitor.update(
-                self.monitorId, query=defn.query, name=defn.monitorName,
+                self.monitor_id, query=defn.query, name=defn.monitor_name,
                 message=defn.message, options=options)
                 if 'errors' in response:
                     raise Exception(str(response['errors']))
 
         with self.depl._db:
             self.state = self.UP
-            self.apiKey = defn.apiKey
-            self.appKey = defn.appKey
-            self.monitorName = defn.monitorName
-            self.monitorType = defn.monitorType
+            self.api_key = defn.api_key
+            self.app_key = defn.app_key
+            self.monitor_name = defn.monitor_name
+            self.monitor_type = defn.monitor_type
             self.query = defn.query
             self.message = defn.message
-            self.renotifyInterval = self.getOptionIfExist(name='renotify_interval',defn=defn)
+            self.renotify_interval = self.getOptionIfExist(name='renotifyInterval',defn=defn)
             self.silenced = self.getOptionIfExist(name='silenced',defn=defn)
-            self.escalationMessage = self.getOptionIfExist(name='escalation_message',defn=defn)
-            self.notifyNoData = self.getOptionIfExist(name='notify_no_data',defn=defn)
-            self.noDataTimeframe = self.getOptionIfExist(name='no_data_timeframe',defn=defn)
-            self.timeoutH = self.getOptionIfExist(name='timeout_h',defn=defn)
-            self.requireFullWindow = self.getOptionIfExist(name='require_full_window',defn=defn)
-            self.notifyAudit = self.getOptionIfExist(name='notify_audit',defn=defn)
+            self.escalation_message = self.getOptionIfExist(name='escalationMessage',defn=defn)
+            self.notify_no_data = self.getOptionIfExist(name='notifyNoData',defn=defn)
+            self.no_data_timeframe = self.getOptionIfExist(name='noDataTimeframe',defn=defn)
+            self.timeout_h = self.getOptionIfExist(name='timeoutH',defn=defn)
+            self.require_full_window = self.getOptionIfExist(name='requireFullWindow',defn=defn)
+            self.notify_audit = self.getOptionIfExist(name='notifyAudit',defn=defn)
             self.locked = self.getOptionIfExist(name='locked',defn=defn)
-            self.includeTags = self.getOptionIfExist(name='include_tags',defn=defn)
-            if defn.extraOptions['thresholds'] != {}:
-                thresholds = defn.extraOptions['thresholds']
+            self.include_tags = self.getOptionIfExist(name='includeTags',defn=defn)
+            if defn.extra_options['thresholds'] != {}:
+                thresholds = defn.extra_options['thresholds']
                 for k in thresholds:
                     if k=='ok': self.thresholdsOk = thresholds[k]
                     if k=='critical': self.thresholdsCritical = thresholds[k]
                     if k=='warning': self.thresholdsWarning = thresholds[k]
-            if monitorId != None: self.monitorId = monitorId
+            if monitor_id != None: self.monitor_id = monitor_id
 
     def getOptionIfExist(self,name,defn):
-        if name in defn.extraOptions:
-            return defn.extraOptions[name] if name != 'silenced' else str(defn.extraOptions[name])
+        if name in defn.extra_options:
+            return defn.extra_options[name] if name != 'silenced' else str(defn.extra_options[name])
         else:
             return None
 
@@ -183,11 +183,11 @@ class DatadogMonitorState(nixops.resources.ResourceState):
 
     def destroy(self, wipe=False):
         if self.state == self.UP:
-            self.connect(self.appKey,self.apiKey)
-            if self.monitor_exist(self.monitorId) == False:
-                self.warn("monitor with id {0} already deleted".format(self.monitorId))
+            self.connect(self.app_key,self.api_key)
+            if self.monitor_exist(self.monitor_id) == False:
+                self.warn("monitor with id {0} already deleted".format(self.monitor_id))
             else:
-                self.log("deleting Datadog monitor ‘{0}’...".format(self.monitorName))
-                self._dd_api.Monitor.delete(self.monitorId)
+                self.log("deleting Datadog monitor ‘{0}’...".format(self.monitor_name))
+                self._dd_api.Monitor.delete(self.monitor_id)
 
         return True

--- a/nixops/resources/datadog-screenboard.py
+++ b/nixops/resources/datadog-screenboard.py
@@ -6,29 +6,28 @@ import nixops.datadog_utils
 import json
 
 
-class DatadogTimeboardDefinition(nixops.resources.ResourceDefinition):
-    """Definition of a Datadog timeboard."""
+class DatadogScreenboardDefinition(nixops.resources.ResourceDefinition):
+    """Definition of a Datadog screenboard."""
 
     @classmethod
     def get_type(cls):
-        return "datadog-timeboard"
+        return "datadog-screenboard"
 
     @classmethod
     def get_resource_type(cls):
-        return "datadogTimeboards"
+        return "datadogScreenboards"
 
     def __init__(self, xml):
         nixops.resources.ResourceDefinition.__init__(self, xml)
         self.api_key = xml.find("attrs/attr[@name='apiKey']/string").get("value")
         self.app_key = xml.find("attrs/attr[@name='appKey']/string").get("value")
-        self.title = xml.find("attrs/attr[@name='title']/string").get("value")
-        self.description = xml.find("attrs/attr[@name='description']/string").get("value")
-        self.graphs = []
-        for graph in xml.findall("attrs/attr[@name='graphs']/list/attrs"):
-            graph_entry = {}
-            graph_entry['title'] = graph.find("attr[@name='title']/string").get("value")
-            graph_entry['definition'] = json.loads(graph.find("attr[@name='definition']/string").get("value"))
-            self.graphs.append(graph_entry)
+        self.board_title = xml.find("attrs/attr[@name='boardTitle']/string").get("value")
+        description = xml.find("attrs/attr[@name='description']/string").get("value")
+        self.description = description if description != "" else None
+        self.widgets = []
+        for widget in xml.findall("attrs/attr[@name='widgets']/list"):
+            widget_entry = json.loads(widget.find("string").get("value"))
+            self.widgets.append(widget_entry)
         self.template_variables = []
         tvariables = xml.findall("attrs/attr[@name='templateVariables']/list/attrs")
         for variable in tvariables:
@@ -39,29 +38,34 @@ class DatadogTimeboardDefinition(nixops.resources.ResourceDefinition):
             default = variable.find("attr[@name='default']/string")
             template_variable['default'] = default.get("value") if default != None else None
             self.template_variables.append(template_variable)
+        width = xml.find("attrs/attr[@name='width']/int")
+        self.width = width.get('value') if width != None else None
+        height = xml.find("attrs/attr[@name='height']/int")
+        self.height = height.get('value') if height != None else None
         read_only = xml.find("attrs/attr[@name='readOnly']/bool").get("value")
         self.read_only = True if read_only=="true" else False
 
     def show_type(self):
         return "{0}".format(self.get_type())
 
-class DatadogTimeboardState(nixops.resources.ResourceState):
-    """State of a Datadog timeboard"""
+class DatadogScreenboardState(nixops.resources.ResourceState):
+    """State of a Datadog screenboard"""
 
     state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
     api_key = nixops.util.attr_property("apiKey", None)
     app_key = nixops.util.attr_property("appKey", None)
-    title = nixops.util.attr_property("title",None)
+    board_title = nixops.util.attr_property("boardTitle",None)
     description = nixops.util.attr_property("description",None)
-    graphs = nixops.util.attr_property("graphs",[],'json')
+    width = nixops.util.attr_property("width",None)
+    height = nixops.util.attr_property("height",None)
+    widgets= nixops.util.attr_property("widgets",[],'json')
     template_variables = nixops.util.attr_property("templateVariables",[],'json')
-    timeboard_id = nixops.util.attr_property("timeboardId", None)
-    url = nixops.util.attr_property("timeboardURL", None)
+    screenboard_id = nixops.util.attr_property("screenboardId", None)
     read_only = nixops.util.attr_property("readOnly",None)
 
     @classmethod
     def get_type(cls):
-        return "datadog-timeboard"
+        return "datadog-screenboard"
 
     def __init__(self, depl, name, id):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
@@ -69,87 +73,74 @@ class DatadogTimeboardState(nixops.resources.ResourceState):
         self._key_options = None
 
     def show_type(self):
-        s = super(DatadogTimeboardState, self).show_type()
+        s = super(DatadogScreenboardState, self).show_type()
         return s
 
     @property
     def resource_id(self):
-        t = self.title
-        if self.url: t = "{0} [ {1} ]".format(t, self.url)
-        return t
-
-    def prefix_definition(self, attr):
-        return {('resources', 'datadogTimeboards'): attr}
-
-    def get_physical_spec(self):
-        return {'url': self.url}
+        return self.board_title
 
     def get_definition_prefix(self):
-        return "resources.datadogTimeboards."
+        return "resources.datadogScreenboards."
 
     def connect(self, app_key, api_key):
         if self._dd_api: return
         self._dd_api, self._key_options = nixops.datadog_utils.initializeDatadog(app_key=app_key, api_key=api_key)
 
-    def create_timeboard(self, defn, template_variables):
-        response = self._dd_api.Timeboard.create(
-            title=defn.title, description=defn.description, graphs=defn.graphs,
-             template_variables=template_variables, read_only=defn.read_only)
+    def create_screenboard(self, defn, template_variables):
+        response = self._dd_api.Screenboard.create(
+            board_title=defn.board_title, description=defn.description, widgets=defn.widgets,
+             template_variables=template_variables, width=defn.width, height=defn.height, read_only=defn.read_only)
         if 'errors' in response:
             raise Exception(str(response['errors']))
         else:
-            return response['dash']['id'], response['url']
+            return response['id']
 
-    def timeboard_exist(self, id):
-        result = self._dd_api.Timeboard.get(id)
+    def screenboard_exist(self, id):
+        result = self._dd_api.Screenboard.get(id)
         if 'errors' in result:
             return False
         else:
             return True
 
     def create(self, defn, check, allow_reboot, allow_recreate):
-        timeboard_id = None
-        url = None
+        screenboard_id = None
         self.connect(app_key=defn.app_key, api_key=defn.api_key)
         tv = defn.template_variables
         template_variables = tv if len(tv)>0 else None
         if self.state != self.UP:
-            self.log("creating datadog timeboard '{0}...'".format(defn.title))
-            timeboard_id, url = self.create_timeboard(defn=defn, template_variables=template_variables)
-
+            self.log("creating datadog screenboard '{0}...'".format(defn.board_title))
+            screenboard_id = self.create_screenboard(defn=defn, template_variables=template_variables)
         if self.state == self.UP:
-            if self.timeboard_exist(self.timeboard_id) == False:
-                self.warn("datadog timeboard with id {0} doesn't exist anymore.. recreating ...".format(self.timeboard_id))
-                timeboard_id, url = self.create_timeboard(defn=defn, template_variables=template_variables)
+            if self.screenboard_exist(self.screenboard_id) == False:
+                self.warn("datadog screenboard with id {0} doesn't exist anymore.. recreating ...".format(self.screenboard_id))
+                screenboard_id = self.create_screenboard(defn=defn, template_variables=template_variables)
             else:
-                response = self._dd_api.Timeboard.update(
-                self.timeboard_id, title=defn.title, description=defn.description, graphs=defn.graphs,
-                 template_variables=template_variables, read_only=defn.read_only)
+                response = self._dd_api.Screenboard.update(
+                self.screenboard_id, board_title=defn.board_title, description=defn.description, widgets=defn.widgets,
+                 template_variables=template_variables, width=defn.width, height=defn.height, read_only=defn.read_only)
                 if 'errors' in response:
                     raise Exception(str(response['errors']))
-                else:
-                    url = response['url']
 
         with self.depl._db:
             self.state = self.UP
             self.api_key = defn.api_key
             self.app_key = defn.app_key
-            if timeboard_id != None: self.timeboard_id = timeboard_id
-            self.title = defn.title
-            self.graphs = defn.graphs
+            if screenboard_id != None: self.screenboard_id = screenboard_id
+            self.board_title = defn.board_title
+            self.widgets = defn.widgets
             self.template_variables = defn.template_variables
             self.description = defn.description
-            self.url = url
             self.read_only = defn.read_only
 
     def _destroy(self):
         if self.state == self.UP:
             self.connect(self.app_key,self.api_key)
-            if self.timeboard_exist(self.timeboard_id) == False:
-                self.warn("datadog timeboard with id {0} already deleted".format(self.timeboard_id))
+            if self.screenboard_exist(self.screenboard_id) == False:
+                self.warn("datadog screenboard with id {0} already deleted".format(self.screenboard_id))
             else:
-                self.log("deleting datadog timeboard ‘{0}’...".format(self.title))
-                self._dd_api.Timeboard.delete(self.timeboard_id)
+                self.log("deleting datadog screenboard ‘{0}’...".format(self.board_title))
+                self._dd_api.Screenboard.delete(self.screenboard_id)
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixops/resources/datadog-timeboard.py
+++ b/nixops/resources/datadog-timeboard.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+import nixops.util
+import nixops.resources
+import nixops.datadog_utils
+
+
+class DatadogTimeboardDefinition(nixops.resources.ResourceDefinition):
+    """Definition of a Datadog monitor."""
+
+    @classmethod
+    def get_type(cls):
+        return "datadog-timeboard"
+
+    @classmethod
+    def get_resource_type(cls):
+        return "datadogTimeboards"
+
+    def __init__(self, xml):
+        nixops.resources.ResourceDefinition.__init__(self, xml)
+        self.api_key = xml.find("attrs/attr[@name='apiKey']/string").get("value")
+        self.app_key = xml.find("attrs/attr[@name='appKey']/string").get("value")
+        self.title = xml.find("attrs/attr[@name='title']/string").get("value")
+        self.description = xml.find("attrs/attr[@name='description']/string").get("value")
+        self.graphs = []
+        for graph in xml.findall("attrs/attr[@name='subscriptions']/list/attrs")
+            graph['title'] =
+
+
+    def show_type(self):
+        return "{0}".format(self.get_type())
+
+class DatadogTimeboardState(nixops.resources.ResourceState):
+    """State of a Datadog monitor"""
+
+    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    api_key = nixops.util.attr_property("apiKey", None)
+    app_key = nixops.util.attr_property("appKey", None)
+
+    @classmethod
+    def get_type(cls):
+        return "datadog-timeboard"
+
+    def __init__(self, depl, name, id):
+        nixops.resources.ResourceState.__init__(self, depl, name, id)
+        self._dd_api = None
+        self._key_options = None
+
+    def _exists(self):
+        return self.state != self.MISSING
+
+    def show_type(self):
+        s = super(DatadogTimeboardState, self).show_type()
+        return s
+
+
+    @property
+    def resource_id(self):
+        return self.title
+
+    def get_definition_prefix(self):
+        return "resources.datadogTimeboards."
+
+    def connect(self, app_key, api_key):
+        if self._dd_api: return
+        self._dd_api, self._key_options = nixops.datadog_utils.initializeDatadog(app_key=app_key, api_key=api_key)
+
+    def create_timeboard(self, defn, options):
+
+    def timeboard_exist(self, id):
+
+    def create(self, defn, check, allow_reboot, allow_recreate):
+
+    def destroy(self, wipe=False):
+        self._destroy()
+        return True

--- a/nixops/resources/datadog-timeboard.py
+++ b/nixops/resources/datadog-timeboard.py
@@ -76,7 +76,9 @@ class DatadogTimeboardState(nixops.resources.ResourceState):
 
     @property
     def resource_id(self):
-        return self.title
+        t = self.title
+        if self.url: t = "{0} [ {1} ]".format(t, self.url)
+        return t
 
     def prefix_definition(self, attr):
         return {('resources', 'datadogTimeboards'): attr}

--- a/nixops/resources/datadog-timeboard.py
+++ b/nixops/resources/datadog-timeboard.py
@@ -95,7 +95,7 @@ class DatadogTimeboardState(nixops.resources.ResourceState):
 
     def create_timeboard(self, defn, template_variables):
         response = self._dd_api.Timeboard.create(
-            title=defn.title, description=defn.description, graphs=defn.graphs)
+            title=defn.title, description=defn.description, graphs=defn.graphs, template_variables=template_variables)
         if 'errors' in response:
             raise Exception(str(response['errors']))
         else:

--- a/nixops/resources/datadog-timeboard.py
+++ b/nixops/resources/datadog-timeboard.py
@@ -3,6 +3,7 @@
 import nixops.util
 import nixops.resources
 import nixops.datadog_utils
+import json
 
 
 class DatadogTimeboardDefinition(nixops.resources.ResourceDefinition):
@@ -23,8 +24,22 @@ class DatadogTimeboardDefinition(nixops.resources.ResourceDefinition):
         self.title = xml.find("attrs/attr[@name='title']/string").get("value")
         self.description = xml.find("attrs/attr[@name='description']/string").get("value")
         self.graphs = []
-        for graph in xml.findall("attrs/attr[@name='subscriptions']/list/attrs")
-            graph['title'] =
+        for graph in xml.findall("attrs/attr[@name='graphs']/list/attrs"):
+            graph_entry = {}
+            graph_entry['title'] = graph.find("attr[@name='title']/string").get("value")
+            graph_entry['definition'] = json.loads(graph.find("attr[@name='definition']/string").get("value"))
+            self.graphs.append(graph_entry)
+        self.template_variables = []
+        tvariables = xml.findall("attrs/attr[@name='templateVariables']/list/attrs")
+        for variable in tvariables:
+            template_variable = {}
+            template_variable['name'] = variable.find("attr[@name='name']/string").get("value")
+            prefix = variable.find("attr[@name='prefix']/string")
+            template_variable['prefix'] = prefix.get("value") if prefix != None else None
+            default = variable.find("attr[@name='default']/string")
+            template_variable['default'] = default.get("value") if default != None else None
+            self.template_variables.append(template_variable)
+
 
 
     def show_type(self):
@@ -36,6 +51,12 @@ class DatadogTimeboardState(nixops.resources.ResourceState):
     state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
     api_key = nixops.util.attr_property("apiKey", None)
     app_key = nixops.util.attr_property("appKey", None)
+    title = nixops.util.attr_property("title",None)
+    description = nixops.util.attr_property("description",None)
+    graphs = nixops.util.attr_property("graphs",[],'json')
+    template_variables = nixops.util.attr_property("templateVariables",[],'json')
+    timeboard_id = nixops.util.attr_property("timeboardId", None)
+    url = nixops.util.attr_property("timeboardURL", None)
 
     @classmethod
     def get_type(cls):
@@ -53,10 +74,15 @@ class DatadogTimeboardState(nixops.resources.ResourceState):
         s = super(DatadogTimeboardState, self).show_type()
         return s
 
-
     @property
     def resource_id(self):
         return self.title
+
+    def prefix_definition(self, attr):
+        return {('resources', 'datadogTimeboards'): attr}
+
+    def get_physical_spec(self):
+        return {'url': self.url}
 
     def get_definition_prefix(self):
         return "resources.datadogTimeboards."
@@ -65,11 +91,63 @@ class DatadogTimeboardState(nixops.resources.ResourceState):
         if self._dd_api: return
         self._dd_api, self._key_options = nixops.datadog_utils.initializeDatadog(app_key=app_key, api_key=api_key)
 
-    def create_timeboard(self, defn, options):
+    def create_timeboard(self, defn, template_variables):
+        response = self._dd_api.Timeboard.create(
+            title=defn.title, description=defn.description, graphs=defn.graphs)
+        if 'errors' in response:
+            raise Exception(str(response['errors']))
+        else:
+            return response['dash']['id'], response['url']
 
     def timeboard_exist(self, id):
+        result = self._dd_api.Timeboard.get(id)
+        if 'errors' in result:
+            return False
+        else:
+            return True
 
     def create(self, defn, check, allow_reboot, allow_recreate):
+        timeboard_id = None
+        url = None
+        self.connect(app_key=defn.app_key, api_key=defn.api_key)
+        tv = defn.template_variables
+        template_variables = tv if len(tv)>0 else None
+        if self.state != self.UP:
+            self.log("creating datadog timeboard '{0}...'".format(defn.title))
+            timeboard_id, url = self.create_timeboard(defn=defn, template_variables=template_variables)
+
+        if self.state == self.UP:
+            if self.timeboard_exist(self.timeboard_id) == False:
+                self.warn("datadog timeboard with id {0} doesn't exist anymore.. recreating ...".format(self.monitor_id))
+                timeboard_id = self.create_timeboard(defn=defn)
+            else:
+                response = self._dd_api.Timeboard.update(
+                self.timeboard_id, title=defn.title, description=defn.description, graphs=defn.graphs,
+                 template_variables=template_variables)
+                if 'errors' in response:
+                    raise Exception(str(response['errors']))
+                else:
+                    url = response['url']
+
+        with self.depl._db:
+            self.state = self.UP
+            self.api_key = defn.api_key
+            self.app_key = defn.app_key
+            if timeboard_id != None: self.timeboard_id = timeboard_id
+            self.title = defn.title
+            self.graphs = defn.graphs
+            self.template_variables = defn.template_variables
+            self.description = defn.description
+            self.url = url
+
+    def _destroy(self):
+        if self.state == self.UP:
+            self.connect(self.app_key,self.api_key)
+            if self.timeboard_exist(self.timeboard_id) == False:
+                self.warn("datadog timeboard with id {0} already deleted".format(self.timeboard_id))
+            else:
+                self.log("deleting datadog timeboard ‘{0}’...".format(self.title))
+                self._dd_api.Timeboard.delete(self.timeboard_id)
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixops/resources/datadog-timeboard.py
+++ b/nixops/resources/datadog-timeboard.py
@@ -7,7 +7,7 @@ import json
 
 
 class DatadogTimeboardDefinition(nixops.resources.ResourceDefinition):
-    """Definition of a Datadog monitor."""
+    """Definition of a Datadog timeboard."""
 
     @classmethod
     def get_type(cls):
@@ -46,7 +46,7 @@ class DatadogTimeboardDefinition(nixops.resources.ResourceDefinition):
         return "{0}".format(self.get_type())
 
 class DatadogTimeboardState(nixops.resources.ResourceState):
-    """State of a Datadog monitor"""
+    """State of a Datadog timeboard"""
 
     state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
     api_key = nixops.util.attr_property("apiKey", None)
@@ -118,7 +118,7 @@ class DatadogTimeboardState(nixops.resources.ResourceState):
 
         if self.state == self.UP:
             if self.timeboard_exist(self.timeboard_id) == False:
-                self.warn("datadog timeboard with id {0} doesn't exist anymore.. recreating ...".format(self.monitor_id))
+                self.warn("datadog timeboard with id {0} doesn't exist anymore.. recreating ...".format(self.timeboard_id))
                 timeboard_id = self.create_timeboard(defn=defn)
             else:
                 response = self._dd_api.Timeboard.update(

--- a/release.nix
+++ b/release.nix
@@ -39,6 +39,7 @@ rec {
         '') [ "ebs-volume" "sns-topic" "sqs-queue" "ec2-keypair" "s3-bucket" "iam-role" "ssh-keypair" "ec2-security-group" "elastic-ip"
               "gce-disk" "gce-image" "gce-forwarding-rule" "gce-http-health-check" "gce-network"
               "gce-static-ip" "gce-target-pool" "gse-bucket"
+              "datadog-monitor" "datadog-timeboard" "datadog-screenboard"
               "azure-availability-set" "azure-blob-container" "azure-blob" "azure-directory"
               "azure-dns-record-set" "azure-dns-zone" "azure-express-route-circuit"
               "azure-file" "azure-gateway-connection" "azure-load-balancer" "azure-local-network-gateway"

--- a/release.nix
+++ b/release.nix
@@ -88,7 +88,7 @@ rec {
           azure-mgmt-storage
           adal
           sqlite3
-	  datadog
+          datadog
         ];
 
       # For "nix-build --run-env".

--- a/release.nix
+++ b/release.nix
@@ -88,6 +88,7 @@ rec {
           pythonPackages.azure-mgmt-storage
           pythonPackages.adal
           pythonPackages.sqlite3
+          pythonPackages.datadog
         ];
 
       # For "nix-build --run-env".


### PR DESCRIPTION
The purpose of this PR is to integrate a Datadog backend into Nixops. The end goal is to be able to deploy monitors/timeboards as resources in the same fashion as tools like [Terraform](https://www.terraform.io/docs/providers/datadog/index.html).

It's still a work in progress. Next steps needed are:

- [x] add all the supported options by the datadog api to the monitor options.
- [x] Implement a timeboard resource
- [x] Implement a screenboard resource
- [x] add examples
- [x] update the nixops manual if needed, etc ..

cc @rbvermaa 