### PR TITLE
libvirtd: fix deprecated boot loader timeout statement

### DIFF
--- a/nix/libvirtd-image.nix
+++ b/nix/libvirtd-image.nix
@@ -8,7 +8,7 @@ let
 
       boot.loader.grub.version = 2;
       boot.loader.grub.device = "/dev/sda";
-      boot.loader.grub.timeout = 0;
+      boot.loader.timeout = 0;
 
       services.openssh.enable = true;
       services.openssh.startWhenNeeded = false;

--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -119,7 +119,7 @@ in
 
     boot.loader.grub.version = 2;
     boot.loader.grub.device = "/dev/sda";
-    boot.loader.grub.timeout = 0;
+    boot.loader.timeout = 0;
 
     services.openssh.enable = true;
     services.openssh.startWhenNeeded = false;


### PR DESCRIPTION
Adjusts libvirtd provider to the renamed <code>boot.loader.timeout</code> statement.