### PR TITLE
Add functional tests for VirtualBox

### DIFF
--- a/doc/manual/hacking.xml
+++ b/doc/manual/hacking.xml
@@ -49,9 +49,19 @@ linkend="sec-deploying-to-ec2"/>.)  To run a specific test, run
 <literal>python2 tests.py
 <replaceable>test-name</replaceable></literal>, e.g.
 
+
 <screen>
 $ python2 tests.py tests.functional.test_encrypted_links
 </screen>
+
+To filter on which backends you want to run functional tests against, you can
+filter on one or more tags.
+To run e.g. only the virtualbox tests, run:
+
+<screen>
+$ python 2 tests.py tests.functional -A vbox
+</screen>
+
 
 There are also a few NixOS VM tests.  These can be run as follows:
 

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,6 +1,5 @@
 import os
 from os import path
-import sqlite3
 import nixops.statefile
 from tests import db_file
 

--- a/tests/functional/single_machine_test.py
+++ b/tests/functional/single_machine_test.py
@@ -15,6 +15,12 @@ class SingleMachineTest(generic_deployment_test.GenericDeploymentTest):
         super(SingleMachineTest,self).setup()
         self.depl.nix_exprs = [ logical_spec ]
 
+    def test_vbox(self):
+        self.depl.nix_exprs = self.depl.nix_exprs + [
+            ('%s/single_machine_vbox_base.nix' % (parent_dir))
+        ]
+        self.run_check()
+
     def test_ec2(self):
         self.depl.nix_exprs = self.depl.nix_exprs + [
             ('%s/single_machine_ec2_base.nix' % (parent_dir))

--- a/tests/functional/single_machine_test.py
+++ b/tests/functional/single_machine_test.py
@@ -1,6 +1,7 @@
 from os import path
 
 from nose import tools
+from nose.plugins.attrib import attr
 
 from tests.functional import generic_deployment_test
 
@@ -15,24 +16,28 @@ class SingleMachineTest(generic_deployment_test.GenericDeploymentTest):
         super(SingleMachineTest,self).setup()
         self.depl.nix_exprs = [ logical_spec ]
 
+    @attr("vbox")
     def test_vbox(self):
         self.depl.nix_exprs = self.depl.nix_exprs + [
             ('%s/single_machine_vbox_base.nix' % (parent_dir))
         ]
         self.run_check()
 
+    @attr("ec2")
     def test_ec2(self):
         self.depl.nix_exprs = self.depl.nix_exprs + [
             ('%s/single_machine_ec2_base.nix' % (parent_dir))
         ]
         self.run_check()
 
+    @attr("gce")
     def test_gce(self):
         self.depl.nix_exprs = self.depl.nix_exprs + [
             ('%s/single_machine_gce_base.nix' % (parent_dir))
         ]
         self.run_check()
 
+    @attr("azure")
     def test_azure(self):
         self.depl.nix_exprs = self.depl.nix_exprs + [
             ('%s/single_machine_azure_base.nix' % (parent_dir))

--- a/tests/functional/single_machine_vbox_base.nix
+++ b/tests/functional/single_machine_vbox_base.nix
@@ -1,0 +1,8 @@
+{
+  machine =
+    { ... }:
+    {
+      deployment.targetEnv = "virtualbox";
+      deployment.virtualbox.headless = true;
+    };
+}


### PR DESCRIPTION
The tests were broken, had to remove the `import sqlite3`. To only see the output for the VirtualBox tests, I added the test filters.

@rbvermaa @domenkozar @edolstra If you want me to change something, just tell me what you're not happy with ;)

---
#### Broken test

Unfortunately, one if the tests is broken.

I believe the error in the trace below implies that the virtualbox machine is still in the state `STARTING`.
What should I do here? Poll a few times with a timeout? Investigate why it is not `UP` yet?

Output:
```
$ ./dev-shell
$ python2 tests.py tests/functional/test_starting_starts.py -A vbox
machine> creating VirtualBox VM...
machine> Virtual machine 'nixops-3d2cda2b-0814-11e7-a541-208984d3285c-machine' is created and registered.
machine> UUID: cfd8d9e4-c089-45df-843a-6180eb528c1a
machine> Settings file: '/home/maarten/VirtualBox VMs/nixops-3d2cda2b-0814-11e7-a541-208984d3285c-machine/nixops-3d2cda2b-0814-11e7-a541-208984d3285c-machine.vbox'
machine> creating disk ‘disk1’...
machine> 0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
machine> Clone medium created in format 'VMDK'. UUID: eed45e43-cd18-4cc8-8ad3-d87943b568e4
machine> attaching disk ‘disk1’...
machine> Waiting for VM "nixops-3d2cda2b-0814-11e7-a541-208984d3285c-machine" to power on...
machine> VM "nixops-3d2cda2b-0814-11e7-a541-208984d3285c-machine" has been successfully started.
machine> waiting for IP address........................ 192.168.56.10
machine> setting state version to 16.09
machine> waiting for SSH...
building all machine configurations...
these derivations will be built:
  /nix/store/w3pxj06k6725avl2qfsv5j3kp23zpw1r-etc-ssh_known_hosts.drv
  /nix/store/3354g0m6a56fhswmw6gbxdrvdmhil9sl-etc.drv
  /nix/store/gynz7pdsi8xmwlsz16b72implwvk9xwa-nixos-system-machine-16.09.1647.ff7777b.drv
  /nix/store/nyrsrgnhbpig0h6hrk3fw9hs6yxm8szf-nixops-machines.drv
building path(s) ‘/nix/store/2rv4r74il51xrpj2hnp02a97iy0jq36p-etc-ssh_known_hosts’
building path(s) ‘/nix/store/a4pxq4kqx0f4j80b9j6p11r6525jymaf-etc’
building path(s) ‘/nix/store/vpmvd53fgpki51ilwsbyz69s725hcn97-nixos-system-machine-16.09.1647.ff7777b’
building path(s) ‘/nix/store/h3k9cllfnpjypzb313aksrzp3p94bnfs-nixops-machines’
machine> copying closure...
machine> copying 403 missing paths (732.23 MiB) to ‘root@192.168.56.10’...
None> closures copied successfully
machine> updating GRUB 2 menu...
machine> stopping the following units: alsa-store.service, audit.service, kmod-static-nodes.service, network-local-commands.service, network-setup.service, nix-daemon.service, nix-daemon.socket, nscd.service, ntpd.service, systemd-modules-load.service, systemd-sysctl.service, systemd-tmpfiles-clean.timer, systemd-tmpfiles-setup-dev.service, systemd-udev-trigger.service, systemd-udevd-control.socket, systemd-udevd-kernel.socket, systemd-udevd.service, systemd-vconsole-setup.service, virtualbox.service
machine> NOT restarting the following changed units: dhcpcd.service, getty@tty1.service, systemd-journal-flush.service, systemd-random-seed.service, systemd-remount-fs.service, systemd-tmpfiles-setup.service, systemd-update-utmp.service, systemd-user-sessions.service, user@0.service
machine> activating the configuration...
machine> setting up /etc...
machine> restarting systemd...
machine> reloading the following units: dbus.service, dev-hugepages.mount, dev-mqueue.mount, firewall.service, sys-kernel-debug.mount
machine> restarting the following units: sshd.service, systemd-journald.service, systemd-logind.service
machine> starting the following units: alsa-store.service, audit.service, kmod-static-nodes.service, network-local-commands.service, network-setup.service, nix-daemon.socket, nscd.service, ntpd.service, systemd-modules-load.service, systemd-sysctl.service, systemd-tmpfiles-clean.timer, systemd-tmpfiles-setup-dev.service, systemd-udev-trigger.service, systemd-udevd-control.socket, systemd-udevd-kernel.socket, systemd-vconsole-setup.service, virtualbox.service
machine> activation finished successfully
None> deployment finished successfully
machine> shutting down... Connection to 192.168.56.10 closed by remote host.
[running] 
machine> [running] 
machine> [running] 
machine> [poweroff] 
machine> starting...
machine> Waiting for VM "nixops-3d2cda2b-0814-11e7-a541-208984d3285c-machine" to power on...
machine> VM "nixops-3d2cda2b-0814-11e7-a541-208984d3285c-machine" has been successfully started.
machine> waiting for IP address... 192.168.56.10
ssh: connect to host 192.168.56.10 port 22: Connection timed out
Fwarning: are you sure you want to destroy VirtualBox VM ‘machine’? (y/N) y
machine> destroying VirtualBox VM...
machine> 0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
machine> 0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
deployment ‘3d2cda2b-0814-11e7-a541-208984d3285c’ destroyed

======================================================================
FAIL: tests.functional.test_starting_starts.TestStartingStarts.test_vbox
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/nix/store/rf16sxb3f5yzfnryl1f0ahychxn9403l-python2.7-nose-1.3.7/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/maarten/code/nixos/nixops/vbox-tests/tests/functional/single_machine_test.py", line 24, in test_vbox
    self.run_check()
  File "/home/maarten/code/nixos/nixops/vbox-tests/tests/functional/test_starting_starts.py", line 12, in run_check
    tools.assert_equal(m.state, m.UP)
AssertionError: 2 != 3

----------------------------------------------------------------------
Ran 1 test in 75.311s

FAILED (failures=1)

```