### PR TITLE
Fix issue with ssh flags used with scp.

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -236,6 +236,10 @@ class MachineState(nixops.resources.ResourceState):
         else:
             return ["-p", str(self.ssh_port)]
 
+    def adapt_ssh_flag_for_use_with_scp(self, flags):
+      # For scp, the "-P" flag is used to specify the port. "-p"
+      # attempt to preserve file attributes.
+      return (map (lambda x: '-P' if x == '-p' else x, flags))
 
     def get_ssh_password(self):
         return None
@@ -353,7 +357,7 @@ class MachineState(nixops.resources.ResourceState):
 
     def upload_file(self, source, target, recursive=False):
         master = self.ssh.get_master()
-        cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
+        cmdline = ["scp"] + self.get_ssh_flags(True) + self.adapt_ssh_flag_for_use_with_scp(master.opts)
         if recursive:
             cmdline += ['-r']
         cmdline += [source, "root@" + self.get_ssh_name() + ":" + target]
@@ -361,7 +365,7 @@ class MachineState(nixops.resources.ResourceState):
 
     def download_file(self, source, target, recursive=False):
         master = self.ssh.get_master()
-        cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
+        cmdline = ["scp"] + self.get_ssh_flags(True) + self.adapt_ssh_flag_for_use_with_scp(master.opts)
         if recursive:
             cmdline += ['-r']
         cmdline += ["root@" + self.get_ssh_name() + ":" + source, target]

--- a/nixops/backends/container.py
+++ b/nixops/backends/container.py
@@ -63,9 +63,9 @@ class ContainerState(MachineState):
         flags = super(ContainerState, self).get_ssh_flags(*args, **kwargs)
         flags += ["-i", self.get_ssh_private_key_file()]
         if self.host == "localhost":
-            flags.extend(MachineState.get_ssh_flags(self))
+            flags.extend(MachineState.get_ssh_flags(self, *args, **kwargs))
         else:
-            cmd = "ssh -x -a root@{0} {1} nc -c {2} {3}".format(self.get_host_ssh(), " ".join(self.get_host_ssh_flags()), self.private_ipv4, self.ssh_port)
+            cmd = "ssh -x -a root@{0} {1} nc -c {2} {3}".format(self.get_host_ssh(), " ".join(self.get_host_ssh_flags(*args, **kwargs)), self.private_ipv4, self.ssh_port)
             flags.extend(["-o", "ProxyCommand=" + cmd])
         return flags
 
@@ -87,12 +87,12 @@ class ContainerState(MachineState):
         else:
             return self.host
 
-    def get_host_ssh_flags(self):
+    def get_host_ssh_flags(self, *args, **kwargs):
         if self.host.startswith("__machine-"):
             m = self.depl.get_machine(self.host[10:])
             if not m.started:
                 raise Exception("host machine ‘{0}’ of container ‘{1}’ is not up".format(m.name, self.name))
-            return m.get_ssh_flags()
+            return m.get_ssh_flags(*args, **kwargs)
         else:
             return []
 


### PR DESCRIPTION
As the '-p' flag attempt to preserve file attributes
with scp, it was making the scp command fail in
contexts where preserving attributes is not possible
(this is without mentionning the '22' argument that
followed and which seems to be accepted silently).

Here's the error it fixes:

```
afrontend> uploading key ‘my_secret.key’...
afrontend> scp: /run/keys/my_secret.key: No such file or directory
afrontend> error: command ‘['scp', '-P', '22', '-i', '/run/user/1000/nixops-tmp4MXxgW/id_nixops-afrontend', '-p', '22', '-oControlPath=/run/user/1000/nixops-ssh-tmpakFvsQ/master-socket', '/run/user/1000/nixops-tmp4MXxgW/key-afrontend', u'root@10.233.1.2:/run/my_secret.key']’ failed on machine ‘afrontend’ (exit code 1)
error: activation of 1 of 1 machines failed (namely on ‘afrontend’)
```

See the `['-P', '22']` part followed not long after by wrong `['-p', '22']`.

Note that this is a prerequisite for #300
