### PR TITLE
libvirt: Fix #584

### DIFF
--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -100,8 +100,8 @@ class LibvirtdState(MachineState):
             self.disk_path = self._disk_path(defn)
             self._logged_exec(["qemu-img", "create", "-f", "qcow2", "-b",
                                base_image + "/disk.qcow2", self.disk_path])
-            # TODO: use libvirtd.extraConfig to make the image accessible for your user
-            os.chmod(self.disk_path, 0666)
+            os.chmod(self.disk_path, 0660)
+
             self.vm_id = self._vm_id()
         self.start()
         return True


### PR DESCRIPTION
This PR makes the libvirt images readable only by their owner/group (i.e. the user/group under which is run qemu, by default root/root on NixOS afaik). It fixes a critical vulnerability in the libvirt backend.
The user does not actually need read/write permissions on that file for nixops to run correctly. If they want access to that file for other reasons, they should configure their libvirt installation to manage permissions accordingly (see e.g. https://libvirt.org/drvqemu.html#securitydac).