### PR TITLE
libvirt: Allow control over boot image configuration

### DIFF
--- a/nix/libvirtd-image.nix
+++ b/nix/libvirtd-image.nix
@@ -1,82 +1,132 @@
-{ system ? builtins.currentSystem, size ? "10", config }:
-let
-  pkgs = import <nixpkgs> {};
-  cfg = (import <nixpkgs/nixos/lib/eval-config.nix> {
-    inherit system;
-    modules = [ config ];
-  }).config;
+rec {
+  base_image_config = {
+    fileSystems."/".device = "/dev/disk/by-label/nixos";
 
-in pkgs.vmTools.runInLinuxVM (
-  # TODO: Use <nixpkgs/nixos/lib/make-disk-image.nix> when
-  # https://github.com/NixOS/nixpkgs/issues/20471 is fixed
-  pkgs.runCommand "libvirtd-image"
-    { memSize = 768;
-      preVM =
+    boot.loader.grub.version = 2;
+    boot.loader.grub.device = "/dev/sda";
+    boot.loader.timeout = 0;
+  };
+
+
+  create_nixos_image = {
+    system ? builtins.currentSystem,
+    pkgs ? import <nixpkgs> {},
+    size ? "10",
+    config ? base_image_config
+  }:
+  let
+    cfg = (import <nixpkgs/nixos/lib/eval-config.nix> {
+      inherit system;
+      modules = [ config ];
+    }).config;
+
+  in pkgs.vmTools.runInLinuxVM (
+    # TODO: Use <nixpkgs/nixos/lib/make-disk-image.nix> when
+    # https://github.com/NixOS/nixpkgs/issues/20471 is fixed
+    pkgs.runCommand "libvirtd-image"
+      { memSize = 768;
+        preVM =
+          ''
+            mkdir $out
+            diskImage=$out/image
+            ${pkgs.vmTools.qemu}/bin/qemu-img create -f qcow2 $diskImage "${size}G"
+            mv closure xchg/
+          '';
+        postVM =
+          ''
+            mv $diskImage $out/disk.qcow2
+          '';
+        buildInputs = [ pkgs.utillinux pkgs.perl ];
+        exportReferencesGraph =
+          [ "closure" cfg.system.build.toplevel ];
+      }
+      ''
+        # Create a single / partition.
+        ${pkgs.parted}/sbin/parted /dev/vda mklabel msdos
+        ${pkgs.parted}/sbin/parted /dev/vda -- mkpart primary ext2 1M -1s
+        . /sys/class/block/vda1/uevent
+        mknod /dev/vda1 b $MAJOR $MINOR
+
+        # Create an empty filesystem and mount it.
+        ${pkgs.e2fsprogs}/sbin/mkfs.ext4 -L nixos /dev/vda1
+        ${pkgs.e2fsprogs}/sbin/tune2fs -c 0 -i 0 /dev/vda1
+        mkdir /mnt
+        mount /dev/vda1 /mnt
+
+        # The initrd expects these directories to exist.
+        mkdir /mnt/dev /mnt/proc /mnt/sys
+        mount --bind /proc /mnt/proc
+        mount --bind /dev /mnt/dev
+        mount --bind /sys /mnt/sys
+
+        # Copy all paths in the closure to the filesystem.
+        storePaths=$(perl ${pkgs.pathsFromGraph} /tmp/xchg/closure)
+
+        echo "filling Nix store..."
+        mkdir -p /mnt/nix/store
+        set -f
+        cp -prd $storePaths /mnt/nix/store/
+
+        mkdir -p /mnt/etc/nix
+        echo 'build-users-group = ' > /mnt/etc/nix/nix.conf
+
+        # Register the paths in the Nix database.
+        printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \
+            chroot /mnt ${cfg.nix.package.out}/bin/nix-store --load-db
+
+        # Create the system profile to allow nixos-rebuild to work.
+        chroot /mnt ${cfg.nix.package.out}/bin/nix-env \
+            -p /nix/var/nix/profiles/system --set ${cfg.system.build.toplevel}
+
+        # `nixos-rebuild' requires an /etc/NIXOS.
+        mkdir -p /mnt/etc/nixos
+        touch /mnt/etc/NIXOS
+
+        # `switch-to-configuration' requires a /bin/sh
+        mkdir -p /mnt/bin
+        ln -s ${cfg.system.build.binsh}/bin/sh /mnt/bin/sh
+
+        # Generate the GRUB menu.
+        ln -s vda /dev/sda
+        chroot /mnt ${cfg.system.build.toplevel}/bin/switch-to-configuration boot
+
+        umount /mnt/proc /mnt/dev /mnt/sys
+        umount /mnt
+      ''
+  );
+
+
+  edit_image = {
+    pkgs ? import <nixpkgs> {},
+    base_image,
+    cmd
+  }:
+    pkgs.vmTools.runInLinuxVM (
+      pkgs.runCommand "libvirtd-edit-image"
+        { memSize = 768;
+          preVM =
+            ''
+              mkdir $out
+              diskImage=$out/image
+              ${pkgs.vmTools.qemu}/bin/qemu-img create -f qcow2 -b ${base_image}/disk.qcow2 $diskImage
+            '';
+          buildInputs = [ pkgs.utillinux ];
+          postVM =
+            ''
+              mv $diskImage $out/disk.qcow2
+            '';
+        }
         ''
-          mkdir $out
-          diskImage=$out/image
-          ${pkgs.vmTools.qemu}/bin/qemu-img create -f qcow2 $diskImage "${size}G"
-          mv closure xchg/
-        '';
-      postVM =
+          . /sys/class/block/vda1/uevent
+          mknod /dev/vda1 b $MAJOR $MINOR
+          mkdir /mnt
+          mount /dev/vda1 /mnt
+
+          ${cmd}
+
+          umount /mnt
         ''
-          mv $diskImage $out/disk.qcow2
-        '';
-      buildInputs = [ pkgs.utillinux pkgs.perl ];
-      exportReferencesGraph =
-        [ "closure" cfg.system.build.toplevel ];
-    }
-    ''
-      # Create a single / partition.
-      ${pkgs.parted}/sbin/parted /dev/vda mklabel msdos
-      ${pkgs.parted}/sbin/parted /dev/vda -- mkpart primary ext2 1M -1s
-      . /sys/class/block/vda1/uevent
-      mknod /dev/vda1 b $MAJOR $MINOR
+    );
 
-      # Create an empty filesystem and mount it.
-      ${pkgs.e2fsprogs}/sbin/mkfs.ext4 -L nixos /dev/vda1
-      ${pkgs.e2fsprogs}/sbin/tune2fs -c 0 -i 0 /dev/vda1
-      mkdir /mnt
-      mount /dev/vda1 /mnt
 
-      # The initrd expects these directories to exist.
-      mkdir /mnt/dev /mnt/proc /mnt/sys
-      mount --bind /proc /mnt/proc
-      mount --bind /dev /mnt/dev
-      mount --bind /sys /mnt/sys
-
-      # Copy all paths in the closure to the filesystem.
-      storePaths=$(perl ${pkgs.pathsFromGraph} /tmp/xchg/closure)
-
-      echo "filling Nix store..."
-      mkdir -p /mnt/nix/store
-      set -f
-      cp -prd $storePaths /mnt/nix/store/
-
-      mkdir -p /mnt/etc/nix
-      echo 'build-users-group = ' > /mnt/etc/nix/nix.conf
-
-      # Register the paths in the Nix database.
-      printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \
-          chroot /mnt ${cfg.nix.package.out}/bin/nix-store --load-db
-
-      # Create the system profile to allow nixos-rebuild to work.
-      chroot /mnt ${cfg.nix.package.out}/bin/nix-env \
-          -p /nix/var/nix/profiles/system --set ${cfg.system.build.toplevel}
-
-      # `nixos-rebuild' requires an /etc/NIXOS.
-      mkdir -p /mnt/etc/nixos
-      touch /mnt/etc/NIXOS
-
-      # `switch-to-configuration' requires a /bin/sh
-      mkdir -p /mnt/bin
-      ln -s ${cfg.system.build.binsh}/bin/sh /mnt/bin/sh
-
-      # Generate the GRUB menu.
-      ln -s vda /dev/sda
-      chroot /mnt ${cfg.system.build.toplevel}/bin/switch-to-configuration boot
-
-      umount /mnt/proc /mnt/dev /mnt/sys
-      umount /mnt
-    ''
-)
+}

--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -13,13 +13,13 @@ let
     services.openssh.extraConfig = "UseDNS no";
   };
 
-  ssh_image = if config.deployment.libvirtd.boot_config == null then
-    let base_image = libvirt_image_helpers.create_nixos_image {
-          size = sz;
-          config = base_config;
-        };
+  base_image = libvirt_image_helpers.create_nixos_image {
+    size = sz;
+    config = base_config;
+  };
 
-    in libvirt_image_helpers.edit_image {
+  ssh_image = if config.deployment.libvirtd.boot_config == null then
+    libvirt_image_helpers.edit_image {
       inherit pkgs base_image;
       cmd = ''
         mkdir -p /mnt/etc/ssh/authorized_keys.d
@@ -28,9 +28,8 @@ let
     }
 
   else
-    libvirt_image_helpers.create_nixos_image {
-      inherit pkgs;
-      size = sz;
+    libvirt_image_helpers.deploy_in_nixos_image {
+      inherit pkgs base_image;
       config.imports = [
         base_config
         { users.users.root.openssh.authorizedKeys.keys = [ ssh_pubkey ]; }


### PR DESCRIPTION
This PR adds a deployment.libvirtd.boot_config option that is used to specify the NixOS configuration to use for the first boot.
This is useful in non-standard configurations, for example in networks without DHCP, in case of needing external filesystems, or if special devices are enabled.
It ensures sharing of the base image to make build times reasonable.