### PR TITLE
Support multiple versions of nixpkgs in one network

### DIFF
--- a/nix/options.nix
+++ b/nix/options.nix
@@ -103,6 +103,13 @@ in
       '';
     };
 
+    deployment.nix_path = mkOption {
+      default = {};
+      type = types.attrsOf types.str;
+      description = ''
+      '';
+    };
+
     deployment.hasFastConnection = mkOption {
       default = false;
       type = types.bool;


### PR DESCRIPTION
Having a machine named foo, described as:

    foo = { # ...snipped...
      deployment.nix_path.nixpkgs = (builtins.filterSource
        (path: type: type != "directory" || baseNameOf path != ".git")
        ./../nixpkgs);
    });

will have the custom nixpkgs set in the `NIX_PATH` as
`nixpkgs=path-to-custom-nixpkgs`.

Note this does not work with foo = { config, ... }: {... machines, but
having a second nix file in the network would work, and also:

    let
      canary = machine: {
        deployment.nix_path.nixpkgs = (builtins.filterSource
          (path: type: type != "directory" || baseNameOf path != ".git")
          ./../nixpkgs);
        imports = [machine];
      };

      machine = { ... }: {
        # your machine config
      };
    in {
      machineA = machine;
      machineB = canary machine;
    }

Note that because this uses scopedImport, the nixops network and
machines may use `import <nixpkgs>` and have a consistent view of
nixpkgs.

Closes https://github.com/NixOS/nixops/issues/649#issuecomment-294330624