### PR TITLE
Add deployment.keys.<K>.destDir and deployment.keys.<K>.path

### DIFF
--- a/nix/auto-luks.nix
+++ b/nix/auto-luks.nix
@@ -97,7 +97,7 @@ with utils;
             mapperDevice' = escapeSystemdPath mapperDevice;
             mapperDevice'' = mapperDevice' + ".device";
 
-            keyFile = "/run/keys/luks-${name}";
+            keyFile = config.deployments.keys."luks-${name}".path;
 
           in assert attrs.passphrase != ""; nameValuePair "cryptsetup-${name}"
 

--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -42,7 +42,7 @@ let
 
     options.destDir = mkOption {
       default = /run/keys;
-      type = types.nullOr types.path;
+      type = types.path;
       description = ''
         When specified, this allows changing the destDir directory of the key
         file from its default value of <filename>/run/keys</filename>.

--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -12,7 +12,7 @@ let
         When non-null, this designates the text that the key should contain. So if
         the key name is <replaceable>password</replaceable> and
         <literal>foobar</literal> is set here, the contents of the file
-        <filename><replaceable>destinationFolder</replaceable>/<replaceable>password</replaceable></filename>
+        <filename><replaceable>destDir</replaceable>/<replaceable>password</replaceable></filename>
         will be <literal>foobar</literal>.
 
         NOTE: Either <literal>text</literal> or <literal>keyFile</literal> have
@@ -28,7 +28,7 @@ let
         specified key on the target machine.  If the key name is
         <replaceable>password</replaceable> and <literal>/foo/bar</literal> is set
         here, the contents of the file
-        <filename><replaceable>destinationFolder</replaceable>/<replaceable>password</replaceable></filename>
+        <filename><replaceable>destDir</replaceable>/<replaceable>password</replaceable></filename>
         deployed will be the same as local file <literal>/foo/bar</literal>.
 
         Since no serialization/deserialization of key contents is involved, there
@@ -40,11 +40,11 @@ let
       '';
     };
 
-    options.destinationFolder = mkOption {
+    options.destDir = mkOption {
       default = /run/keys;
       type = types.nullOr types.path;
       description = ''
-        When specified, this allows changing the destinationFolder directory of the key
+        When specified, this allows changing the destDir directory of the key
         file from its default value of <filename>/run/keys</filename>.
 
         This directory will be created, its permissions changed to
@@ -129,13 +129,13 @@ in
 
         <para>The set of keys to be deployed to the machine.  Each attribute maps
         a key name to a file that can be accessed as
-        <filename><replaceable>destinationFolder</replaceable>/<replaceable>name</replaceable></filename>,
-        where <literal>destinationFolder</literal> defaults to
+        <filename><replaceable>destDir</replaceable>/<replaceable>name</replaceable></filename>,
+        where <literal>destDir</literal> defaults to
         <filename>/run/keys</filename>.  Thus, <literal>{ password.text =
         "foobar"; }</literal> causes a file
-        <filename><replaceable>destinationFolder</replaceable>/password</filename> to be
+        <filename><replaceable>destDir</replaceable>/password</filename> to be
         created with contents <literal>foobar</literal>.  The directory
-        <filename><replaceable>destinationFolder</replaceable></filename> is only
+        <filename><replaceable>destDir</replaceable></filename> is only
         accessible to root and the <literal>keys</literal> group, so keep in mind
         to add any users that need to have access to a particular key to this
         group.</para>
@@ -182,7 +182,7 @@ in
                                                       (if !isNull value.keyFile
                                                        then builtins.readFile value.keyFile
                                                        else value.text);
-                                            destDir = toString value.destinationFolder;
+                                            destDir = toString value.destDir;
                                           in
                                           ''
                                                if test ! -d ${destDir}
@@ -201,7 +201,7 @@ in
 
         ${optionalString (!config.deployment.storeKeysOnMachine)
           (concatStringsSep "\n" (flip mapAttrsToList config.deployment.keys (name: value:
-            let destDir = toString value.destinationFolder;
+            let destDir = toString value.destDir;
             in
             # Make sure each key has correct ownership, since the configured owning
             # user or group may not have existed when first uploaded.

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -24,7 +24,7 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
             opts = {}
             for (key, xmlType) in (('text',        'string'),
                                    ('keyFile',     'path'),
-                                   ('destinationFolder', 'path'),
+                                   ('destDir',     'path'),
                                    ('user',        'string'),
                                    ('group',       'string'),
                                    ('permissions', 'string')):
@@ -216,16 +216,16 @@ class MachineState(nixops.resources.ResourceState):
             self.log("uploading key ‘{0}’...".format(k))
             tmp = self.depl.tempdir + "/key-" + self.name
 
-            if 'destinationFolder' not in opts:
-                raise Exception("Key '%s' has no 'destinationFolder' specified.".format(k))
+            if 'destDir' not in opts:
+                raise Exception("Key '%s' has no 'destDir' specified.".format(k))
 
-            destinationFolder = opts['destinationFolder'].rstrip("/")
-            print ("opts: %s, destinationFolder: '%s'" % (opts, destinationFolder))
+            destDir = opts['destDir'].rstrip("/")
+            print ("opts: %s, destDir: '%s'" % (opts, destDir))
             self.run_command(("test -d '{0}' || ("
                               " mkdir -m 0750 -p '{0}' &&"
-                              " chown root:keys  '{0}';)").format(destinationFolder))
+                              " chown root:keys  '{0}';)").format(destDir))
 
-            if 'text' in opts: 
+            if 'text' in opts:
                 with open(tmp, "w+") as f:
                     f.write(opts['text'])
             elif 'keyFile' in opts:
@@ -233,7 +233,7 @@ class MachineState(nixops.resources.ResourceState):
             else:
                 raise Exception("Neither 'text' or 'keyFile' options were set for key '{0}'.".format(k))
 
-            outfile = destinationFolder + "/" + k
+            outfile = destDir + "/" + k
             outfile_esc = "'" + outfile.replace("'", r"'\''") + "'"
             self.run_command("rm -f " + outfile_esc)
             self.upload_file(tmp, outfile)

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -24,7 +24,7 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
             opts = {}
             for (key, xmlType) in (('text',        'string'),
                                    ('keyFile',     'path'),
-                                   ('destDir',     'path'),
+                                   ('destDir',     'string'),
                                    ('user',        'string'),
                                    ('group',       'string'),
                                    ('permissions', 'string')):
@@ -217,7 +217,7 @@ class MachineState(nixops.resources.ResourceState):
             tmp = self.depl.tempdir + "/key-" + self.name
 
             if 'destDir' not in opts:
-                raise Exception("Key '%s' has no 'destDir' specified.".format(k))
+                raise Exception("Key '{}' has no 'destDir' specified.".format(k))
 
             destDir = opts['destDir'].rstrip("/")
             print ("opts: %s, destDir: '%s'" % (opts, destDir))

--- a/tests/functional/single_machine_elsewhere_key.nix
+++ b/tests/functional/single_machine_elsewhere_key.nix
@@ -1,0 +1,8 @@
+{
+  machine.deployment = {
+    storeKeysOnMachine = false;
+
+    keys."elsewhere.key".text = "12345";
+    keys."elsewhere.key".destinationFolder = /new/directory;
+  };
+}

--- a/tests/functional/single_machine_elsewhere_key.nix
+++ b/tests/functional/single_machine_elsewhere_key.nix
@@ -3,6 +3,6 @@
     storeKeysOnMachine = false;
 
     keys."elsewhere.key".text = "12345";
-    keys."elsewhere.key".destinationFolder = /new/directory;
+    keys."elsewhere.key".destDir = /new/directory;
   };
 }

--- a/tests/functional/test_send_keys_sends_keys.py
+++ b/tests/functional/test_send_keys_sends_keys.py
@@ -5,18 +5,22 @@ from tests.functional import single_machine_test
 
 parent_dir = path.dirname(__file__)
 
-secret_key_spec = '%s/single_machine_secret_key.nix' % (parent_dir)
+secret_key_spec    = '%s/single_machine_secret_key.nix'    % (parent_dir)
+elsewhere_key_spec = '%s/single_machine_elsewhere_key.nix' % (parent_dir)
 
 class TestSendKeysSendsKeys(single_machine_test.SingleMachineTest):
     _multiprocess_can_split_ = True
 
     def setup(self):
         super(TestSendKeysSendsKeys,self).setup()
-        self.depl.nix_exprs = self.depl.nix_exprs + [ secret_key_spec ]
+        self.depl.nix_exprs = self.depl.nix_exprs + [ secret_key_spec, elsewhere_key_spec ]
 
     def run_check(self):
         self.depl.deploy()
         self.check_command("test -f /run/keys/secret.key")
         self.check_command("rm -f /run/keys/secret.key")
+        self.check_command("test -f /new/directory/elsewhere.key")
+        self.check_command("rm -f /new/directory/elsewhere.key")
         self.depl.send_keys()
         self.check_command("test -f /run/keys/secret.key")
+        self.check_command("test -f /new/directory/elsewhere.key")


### PR DESCRIPTION
This allows customisation of the default `/run/keys` location for the deployment keys.
