### PR TITLE
Attempt to fix an issue introduced by #548

### DIFF
--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -412,7 +412,7 @@ in
       options = {
         ec2 = mkOption {
           default = null;
-          type = with types; uniq (nullOr (submodule ec2DiskOptions));
+          type = with types; (nullOr (submodule ec2DiskOptions));
           description = ''
             EC2 disk to be attached to this mount point.  This is
             shorthand for defining a separate


### PR DESCRIPTION
The EC2 deployments evaluations are failing after the optionSet -> submodule PR merge.
```
[nix-shell:~/work/nixops]$ nixops info -d minimal-lb 
error: attribute ‘cipher’ missing, at /home/aminechikhaoui/work/nixops/nix/ec2.nix:461:10
(use ‘--show-trace’ to show detailed location information)
warning: evaluation of the deployment specification failed; status info may be incorrect
```
Removing the types.uniq looks like a possible fix but I wasn't able to understand the issue or why removing that is fixing it.

@domenkozar @rbvermaa any ideas ?