### PR TITLE
libvirt: Add different options for VM IP detection

### DIFF
--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -95,6 +95,17 @@ in
       description = "Names of libvirt networks to attach the VM to.";
     };
 
+    deployment.libvirtd.privateIPv4 = mkOption {
+      default = "dhcp";
+      example = "10.1.2.3";
+      type = types.str;
+      description = ''
+        IP to use to ssh into the machine.
+        Put 'dhcp' to let nixops get the IP from libvirt's dhcp (works with default libvirt network);
+        put 'arp' to let nixops detect IP in the host's ARP table (works with most setups).
+      '';
+    };
+
     deployment.libvirtd.extraDevicesXML = mkOption {
       default = "";
       type = types.str;

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -7,6 +7,7 @@ import random
 import string
 import subprocess
 import time
+import re
 from xml.etree import ElementTree
 
 from nixops.backends import MachineDefinition, MachineState
@@ -31,6 +32,7 @@ class LibvirtdDefinition(MachineDefinition):
         self.extra_domain = x.find("attr[@name='extraDomainXML']/string").get("value")
         self.headless = x.find("attr[@name='headless']/bool").get("value") == 'true'
         self.image_dir = x.find("attr[@name='imageDir']/string").get("value")
+        self.private_ipv4_setting = x.find("attr[@name='privateIPv4']/string").get("value")
         assert self.image_dir is not None
 
         self.networks = [
@@ -41,6 +43,7 @@ class LibvirtdDefinition(MachineDefinition):
 
 class LibvirtdState(MachineState):
     private_ipv4 = nixops.util.attr_property("privateIpv4", None)
+    private_ipv4_setting = nixops.util.attr_property("libvirtd.privateIpv4Setting", "dhcp") # Default for retro-compatibility
     client_public_key = nixops.util.attr_property("libvirtd.clientPublicKey", None)
     client_private_key = nixops.util.attr_property("libvirtd.clientPrivateKey", None)
     domain_xml = nixops.util.attr_property("libvirtd.domainXML", None)
@@ -68,6 +71,7 @@ class LibvirtdState(MachineState):
     def create(self, defn, check, allow_reboot, allow_recreate):
         assert isinstance(defn, LibvirtdDefinition)
         self.set_common_state(defn)
+        self.private_ipv4_setting = defn.private_ipv4_setting
         self.domain_xml = self._make_domain_xml(defn)
 
         if not self.client_public_key:
@@ -143,34 +147,64 @@ class LibvirtdState(MachineState):
             defn.vcpu
         )
 
-    def _get_ip(self):
-        xml = subprocess.check_output(["virsh", "-c", "qemu:///system", "dumpxml", self.vm_id])
-        tree = ElementTree.fromstring(xml)
-        interface = tree.find("devices/interface[@type=network][1]")
-        mac = interface.find("mac").get("address")
-        net = interface.find("source").get("network")
+    def _fetch_ip(self):
+        if re.match("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$", self.private_ipv4_setting):
+            return self.private_ipv4_setting
 
+        elif self.private_ipv4_setting == "arp":
+            # Inspired from https://rwmj.wordpress.com/2010/10/26/tip-find-the-ip-address-of-a-virtual-machine/
+            xml = subprocess.check_output(["virsh", "-c", "qemu:///system", "dumpxml", self.vm_id])
+            tree = ElementTree.fromstring(xml)
+            macs = [x.get("address") for x in tree.findall("devices/interface/mac")]
+            if len(macs) == 0:
+                raise Exception('VM has no interface configured; aborting')
+            self.log("Found MAC addresses " + repr(macs))
 
-        cmd = [ "virsh", "-c", "qemu:///system", "net-dhcp-leases", "--network", net ]
-        lines = subprocess.check_output(cmd).split()
-        try:
-            i = lines.index(mac)
-        except ValueError:
-            pass
+            self.log_start("Waiting for IP address to appear in the ARP table...")
+            while True:
+                lines = subprocess.check_output(["arp", "-an"]).split("\n")
+                for line in lines:
+                    r = re.match('[^()]+ \(([0-9.]+)\) at ([0-9a-f:]+) ', line)
+                    if not r: continue
+                    for mac in macs:
+                        if r.group(2) == mac:
+                            ip = r.group(1)
+                            self.log_end(" " + ip)
+                            return ip
+
+                self.log_continue(".")
+                time.sleep(1)
+
+        elif self.private_ipv4_setting == "dhcp":
+            xml = subprocess.check_output(["virsh", "-c", "qemu:///system", "dumpxml", self.vm_id])
+            tree = ElementTree.fromstring(xml)
+            interfaces = tree.findall("devices/interface[@type='network']")
+            nets = [(x.find("source").get("network"), x.find("mac").get("address")) for x in interfaces]
+            if len(nets) == 0:
+                raise Exception('VM has no networks configured; aborting')
+            self.log("Found networks/MAC pairs " + repr(nets))
+
+            self.log_start("Waiting for IP address to appear in DHCP leases...")
+            while True:
+                for net, mac in nets:
+                    # TODO: parse command output with a proper regexp, and/or use "net-dhcp-leases --network <network> [--mac <mac>]"
+                    cmd = [ "virsh", "-c", "qemu:///system", "net-dhcp-leases", "--network", net ]
+                    lines = subprocess.check_output(cmd).split()
+                    try:
+                        i = lines.index(mac)
+                    except ValueError:
+                        continue
+                    else:
+                        ip_with_subnet = lines[i + 2]
+                        ip = ip_with_subnet.split('/')[0]
+                        self.log_end(" " + ip)
+                        return ip
+
+                self.log_continue(".")
+                time.sleep(1)
+
         else:
-            ip_with_subnet = lines[i + 2]
-            return ip_with_subnet.split('/')[0]
-
-    def _wait_for_ip(self):
-        self.log_start("waiting for IP address to appear in DHCP leases...")
-        while True:
-            ip = self._get_ip()
-            if ip:
-                self.private_ipv4 = ip
-                break
-            time.sleep(1)
-            self.log_continue(".")
-        self.log_end(" " + self.private_ipv4)
+            raise Exception('"{}" is not a valid value for deployment.libvirtd.privateIPv4'.format(self.private_ipv4_setting))
 
     def _is_running(self):
         ls = subprocess.check_output(["virsh", "-c", "qemu:///system", "list"])
@@ -181,13 +215,12 @@ class LibvirtdState(MachineState):
         assert self.domain_xml
         if self._is_running():
             self.log("connecting...")
-            self.private_ipv4 = self._get_ip()
         else:
             self.log("starting...")
             dom_file = self.depl.tempdir + "/{0}-domain.xml".format(self.name)
             nixops.util.write_file(dom_file, self.domain_xml)
             self._logged_exec(["virsh", "-c", "qemu:///system", "create", dom_file])
-            self._wait_for_ip()
+        self.private_ipv4 = self._fetch_ip()
 
     def get_ssh_name(self):
         assert self.private_ipv4


### PR DESCRIPTION
This PR adds different methods for detecting the VM's IP address, in case DHCP is not used for example.
It also removes the hacky way to get static MACs since we can get the devices' MAC from libvirt. I understand this could cause libvirt's DHCP to more often assign different IPs to a given machine across deployments. I however believe that people needing a static IP should not have to rely on a DHCP anyways (I'm working on enabling that too).