### PR TITLE
libvirtd: add address_to method

### DIFF
--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -9,6 +9,7 @@ import subprocess
 import time
 
 from nixops.backends import MachineDefinition, MachineState
+import nixops.known_hosts
 import nixops.util
 
 
@@ -65,6 +66,11 @@ class LibvirtdState(MachineState):
 
     def get_physical_spec(self):
         return {('users', 'extraUsers', 'root', 'openssh', 'authorizedKeys', 'keys'): [self.client_public_key]}
+
+    def address_to(self, m):
+        if isinstance(m, LibvirtdState):
+            return m.private_ipv4
+        return MachineState.address_to(self, m)
 
     def _vm_id(self):
         return "nixops-{0}-{1}".format(self.depl.uuid, self.name)


### PR DESCRIPTION
The mechanism generating the extraHosts declaration is calling this
method. So without it, the extraHosts stays basic and
inter machine communication can't defined in a sane way.
Furthermore without this the libvirtd backend dosnt' behave like
manual is stating.