### PR TITLE
Datadog monitors: fix #611

### DIFF
--- a/nix/datadog-monitor.nix
+++ b/nix/datadog-monitor.nix
@@ -18,7 +18,7 @@ with lib;
         name = mkOption {
           default = "datadog-monitor-${uuid}-${name}";
           type = types.str;
-          description = "Name of the datadog resource.";
+          description = "Name of the alert which will show up in the subject line of the email.";
         };
         type = mkOption {
           type = types.str;

--- a/nixops/datadog_utils.py
+++ b/nixops/datadog_utils.py
@@ -22,3 +22,6 @@ def get_template_variables(defn):
         tvariable['default'] = var['default']
         template_variables.append(tvariable)
     return template_variables
+
+def get_base_url():
+    return "https://app.datadoghq.com/"

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -42,6 +42,7 @@ class DatadogMonitorState(nixops.resources.ResourceState):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._dd_api = None
         self._key_options = None
+        self._monitor_url = nixops.datadog_utils.get_base_url()+"monitors#"
 
     def _exists(self):
         return self.state != self.MISSING
@@ -52,10 +53,16 @@ class DatadogMonitorState(nixops.resources.ResourceState):
 
     @property
     def resource_id(self):
-        return "https://app.datadoghq.com/monitors#{0}".format(self.monitor_id) if self.monitor_id else None 
-
+        return self._monitor_url + self.monitor_id if self.monitor_id else None
+    
     def get_definition_prefix(self):
         return "resources.datadogMonitors."
+
+    def get_physical_spec(self):
+        return {'url': self._monitor_url + self.monitor_id } if self.monitor_id else {} 
+
+    def prefix_definition(self, attr):
+        return {('resources', 'datadogMonitors'): attr}
 
     def connect(self, app_key, api_key):
         if self._dd_api: return

--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -52,9 +52,7 @@ class DatadogMonitorState(nixops.resources.ResourceState):
 
     @property
     def resource_id(self):
-        r = self.monitor_name
-        if self.monitor_id: r = "{0} [ {1} ]".format(r, self.monitor_id)
-        return r
+        return "https://app.datadoghq.com/monitors#{0}".format(self.monitor_id) if self.monitor_id else None 
 
     def get_definition_prefix(self):
         return "resources.datadogMonitors."

--- a/nixops/resources/datadog-screenboard.py
+++ b/nixops/resources/datadog-screenboard.py
@@ -43,6 +43,7 @@ class DatadogScreenboardState(nixops.resources.ResourceState):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._dd_api = None
         self._key_options = None
+        self._screen_url = nixops.datadog_utils.get_base_url()+"screen/"
 
     def show_type(self):
         s = super(DatadogScreenboardState, self).show_type()
@@ -50,9 +51,13 @@ class DatadogScreenboardState(nixops.resources.ResourceState):
 
     @property
     def resource_id(self):
-        r = self.board_title
-        if self.screenboard_id: r = "{0} [ {1} ]".format(r, self.screenboard_id)
-        return r
+        return self._screen_url + self.screenboard_id if self.screenboard_id else None
+
+    def get_physical_spec(self):
+        return {'url': self._screen_url + self.screenboard_id } if self.screenboard_id else {} 
+
+    def prefix_definition(self, attr):
+        return {('resources', 'datadogScreenboards'): attr}
 
     def get_definition_prefix(self):
         return "resources.datadogScreenboards."

--- a/nixops/resources/datadog-timeboard.py
+++ b/nixops/resources/datadog-timeboard.py
@@ -42,6 +42,7 @@ class DatadogTimeboardState(nixops.resources.ResourceState):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._dd_api = None
         self._key_options = None
+        self._dash_url = nixops.datadog_utils.get_base_url()+"dash/"
 
     def show_type(self):
         s = super(DatadogTimeboardState, self).show_type()
@@ -49,15 +50,13 @@ class DatadogTimeboardState(nixops.resources.ResourceState):
 
     @property
     def resource_id(self):
-        t = self.title
-        if self.url: t = "{0} [ {1} ]".format(t, self.url)
-        return t
+        return self._dash_url + self.timeboard_id if self.timeboard_id else None
 
     def prefix_definition(self, attr):
         return {('resources', 'datadogTimeboards'): attr}
 
     def get_physical_spec(self):
-        return {'url': self.url}
+        return {'url': self._dash_url + self.timeboard_id } if self.timeboard_id else {} 
 
     def get_definition_prefix(self):
         return "resources.datadogTimeboards."


### PR DESCRIPTION
This allows showing URL links in the output of `nixops info` instead of subject lines + monitor ids which might be too long in certain cases

Example of the new output:
```
+----------------------+----------------------+--------------------+--------------------------------------------+------------+
| Name                 |        Status        | Type               | Resource Id                                | IP address |
+----------------------+----------------------+--------------------+--------------------------------------------+------------+
| disk-usage-monitor   |   Up / Up-to-date    | datadog-monitor    | https://app.datadoghq.com/monitors#1666820 |            |
| memory-monitor       |   Up / Up-to-date    | datadog-monitor    | https://app.datadoghq.com/monitors#1666822 |            |
| no-data-monitor      |   Up / Up-to-date    | datadog-monitor    | https://app.datadoghq.com/monitors#1666819 |            |
| unit-failure-monitor |   Up / Up-to-date    | datadog-monitor    | https://app.datadoghq.com/monitors#1666821 |            |
| machine              |  Missing / Outdated  | ec2                |                                            |            |
| keypair              | Missing / Up-to-date | ec2-keypair        |                                            |            |
| sg                   | Unknown / Up-to-date | ec2-security-group |                                            |            |
+----------------------+----------------------+--------------------+--------------------------------------------+------------+

```
Not sure if it's better to set the base URL of datadog i.e `https://app.datadoghq.com/monitors#` in a different place instead of hardcoding it in code, but in any case this doesn't have any effect other than the info output afaik so even of the base URL might change in the future that can be patched.

**Update:** I made the same changes to the other Datadog resources to be more consistent.