### PR TITLE
Remove -c switch in call to nc of container backend

### DIFF
--- a/nixops/backends/container.py
+++ b/nixops/backends/container.py
@@ -65,7 +65,7 @@ class ContainerState(MachineState):
         if self.host == "localhost":
             flags.extend(MachineState.get_ssh_flags(self))
         else:
-            cmd = "ssh -x -a root@{0} {1} nc -c {2} {3}".format(self.get_host_ssh(), " ".join(self.get_host_ssh_flags()), self.private_ipv4, self.ssh_port)
+            cmd = "ssh -x -a root@{0} {1} nc {2} {3}".format(self.get_host_ssh(), " ".join(self.get_host_ssh_flags()), self.private_ipv4, self.ssh_port)
             flags.extend(["-o", "ProxyCommand=" + cmd])
         return flags
 


### PR DESCRIPTION
Noticed that a call to "nixops ssh" did not work anymore after I upgraded the
target host to the current 17.03 channel.

Tracked the issue down to a change of the default netcat in the following PR:
https://github.com/NixOS/nixpkgs/pull/19982

I've found the PR https://github.com/NixOS/nixops/pull/559 which does seem to be wrong since `-C` (uppercase) has a different meaning than the `-c` from gnu-netcat.