### PR TITLE
virtualbox.{nix,py}: add .vcpu option

### DIFF
--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -62,6 +62,7 @@ to the configuration. Otherwise, VirtualBox will fail when it tries to open a gr
     { config, pkgs, ... }:
     { deployment.targetEnv = "virtualbox";
       deployment.virtualbox.memorySize = 1024; # megabytes
+      deployment.virtualbox.vcpu = 2; # number of cpu
     };
 }
 </programlisting>

--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -62,7 +62,7 @@ to the configuration. Otherwise, VirtualBox will fail when it tries to open a gr
     { config, pkgs, ... }:
     { deployment.targetEnv = "virtualbox";
       deployment.virtualbox.memorySize = 1024; # megabytes
-      deployment.virtualbox.vcpu = 2; # number of cpu
+      deployment.virtualbox.vcpu = 2; # number of cpus
     };
 }
 </programlisting>

--- a/nix/virtualbox.nix
+++ b/nix/virtualbox.nix
@@ -18,11 +18,19 @@ in
 
   options = {
 
-    deployment.virtualbox.vcpu = mkOption {
-      default = 1;
-      type = types.int;
+    deployment.virtualbox.vmFlags = mkOption {
+      default = [];
+      type = types.listOf types.string;
       description = ''
-        Number of Virtual CPUs.
+        Arbitrary string arguments to append to the modifyvm command.
+      '';
+    };
+
+    deployment.virtualbox.vcpu = mkOption {
+      default = null;
+      type = types.nullOr types.int;
+      description = ''
+        Number of Virtual CPUs.  Left unspecified if not provided.
       '';
     };
 

--- a/nix/virtualbox.nix
+++ b/nix/virtualbox.nix
@@ -18,6 +18,14 @@ in
 
   options = {
 
+    deployment.virtualbox.vcpu = mkOption {
+      default = 1;
+      type = types.int;
+      description = ''
+        Number of Virtual CPUs.
+      '';
+    };
+
     deployment.virtualbox.memorySize = mkOption {
       default = 512;
       type = types.int;

--- a/nixops/backends/virtualbox.py
+++ b/nixops/backends/virtualbox.py
@@ -350,9 +350,13 @@ class VirtualBoxState(MachineState):
         if not self.started:
             self._logged_exec(
                 ["VBoxManage", "modifyvm", self.vm_id,
-                 "--memory", str(defn.config["virtualbox"]["memorySize"]), "--vram", "10",
-                 "--nictype1", "virtio", "--nictype2", "virtio",
-                 "--nic2", "hostonly", "--hostonlyadapter2", "vboxnet0",
+                 "--memory", str(defn.config["virtualbox"]["memorySize"]),
+                 "--cpus", str(defn.config["virtualbox"]["vcpu"]),
+                 "--vram", "10",
+                 "--nictype1", "virtio",
+                 "--nictype2", "virtio",
+                 "--nic2", "hostonly",
+                 "--hostonlyadapter2", "vboxnet0",
                  "--nestedpaging", "off",
                  "--paravirtprovider", "kvm"])
 

--- a/nixops/backends/virtualbox.py
+++ b/nixops/backends/virtualbox.py
@@ -348,17 +348,23 @@ class VirtualBoxState(MachineState):
             (self._client_private_key, self._client_public_key) = nixops.util.create_key_pair()
 
         if not self.started:
-            self._logged_exec(
-                ["VBoxManage", "modifyvm", self.vm_id,
+            modifyvm_args = [
                  "--memory", str(defn.config["virtualbox"]["memorySize"]),
-                 "--cpus", str(defn.config["virtualbox"]["vcpu"]),
                  "--vram", "10",
                  "--nictype1", "virtio",
                  "--nictype2", "virtio",
                  "--nic2", "hostonly",
                  "--hostonlyadapter2", "vboxnet0",
                  "--nestedpaging", "off",
-                 "--paravirtprovider", "kvm"])
+                 "--paravirtprovider", "kvm"
+            ]
+            vcpus = defn.config["virtualbox"]["vcpu"]  # None or integer
+            if vcpus is not None:
+                modifyvm_args.extend(["--cpus", str(vcpus)])
+            # Include arbitrary additional arguments
+            modifyvm_args.extend(defn.config["virtualbox"]["vmFlags"])
+            self._logged_exec(
+                ["VBoxManage", "modifyvm", self.vm_id] + modifyvm_args)
 
             self._headless = defn.config["virtualbox"]["headless"]
             self._start()


### PR DESCRIPTION
We follow the naming convention used by libvirt, and convert this
option to a "--cpu" command line option for VBoxManage.