### PR TITLE
Fix incorrect environment variable name in DigitalOcean documentation

### DIFF
--- a/nix/digital-ocean.nix
+++ b/nix/digital-ocean.nix
@@ -17,7 +17,7 @@ in
       type = types.str;
       description = ''
         The API auth token. We're checking the environment for
-        <envar>DIGITAL_OCEAN_API_TOKEN</envar> first and if that is
+        <envar>DIGITAL_OCEAN_AUTH_TOKEN</envar> first and if that is
         not set we try this auth token.
       '';
     };


### PR DESCRIPTION
The code disagrees with the documentation; it [checks](https://github.com/NixOS/nixops/blob/985886cff4ac09c9cb635e31b45f0cc0dbd84e0a/nixops/backends/digital_ocean.py#L107) for `DIGITAL_OCEAN_AUTH_TOKEN`, not `DIGITAL_OCEAN_API_TOKEN`.