### PR TITLE
Move has_really_fast_connection() to Nix (deployment.hasFastConnection)

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -262,7 +262,7 @@ rec {
 
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
-        { inherit (v.config.deployment) targetEnv targetPort targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys;
+        { inherit (v.config.deployment) targetEnv targetPort targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys hasFastConnection;
           nixosRelease = v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
           azure = optionalAttrs (v.config.deployment.targetEnv == "azure")  v.config.deployment.azure;
           ec2 = optionalAttrs (v.config.deployment.targetEnv == "ec2") v.config.deployment.ec2;

--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -124,6 +124,8 @@ in
     services.openssh.enable = true;
     services.openssh.startWhenNeeded = false;
     services.openssh.extraConfig = "UseDNS no";
+
+    deployment.hasFastConnection = true;
 };
 
 }

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -102,6 +102,20 @@ in
       '';
     };
 
+    deployment.hasFastConnection = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        If set to <literal>true</literal>, whole closure will be copied using just `nix-copy-closure`.
+
+        If set to <literal>false</literal>, closure will be copied first using binary substitution.
+        Addtionally, any missing derivations copied with `nix-copy-closure` will be done
+        using <literal>--gzip</literal> flag.
+
+        Some backends set this value to <literal>true</literal>.
+      '';
+    };
+
     # Computed options useful for referring to other machines in
     # network specifications.
 

--- a/nix/virtualbox.nix
+++ b/nix/virtualbox.nix
@@ -120,6 +120,8 @@ in
 
     nixpkgs.system = mkOverride 900 "x86_64-linux";
 
+    deployment.hasFastConnection = true;
+
     # Add vboxsf support to initrd to support booting from
     # shared folders
     boot.initrd = mkIf (cfg.sharedFolders != {}) {

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -2,7 +2,6 @@
 
 import os
 import re
-import sys
 import subprocess
 
 import nixops.util
@@ -19,6 +18,7 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
         self.ssh_port = int(xml.find("attrs/attr[@name='targetPort']/int").get("value"))
         self.always_activate = xml.find("attrs/attr[@name='alwaysActivate']/bool").get("value") == "true"
         self.owners = [e.get("value") for e in xml.findall("attrs/attr[@name='owners']/list/string")]
+        self.has_fast_connection = xml.find("attrs/attr[@name='hasFastConnection']/bool").get("value") == "true"
 
         def _extract_key_options(x):
             opts = {}
@@ -36,6 +36,7 @@ class MachineState(nixops.resources.ResourceState):
     """Base class for NixOps machine state objects."""
 
     vm_id = nixops.util.attr_property("vmId", None)
+    has_fast_connection = nixops.util.attr_property("hasFastConnection", False, bool)
     ssh_pinged = nixops.util.attr_property("sshPinged", False, bool)
     ssh_port = nixops.util.attr_property("targetPort", 22, int)
     public_vpn_key = nixops.util.attr_property("publicVpnKey", None)
@@ -80,6 +81,7 @@ class MachineState(nixops.resources.ResourceState):
         self.store_keys_on_machine = defn.store_keys_on_machine
         self.keys = defn.keys
         self.ssh_port = defn.ssh_port
+        self.has_fast_connection = defn.has_fast_connection
 
     def stop(self):
         """Stop this machine, if possible."""
@@ -316,7 +318,7 @@ class MachineState(nixops.resources.ResourceState):
 
         # It's usually faster to let the target machine download
         # substitutes from nixos.org, so try that first.
-        if not self.has_really_fast_connection():
+        if not self.has_fast_connection:
             closure = subprocess.check_output(["nix-store", "-qR", path]).splitlines()
             ssh.run_command("nix-store -j 4 -r --ignore-unknown " + ' '.join(closure), check=False)
 
@@ -325,11 +327,8 @@ class MachineState(nixops.resources.ResourceState):
         env['NIX_SSHOPTS'] = ' '.join(ssh._get_flags() + ssh.get_master().opts)
         self._logged_exec(
             ["nix-copy-closure", "--to", ssh._get_target(), path]
-            + ([] if self.has_really_fast_connection() else ["--gzip"]),
+            + ([] if self.has_fast_connection else ["--gzip"]),
             env=env)
-
-    def has_really_fast_connection(self):
-        return False
 
     def generate_vpn_key(self, check=False):
         key_missing = False

--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -259,7 +259,7 @@ class HetznerState(MachineState):
 
         self.log_start("copying bootstrap files to rescue system... ")
         tarstream = subprocess.Popen([bootstrap], stdout=subprocess.PIPE)
-        if not self.has_really_fast_connection():
+        if not self.has_fast_connection:
             stream = subprocess.Popen(["gzip", "-c"], stdin=tarstream.stdout,
                                       stdout=subprocess.PIPE)
             self.run_command("gzip -d | ({0})".format(recv),

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -106,9 +106,6 @@ class LibvirtdState(MachineState):
         self.start()
         return True
 
-    def has_really_fast_connection(self):
-        return True
-
     def _disk_path(self, defn):
         return "{0}/{1}.img".format(defn.image_dir, self._vm_id())
 

--- a/nixops/backends/virtualbox.py
+++ b/nixops/backends/virtualbox.py
@@ -74,10 +74,6 @@ class VirtualBoxState(MachineState):
             return m.private_ipv4
         return MachineState.address_to(self, m)
 
-
-    def has_really_fast_connection(self):
-        return True
-
     @property
     def _vbox_version(self):
         v = getattr(self, '_vbox_version_obj', None)


### PR DESCRIPTION
This fixes #551 #513

I actually would decouple `nix-copy-closure --gzip` and binary substitution, as they don't necessarily belong together.

If you're deploying 100 nodes, you might not want gzip as it's a huge overhead on the host machine, compressing all data. But the binary substitution might still do a good job deploying from S3. So anything we do not to overload the deployment host helps.

cc @edolstra @rbvermaa 