### PR TITLE
virtualbox: revert part of 56157cda709e49263bfd8089fcbdd0b333a0a4e6

### DIFF
--- a/nixops/backends/virtualbox.py
+++ b/nixops/backends/virtualbox.py
@@ -133,11 +133,8 @@ class VirtualBoxState(MachineState):
         self._logged_exec(
             ["VBoxManage", "guestproperty", "set", self.vm_id, "/VirtualBox/GuestInfo/Charon/ClientPublicKey", self._client_public_key])
 
-        if self._headless:
-          self._logged_exec(["VBoxHeadless", "--startvm", self.vm_id])
-        else:
-          self._logged_exec(["VBoxManage", "startvm", self.vm_id])
-
+        self._logged_exec(["VBoxManage", "startvm", self.vm_id] +
+                          (["--type", "headless"] if self._headless else []))
 
         self.state = self.STARTING
 


### PR DESCRIPTION
VBoxHeadless runs in foreground and blocks `_logged_exec`. This breaks deploy.

Luckily, `VBoxManage startvm --type headless` still uses VBoxHeadless as a backend, so
we don't get errors when using with headless virtualbox build.

The not-so-nice error message should be addressed in some other way and is a minor issue.

Sorry @domenkozar for misleading comment in my previous PR