### PR TITLE
Fixes #547 by using pysqlite2

### DIFF
--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -3,7 +3,7 @@
 import nixops.deployment
 import os
 import os.path
-import sqlite3
+from pysqlite2 import dbapi2 as sqlite3
 import sys
 import threading
 
@@ -25,6 +25,8 @@ class Connection(sqlite3.Connection):
         if self.nesting == 0:
             self.must_rollback = False
         self.nesting = self.nesting + 1
+        sqlite3.Connection.__enter__(self)
+
 
     def __exit__(self, exception_type, exception_value, exception_traceback):
         if exception_type != None: self.must_rollback = True
@@ -37,7 +39,7 @@ class Connection(sqlite3.Connection):
                 except sqlite3.ProgrammingError:
                     pass
             else:
-                self.commit()
+                sqlite3.Connection.__exit__(self, exception_type, exception_value, exception_traceback)
         self.lock.release()
 
 
@@ -65,7 +67,7 @@ class StateFile(object):
 
         if os.path.splitext(db_file)[1] not in ['.nixops', '.charon']:
             raise Exception("state file ‘{0}’ should have extension ‘.nixops’".format(db_file))
-        db = sqlite3.connect(db_file, timeout=60, check_same_thread=False, factory=Connection) # FIXME
+        db = sqlite3.connect(db_file, timeout=60, check_same_thread=False, factory=Connection, isolation_level=None) # FIXME
         db.db_file = db_file
 
         db.execute("pragma journal_mode = wal")

--- a/release.nix
+++ b/release.nix
@@ -88,7 +88,8 @@ rec {
           azure-mgmt-resource
           azure-mgmt-storage
           adal
-          sqlite3
+          # Go back to sqlite once Python 2.7.13 is released
+          pysqlite
           datadog
         ];
 


### PR DESCRIPTION
#547

Upstream Python fixes this, but it will only be
released in Python 2.7.13 (since 2.7.12 was just released, this will probably happen in a year).

See https://bugs.python.org/issue10513

I needed to set `isolation_level=None` so that setting WAL pragma doesn't complain we're in transaction mode.

cc @rbvermaa @edolstra 