### PR TITLE
Add support for ~/.aws/credentials

### DIFF
--- a/doc/manual/hacking.xml
+++ b/doc/manual/hacking.xml
@@ -43,7 +43,8 @@ Note that some of the tests involve the creation of EC2 resources and
 thus cost money.  You must set the environment variable
 <envar>EC2_ACCESS_KEY</envar> and (optionally)
 <envar>EC2_SECRET_KEY</envar>.  (If the latter is not set, it will be
-looked up in <filename>~/.ec2-keys</filename>, as described in <xref
+looked up in <filename>~/.ec2-keys</filename> or in
+<filename>~/.aws/credentials</filename>, as described in <xref
 linkend="sec-deploying-to-ec2"/>.)  To run a specific test, run
 <literal>python tests.py
 <replaceable>test-name</replaceable></literal>, e.g.

--- a/doc/manual/nixops.xml
+++ b/doc/manual/nixops.xml
@@ -215,7 +215,16 @@ cloud.</para>
     <listitem><para>AWS Secret Access Key used to communicate with the
     Amazon EC2 cloud.  It is only used if no secret key corresponding
     to the AWS Access Key ID is defined in
-    <filename>~/.ec2-keys</filename>.</para></listitem>
+    <filename>~/.ec2-keys</filename>
+    or <filename>~/.aws/credentials</filename>.</para></listitem>
+
+  </varlistentry>
+
+  <varlistentry><term><envar>AWS_SHARED_CREDENTIALS_FILE</envar></term>
+
+    <listitem><para>Alternative path to the the shared credentials
+    file, which is located in <filename>~/.aws/credentials</filename>
+    by default.</para></listitem>
 
   </varlistentry>
 
@@ -309,6 +318,42 @@ deployment.ec2.accessKeyId = "prod";
     This is useful if you have an AWS account with multiple user
     accounts and you don’t want to hard-code an Access Key ID in
     a NixOps specification.</para>
+
+    </listitem>
+
+  </varlistentry>
+
+  <varlistentry><term><filename>~/.aws/credentials</filename></term>
+
+    <listitem><para>This file pairs AWS Access Key IDs with their
+    corresponding Secret Access Keys under symbolic profile names.
+    It consists of sections marked by profile names. Sections contain
+    newline-separated "assignments" of "variables"
+    <literal>aws_access_key_id</literal> and <literal>aws_secret_access_key</literal>
+    to a desired Access Key ID and a Secret Access Key, respectively, e.g.:
+
+<programlisting>
+[dev]
+aws_access_key_id = AKIAIUTDLWJKSLSJDLDQ
+aws_secret_access_key = Grsjf37cDKKWndklek3jdxnSKE3fkskDLqdldDl/
+
+[prod]
+aws_access_key_id = AKIAEODJSLXMDLLJKDLW
+aws_secret_access_key = DLeodsk32kldlDLSKdflexfpgiklf130r4dl23qp
+</programlisting>
+
+    Symbolic profile names are specified in
+    <option>deployment.ec2.accessKeyId</option>, e.g.:
+
+<programlisting>
+deployment.ec2.accessKeyId = "prod";
+</programlisting>
+
+    If an actual Access Key IDs is used in
+    <option>deployment.ec2.accessKeyId</option> its corresponding Secret Access Key is
+    looked up under <literal>[default]</literal> profile name.
+    Location of credentials file can be customized by setting the
+    <envar>AWS_SHARED_CREDENTIALS_FILE</envar> environment variable. </para>
 
     </listitem>
 

--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -352,7 +352,7 @@ provision them.)</para>
 let
 
   region = "eu-west-1";
-  accessKeyId = "dev"; # symbolic name looked up in ~/.ec2-keys
+  accessKeyId = "dev"; # symbolic name looked up in ~/.ec2-keys or a ~/.aws/credentials profile name
 
   ec2 =
     { resources, ... }:
@@ -438,6 +438,21 @@ AKIAIUTDLWJKSLSJDLDQ Grsjf37cDKKWndklek3jdxnSKE3fkskDLqdldDl/ dev # my AWS devel
   Here <literal>dev</literal> is a symbolic name for the AWS account,
   which you can use in
   <varname>deployment.ec2.accessKeyId</varname>.</para>
+
+  <para>Also you can use a standard way of storing credentials in a
+  <filename>~/.aws/credentials</filename>:
+
+<programlisting>
+[dev]
+aws_access_key_id = AKIAIUTDLWJKSLSJDLDQ
+aws_secret_access_key = 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
+</programlisting>
+
+  Profile name <literal>dev</literal> is the same as a previously
+  mentioned symbolic name which you can set in
+  <varname>deployment.ec2.accessKeyId</varname>.
+  It is also possible to use an alternative credentials file by setting
+  the <envar>AWS_SHARED_CREDENTIALS_FILE</envar> environment variable.</para>
 
   <para>Alternatively, you can set the environment variables
   <envar>EC2_ACCESS_KEY</envar> and

--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -183,8 +183,10 @@ in
         deployment model, but looked up in the file
         <filename>~/.ec2-keys</filename>, which should specify, on
         each line, an Access Key ID followed by the corresponding
-        Secret Access Key.  If it does not appear in that file, the
-        environment variables environment variables
+        Secret Access Key. If the lookup was unsuccessful it is continued
+        in the standard AWS tools <filename>~/.aws/credentials</filename> file.
+        If it does not appear in these files, the
+        environment variables
         <envar>EC2_SECRET_KEY</envar> or
         <envar>AWS_SECRET_ACCESS_KEY</envar> are used.
       '';

--- a/nix/route53.nix
+++ b/nix/route53.nix
@@ -23,8 +23,10 @@ with lib;
         deployment model, but looked up in the file
         <filename>~/.ec2-keys</filename>, which should specify, on
         each line, an Access Key ID followed by the corresponding
-        Secret Access Key.  If it does not appear in that file, the
-        environment variables environment variables
+        Secret Access Key. If the lookup was unsuccessful it is continued
+        in the standard AWS tools <filename>~/.aws/credentials</filename> file.
+        If it does not appear in these files, the
+        environment variables
         <envar>EC2_SECRET_KEY</envar> or
         <envar>AWS_SECRET_ACCESS_KEY</envar> are used.
       '';


### PR DESCRIPTION
Fixes #396.

Now you can use a standard way to store credentials in `~/.aws/credentials`.
This default location can be changed by setting the `$AWS_SHARED_CREDENTIALS_FILE` variable.

Previously search for access keys was conducted first in `~/.ec2-keys`, then in the environment variables.
Now the priority order looks like this: `~/.ec2-keys` > `~/.aws/credentials` > env variables.

Also not directly related, but adding new option to decouple an actual `ec2.accessKeyId` from useful symbolic names could be a good idea (see discussion in the issue).