### PR TITLE
Fix errata in nc option in nixops ssh into deployed container on remo…

### DIFF
--- a/nixops/backends/container.py
+++ b/nixops/backends/container.py
@@ -65,7 +65,7 @@ class ContainerState(MachineState):
         if self.host == "localhost":
             flags.extend(MachineState.get_ssh_flags(self))
         else:
-            cmd = "ssh -x -a root@{0} {1} nc -c {2} {3}".format(self.get_host_ssh(), " ".join(self.get_host_ssh_flags()), self.private_ipv4, self.ssh_port)
+            cmd = "ssh -x -a root@{0} {1} nc -C {2} {3}".format(self.get_host_ssh(), " ".join(self.get_host_ssh_flags()), self.private_ipv4, self.ssh_port)
             flags.extend(["-o", "ProxyCommand=" + cmd])
         return flags
 


### PR DESCRIPTION
…te machine.

When connecting a remote container via nixops ssh, the following error happened. 
```
$  nixops ssh -d query query 
nc: invalid option -- 'c'
usage: nc [-46bCDdhjklnrStUuvZz] [-I length] [-i interval] [-O length]
          [-P proxy_username] [-p source_port] [-q seconds] [-s source]
          [-T toskeyword] [-V rtable] [-w timeout] [-X proxy_protocol]
          [-x proxy_address[:port]] [destination] [port]
ssh_exchange_identification: Connection closed by remote host
query> could not connect to ‘root@mark.uphere.he~10.233.1.2’, retrying in 1 seconds...
```
This was because `-c` option should be `-C`. This pull request fixed the issue and I have tested that nixops ssh works well.