### PR TITLE
Flag libvird attrs as optional depending on targetEnv

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -278,7 +278,7 @@ rec {
             optionalAttrs (v.config.deployment.targetEnv == "virtualbox") (cfg
               // { disks = mapAttrs (n: v: v //
                 { baseImage = if isDerivation v.baseImage then "drv" else toString v.baseImage; }) cfg.disks; });
-          libvirtd = v.config.deployment.libvirtd;
+          libvirtd = optionalAttrs (v.config.deployment.targetEnv == "libvirtd") v.config.deployment.libvirtd;
           publicIPv4 = v.config.networking.publicIPv4;
         }
       );


### PR DESCRIPTION
I think libvirtd should only be included for libvirtd targets, same style as other backends. 

Noticed this while debugging things.