### PR TITLE
libvirtd : Allow instanciating vms on a remote host

### DIFF
--- a/examples/trivial-remote-virtd.nix
+++ b/examples/trivial-remote-virtd.nix
@@ -1,0 +1,7 @@
+{
+  machine =
+    { deployment.targetEnv = "libvirtd";
+      deployment.libvirtd.headless = true;
+      deployment.libvirtd.targetHost = "my.machine.net";
+    };
+}

--- a/examples/trivial-virtd-in-vbox.nix
+++ b/examples/trivial-virtd-in-vbox.nix
@@ -1,0 +1,29 @@
+{
+  vbox =
+    {
+      deployment.targetEnv = "virtualbox";
+      virtualisation.libvirtd.enable = true;
+      networking.firewall.checkReversePath = false;
+
+      users.users.libvirtd_master = {
+        extraGroups = [ "libvirtd" ];
+        openssh.authorizedKeys.keys = [ "my-ssh-public-key" ];
+      };
+      system.activationScripts.createLibvirtdImageDir = {
+        text = ''
+          mkdir -p /var/lib/libvirtd/images
+          chown libvirtd_master:libvirtd /var/lib/libvirtd/images
+        '';
+        deps = [];
+      };
+    };
+
+  machine =
+    { resources, ... }:
+    { deployment.targetEnv = "libvirtd";
+      deployment.libvirtd.host = resources.machines.vbox;
+      deployment.libvirtd.remote_user = "libvirtd_master";
+      deployment.libvirtd.headless = true;
+    };
+}
+

--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -32,6 +32,12 @@ let
         umount /mnt
       ''
   );
+  machine = mkOptionType {
+    name = "a machine";
+    check = x: x._type or "" == "machine";
+    merge = mergeOneOption;
+  };
+
 in
 
 {
@@ -105,6 +111,26 @@ in
       default = "";
       type = types.str;
       description = "Additional XML appended at the end of domain xml. See https://libvirt.org/formatdomain.html";
+    };
+
+    deployment.libvirtd.host = mkOption {
+      default = "localhost";
+      example = "example.com";
+      type = types.either types.str machine;
+      apply = x: if builtins.isString x then x else "__machine-" + x._name;
+      description = "Host on which instanciate the VM";
+    };
+
+    deployment.libvirtd.remote_user = mkOption {
+      default = "root";
+      type = types.nullOr types.str;
+      example = "myUsername";
+      description = ''
+        The user which will manage machines on the remote host.
+        This user must be on the libvirtd group and be a nix trusted user.
+
+        This option has no effect if deployment.libvirtd.host is "localhost"
+      '';
     };
   };
 

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -337,7 +337,7 @@ class MachineState(nixops.resources.ResourceState):
 
         # Any remaining paths are copied from the local machine.
         env = dict(os.environ)
-        env['NIX_SSHOPTS'] = ' '.join(ssh._get_flags() + ssh.get_master().opts)
+        env['NIX_SSHOPTS'] ='"' + '" "'.join(ssh._get_flags() + ssh.get_master().opts) + '"'
         self._logged_exec(
             ["nix-copy-closure", "--to", ssh._get_target(), path]
             + ([] if self.has_fast_connection else ["--gzip"]),

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -113,6 +113,13 @@ class LibvirtdState(MachineState):
                 self.get_host_user()
             )
 
+    def create_after(self, resources, defn):
+        host = defn.host if defn else self.host
+        if host and host.startswith("__machine-"):
+            return {self.depl.get_machine(host[10:])}
+        else:
+            return {}
+
     def _vm_id(self):
         return "nixops-{0}-{1}".format(self.depl.uuid, self.name)
 


### PR DESCRIPTION
Nixops has a libvirtd backend, but it is only able to instanciate vms
on the local machine.

This pr adds a `deployment.libvirtd.host` option (and also a
`deployment.libvirtd.remote_user` option) to define a vm that will be
instanciated on another machine.