### PR TITLE
Adding the ability to pass/modify a service account in a GCE instance

### DIFF
--- a/nix/gce.nix
+++ b/nix/gce.nix
@@ -264,6 +264,32 @@ in
         '';
       };
 
+      instanceServiceAccount = mkOption {
+        default  = {};
+        type = (types.submodule {
+          options = {
+            email = mkOption {
+              default = "default";
+              type = types.str;
+              description = ''
+                Email address of the service account.
+                If not given, Google Compute Engine default service account is used.
+              '';
+            };
+            scopes = mkOption {
+              default = [];
+              type = types.listOf types.str;
+              description = ''
+                The list of scopes to be made available for this service account.
+              '';
+            };
+          };
+        });
+        description = ''
+          A service account with its specified scopes, authorized for this instance.
+        '';
+      };
+
       blockDeviceMapping = mkOption {
         default = { };
         example = { "/dev/sda".image = "bootstrap-img"; "/dev/sdb".disk = "vol-d04895b8"; };


### PR DESCRIPTION
This allows setting a service account option in a GCE machine definition and changing it as well if the definition is modified by either changing the service account or the scopes (require a reboot).

Example:
```
gce = { pkgs, resources, lib, ...}:  {
      environment.systemPackages = [ pkgs.google-cloud-sdk ];
      deployment.targetEnv = "gce";
      deployment.gce = credentials // {
        region = "europe-west1-b";
        instanceType = "n1-standard-4";
        network = resources.gceNetworks.lb-net;
        instanceServiceAccount = { 
          email = "gce-test-1@...iam.gserviceaccount.com";
          scopes = [ "https://www.googleapis.com/auth/monitoring.write" "https://www.googleapis.com/auth/devstorage.read_only" ];
        };  
      };  
    };
```

This also fix the weird behavior of #465 by avoiding the deployment failure but doesn't fix the original issue which is the update of the instance type (will take care of it in a different PR).