### PR TITLE
deployment: avoid spurious warnings with --dry-run

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -632,7 +632,7 @@ class Deployment(object):
         except subprocess.CalledProcessError:
             raise Exception("unable to build all machine configurations")
 
-        if self.rollback_enabled:
+        if self.rollback_enabled and not dry_run:
             profile = self.create_profile()
             if subprocess.call(["nix-env", "-p", profile, "--set", configs_path]) != 0:
                 raise Exception("cannot update profile ‘{0}’".format(profile))


### PR DESCRIPTION
Prior to this commit, error messages like:

    error: selector ‘’ matches no derivations
    error: cannot update profile ‘/nix/var/nix/profiles/per-user/_/nixops/_’

would be generated when invoking `nixops deploy --dry-run`.

This occurs because `nix-build --dry-run` does not return a configuration 
path, causing a subsequent `nix-env` to fail on the empty value.  We skip 
profile creation during dry runs to avoid this.

Closes #225.