### PR TITLE
nix/ssh-tunnel: Prevent IPv6 address generation

### DIFF
--- a/nix/ssh-tunnel.nix
+++ b/nix/ssh-tunnel.nix
@@ -73,14 +73,28 @@ with lib;
       wantedBy = [ "multi-user.target" "encrypted-links.target" ];
       partOf = [ "encrypted-links.target" ];
       after = [ "network-interfaces.target" ];
-      path = [ pkgs.nettools pkgs.openssh ];
+      path = [ pkgs.iproute pkgs.openssh ];
       # FIXME: ensure that the remote tunnel device is free
-      script =
-        "ssh -i ${v.privateKey} -x"
-        + " -o StrictHostKeyChecking=no -o PermitLocalCommand=yes -o ServerAliveInterval=20"
-        + " -o LocalCommand='ifconfig tun${toString v.localTunnel} ${v.localIPv4} pointopoint ${v.remoteIPv4} netmask 255.255.255.255; route add ${v.remoteIPv4}/32 dev tun${toString v.localTunnel}'"
-        + " -w ${toString v.localTunnel}:${toString v.remoteTunnel} ${v.target} -p ${toString v.targetPort}"
-        + " 'ifconfig tun${toString v.remoteTunnel} ${v.remoteIPv4} pointopoint ${v.localIPv4} netmask 255.255.255.255; route add ${v.localIPv4}/32 dev tun${toString v.remoteTunnel}'";
+
+      script = let
+        mkAddrConf = tun: localIP: remoteIP: concatStringsSep " && " [
+          "ip link set tun${toString tun} addrgenmode none"
+          "ip addr add ${localIP}/32 peer ${remoteIP} dev tun${toString tun}"
+          "ip link set tun${toString tun} up"
+        ];
+
+        localCommand = mkAddrConf v.localTunnel v.localIPv4 v.remoteIPv4;
+        remoteCommand = mkAddrConf v.remoteTunnel v.remoteIPv4 v.localIPv4;
+
+      in "ssh -i ${v.privateKey} -x"
+       + " -o StrictHostKeyChecking=no"
+       + " -o PermitLocalCommand=yes"
+       + " -o ServerAliveInterval=20"
+       + " -o LocalCommand='${localCommand}'"
+       + " -w ${toString v.localTunnel}:${toString v.remoteTunnel}"
+       + " ${v.target} -p ${toString v.targetPort}"
+       + " '${remoteCommand}'";
+
       serviceConfig =
         { Restart = "always";
           RestartSec = 20;


### PR DESCRIPTION
This should fix `encryptedLinksTo` for kernels with version 4.5 and later. I've tested this in production but currently I can't test `tests.functional.test_encrypted_links`, because I don't have (nor use) VirtualBox anymore.

So to anybody who's running VirtualBox, can you please run the following command in the checked out source tree of this branch and report success/failure back here?

``` shell-session
./dev-shell --command 'python tests.py tests.functional.test_encrypted_links'
```

Thanks a lot. Reviews are also welcome of course :-)

Cc: @rbvermaa
