### PR TITLE
Adding `deployment.keyDirs` option to recursively deploy directories of keys

### DIFF
--- a/doc/manual/nixops.xml
+++ b/doc/manual/nixops.xml
@@ -621,8 +621,9 @@ specification described by the Nix expressions given in the preceding
 <command>nixops create</command> call.  It creates missing virtual
 machines, builds each machine configuration, copies the closure of
 each configuration to the corresponding machine, uploads any keys
-described in <varname>deployment.keys</varname>, and activates
-the new configuration.</para>
+described in <varname>deployment.keys</varname> and key directories
+in <varname>deployment.keyDirs</varname>, and activates the new
+configuration.</para>
 
 </refsection>
 
@@ -1943,6 +1944,7 @@ input.  See <command>nixops export</command> for examples.</para>
     <title>Description</title>
     <para>
       This command uploads the keys described in <varname>deployment.keys</varname>
+      and the key directories described in <varname>deployment.keyDirs</varname>
       to remote machines in the <literal>/run/keys/</literal> directory.
     </para>
     <para>

--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -1727,8 +1727,9 @@ deploy the new configuration.
     Files in <filename>/nix/store/</filename> are readable by every
     user on that host, so storing secret keys embedded in nix derivations
     is insecure. To address this, nixops provides the configuration
-    option <varname>deployment.keys</varname>, which nixops manages
-    separately from the main configuration derivation for each machine.
+    options <varname>deployment.keys</varname> and 
+    <varname>deployment.keyDirs</varname>, which nixops manages separately
+    from the main configuration derivation for each machine.
   </para>
 
   <para>
@@ -1759,8 +1760,39 @@ deploy the new configuration.
   </para>
 
   <para>
-    Keys from <varname>deployment.keys</varname> are stored under <filename>/run/</filename>
-    on a temporary filesystem and will not persist across a reboot.
+    Add a key directory to a machine (recursively) like so.
+
+    <screen>
+{
+  machine =
+    { config, pkgs, ... }:
+    {
+      deployment.keyDirs.my-secret-folder.path = "./foo/bar";
+      deployment.keyDirs.my-secret-folder.user = "myuser";
+      deployment.keyDirs.my-secret-folder.group = "wheel";
+      deployment.keyDirs.my-secret-folder.dirPermissions = "0750";
+      deployment.keyDirs.my-secret-folder.filePermissions = "0640";
+    };
+}
+    </screen>
+
+    This will create a directory <filename>/run/keys/my-secret-folder</filename>
+    with the contents of <filename>./foo/bar</filename>, and set ownership and
+    permissions.
+  </para>
+
+  <para>
+    Among the keyDir options, only <varname>path</varname> is required. The
+    <varname>user</varname> and <varname>group</varname> options both default
+    to <literal>"root"</literal>. <varname>dirPermissions</varname> defaults
+    to <literal>"0700"</literal> and <varname>filePermissions</varname> defaults
+    to <literal>"0600"</literal>.
+  </para>
+
+  <para>
+    Keys from <varname>deployment.keys</varname> and <varname>deployment.keyDirs</varname>
+    are stored under <filename>/run/</filename> on a temporary filesystem and will not
+    persist across a reboot.
     To send a rebooted machine its keys, use <command>nixops send-keys</command>. Note that all
     <command>nixops</command> commands implicitly upload keys when appropriate,
     so manually sending keys should only be necessary after an unattended reboot.

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -264,7 +264,7 @@ rec {
 
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
-        { inherit (v.config.deployment) targetEnv targetPort targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys hasFastConnection;
+        { inherit (v.config.deployment) targetEnv targetPort targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys keyDirs hasFastConnection;
           nixosRelease = v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
           azure = optionalAttrs (v.config.deployment.targetEnv == "azure")  v.config.deployment.azure;
           ec2 = optionalAttrs (v.config.deployment.targetEnv == "ec2") v.config.deployment.ec2;


### PR DESCRIPTION
Instead of having to manually specify each key to deploy, recursively copy the contents of a local directory under /run/keys. 
This is particularly helpful when deploying servers having multiple user accounts that need nixops. Each user would have his own key folder, owned by him that he can use for his deployments. Otherwise, using `deployment.keys` , one line per key is needed.

`deployment.keyDirs` supports having different permissions on directories than files inside them. Key directories will be deployed upon `nixops deploy` or `nixops send-keys` only if `deployment.storeKeysOnMachine` is set to false.

Also changed `nixops-keys` systemd unit's script to account for when `deployment.keys` or `deployment.keyDirs` is empty.