### PR TITLE
DigitalOcean backend: fix authToken, add IPv6 support.

### DIFF
--- a/nix/digital-ocean.nix
+++ b/nix/digital-ocean.nix
@@ -41,6 +41,14 @@ in
         https://developers.digitalocean.com/documentation/v2/#list-all-sizes
       '';
     };
+
+    deployment.digitalOcean.enableIpv6 = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Whether to enable IPv6 support on the droplet.
+      '';
+    };
   };
 
   config = mkIf (config.deployment.targetEnv == "digitalOcean") {

--- a/nixops/backends/digital_ocean.py
+++ b/nixops/backends/digital_ocean.py
@@ -30,6 +30,7 @@ import digitalocean
 
 infect_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'nixos-infect'))
 
+AUTH_TOKEN_ENV_VAR='DIGITAL_OCEAN_AUTH_TOKEN'
 
 class DigitalOceanDefinition(MachineDefinition):
     @classmethod
@@ -104,12 +105,12 @@ class DigitalOceanState(MachineState):
         }
 
     def get_auth_token(self):
-        return os.environ.get('DIGITAL_OCEAN_AUTH_TOKEN', self.auth_token)
+        return os.environ.get(AUTH_TOKEN_ENV_VAR)
 
     def destroy(self, wipe=False):
         self.log("destroying droplet {}".format(self.droplet_id))
         try:
-            droplet = digitalocean.Droplet(id=self.droplet_id, token=self.get_auth_token())
+            droplet = digitalocean.Droplet(id=self.droplet_id, token=self.auth_token)
             droplet.destroy()
         except digitalocean.baseapi.NotFoundError:
             self.log("droplet not found - assuming it's been destroyed already")
@@ -117,18 +118,24 @@ class DigitalOceanState(MachineState):
         self.droplet_id = None
 
     def create(self, defn, check, allow_reboot, allow_recreate):
+        assert isinstance(defn, DigitalOceanDefinition)
+
         ssh_key = self.depl.active_resources.get('ssh-key')
         if ssh_key is None:
             raise Exception('Please specify a ssh-key resource (resources.sshKeyPairs.ssh-key = {}).')
 
         self.set_common_state(defn)
 
+        self.auth_token = defn.auth_token or self.get_auth_token()
+        if not self.auth_token:
+            raise Exception("please set ‘deployment.digitalOcean.authToken’ or ${}".format(AUTH_TOKEN_ENV_VAR))
+
         if self.droplet_id is not None:
             return
 
-        self.manager = digitalocean.Manager(token=self.get_auth_token())
+        self.manager = digitalocean.Manager(token=self.auth_token)
         droplet = digitalocean.Droplet(
-            token=self.get_auth_token(),
+            token=self.auth_token,
             name=self.name,
             region=defn.region,
             ssh_keys=[ssh_key.public_key],


### PR DESCRIPTION
Currently, the DigitalOcean backend ignores the
`digitalOcean.authToken` config variable completely.

Additionally, the DigitalOcean backend requires that the
`DIGITAL_OCEAN_AUTH_TOKEN` environment variable is always set for any
NixOps operation on a DigitalOcean target (`create`, `deploy`, etc.),
because it does not persist the auth token value in the NixOps state
database.

This change modifies the DigitalOcean backend so that it treats auth
tokens like the EC2 backend treats AWS access keys; namely:

- Use the `digitalOcean.authToken` value, if specified in the
  deployment configuration. If both this value and the
  `DIGITAL_OCEAN_AUTH_TOKEN` environment variable are set, the backend
  prefers the `digitalOcean.authToken` value; this behavior is
  consistent with the EC2 backend and its preference of the
  `ec2.accessKeyId` value over the `AWS_ACCESS_KEY_ID` environment
  variable.

- When a DigitalOcean droplet is created, if neither auth token value
  is set, the backend aises an exception, rather than attempting to
  create the droplet anyway and failing with an error from the
  DigitalOcean API.

- Upon successful creation of a droplet, persist the DigitalOcean auth
  token used to create it in the NixOps state database. This happens
  regardless of whether the token was provided via the
  `digitalOcean.authToken` deployment configuration, or the
  `DIGITAL_OCEAN_AUTH_TOKEN` environment variable. Based on a review
  of the code in the EC2 backend, I believe this behavior is
  consistent with the EC2 backend, though I have not used the EC2
  backend myself to verify this.

- If the user does not set `digitalOcean.authToken` and uses the
  environment variable instead, the environment variable is only ever
  used to create the droplet; from that point on, NixOps will use the
  token value that was persisted in the NixOps state database. Again,
  based on a review of the code in the EC2 backend, I believe this
  behavior is consistent with the EC2 backend.