### PR TITLE
Always print the stacktrace if unforeseen exception in deploy

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -726,7 +726,7 @@ class Deployment(object):
                 # This thread shouldn't throw an exception because
                 # that will cause NixOps to exit and interrupt
                 # activation on the other machines.
-                m.logger.error(traceback.format_exc() if debug else str(e))
+                m.logger.error(traceback.format_exc())
                 return m.name
             return None
 


### PR DESCRIPTION
“This thread shouldn’t throw an exception”, but it sometimes does, and when it
does it should print the whole stacktrace for debugging, not just a cute
message, since `debug` is an alias of `False` (line 38).