### PR TITLE
fix typo in libvirtd section

### DIFF
--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -1401,8 +1401,8 @@ add your user to libvirtd group and change firewall not to filter DHCP packets.
 <para>Next we have to make sure our user has access to create images by
   executing:
   <programlisting>
-  $ sudo mkdir /var/lib/libvirtd/images
-  $ sudo chown myuser:libvirtd /var/lib/libvirtd/images</programlisting>
+  $ sudo mkdir /var/lib/libvirt/images
+  $ sudo chown myuser:libvirtd /var/lib/libvirt/images</programlisting>
 </para>
 
 <para>We're ready to create the deployment, start by creating


### PR DESCRIPTION
I followed the manual, but got this
```
error: Multiple exceptions: command ‘['nix-build', '-I', 'nixops=/nix/store/amaq26bnx2chm6hsb744b2vfrpwcr4rs-nixops-1.5pre0_abcdef/share/nix/nixops', '--arg', 'networkExprs', u'[ <fleet/fleet.nix> <fleet/fleet-virtual.nix> ]', '--arg', 'args', '{}', '--argstr', 'uuid', u'6281471e-6a37-11e6-8e21-901b0e968b96', '--argstr', 'deploymentName', u'fleet-virtual', '<nixops/eval-machine-info.nix>', '--arg', 'checkConfigurationOptions', 'false', '-A', 'nodes.jolly.roger.config.deployment.libvirtd.baseImage', '-o', '/run/user/1000/nixops-tmpQ02Ulo/libvirtd-image-jolly.roger']’ failed on machine ‘jolly.roger’ (exit code 1), /var/lib/libvirt/images is not writable by this user or it does not exist
```
I'm on unstable channel