### PR TITLE
SNS fix

### DIFF
--- a/nixops/resources/sns_topic.py
+++ b/nixops/resources/sns_topic.py
@@ -133,7 +133,8 @@ class SNSTopicState(nixops.resources.ResourceState):
             for subscriber_endpoint, subscriber_arn in current_subscriptions_arns.items():
                 if subscriber_endpoint not in defn_endpoints:
                     self.log("removing SNS subscriber with endpoint '{0}'...".format(subscriber_endpoint))
-                    self._conn.unsubscribe(subscription=subscriber_arn)
+                    if subscriber_arn != "PendingConfirmation": 
+                     self._conn.unsubscribe(subscription=subscriber_arn)
 
         with self.depl._db:
             self.state = self.UP


### PR DESCRIPTION
AWS does not allow removing any "PendingConfirmation" subscriptions, if there is a pending one and it's removed from the deployment definition, it will be skipped and the subscriber can subscribe later and won't be removed until the next deployment. It's basically an issue from AWS.

Note that trying to delete a pending subscription breaks the deployment so this needs to be merged as soon as possible. Thanks in advance.
