### PR TITLE
PoC | tests:  add a libvirtd backend test

### DIFF
--- a/tests/functional/single_machine_libvirtd_base.nix
+++ b/tests/functional/single_machine_libvirtd_base.nix
@@ -1,0 +1,10 @@
+{
+  machine =
+    { resources, ... }:
+    {
+      deployment.targetEnv = "libvirtd";
+      deployment.libvirtd = {
+        headless = true;
+      };
+    };
+}

--- a/tests/functional/single_machine_test.py
+++ b/tests/functional/single_machine_test.py
@@ -6,7 +6,7 @@ from tests.functional import generic_deployment_test
 
 parent_dir = path.dirname(__file__)
 
-logical_spec = '%s/single_machine_logical_base.nix' % (parent_dir)
+logical_spec = '{0}/single_machine_logical_base.nix'.format(parent_dir)
 
 class SingleMachineTest(generic_deployment_test.GenericDeploymentTest):
     _multiprocess_can_split_ = True
@@ -17,25 +17,25 @@ class SingleMachineTest(generic_deployment_test.GenericDeploymentTest):
 
     def test_ec2(self):
         self.depl.nix_exprs = self.depl.nix_exprs + [
-            ('%s/single_machine_ec2_base.nix' % (parent_dir))
+            ('{0}/single_machine_ec2_base.nix'.format(parent_dir))
         ]
         self.run_check()
 
     def test_gce(self):
         self.depl.nix_exprs = self.depl.nix_exprs + [
-            ('%s/single_machine_gce_base.nix' % (parent_dir))
+            ('{0}/single_machine_gce_base.nix'.format(parent_dir))
         ]
         self.run_check()
 
     def test_azure(self):
         self.depl.nix_exprs = self.depl.nix_exprs + [
-            ('%s/single_machine_azure_base.nix' % (parent_dir))
+            ('{0}/single_machine_azure_base.nix'.format(parent_dir))
         ]
         self.run_check()
 
     def test_libvirtd(self):
         self.depl.nix_exprs = self.depl.nix_exprs + [
-            ('%s/single_machine_libvirtd_base.nix' % (parent_dir))
+            ('{0}/single_machine_libvirtd_base.nix'.format(parent_dir))
         ]
         self.run_check()
 

--- a/tests/functional/single_machine_test.py
+++ b/tests/functional/single_machine_test.py
@@ -33,6 +33,12 @@ class SingleMachineTest(generic_deployment_test.GenericDeploymentTest):
         ]
         self.run_check()
 
+    def test_libvirtd(self):
+        self.depl.nix_exprs = self.depl.nix_exprs + [
+            ('%s/single_machine_libvirtd_base.nix' % (parent_dir))
+        ]
+        self.run_check()
+
     def check_command(self, command):
         self.depl.evaluate()
         machine = self.depl.machines.values()[0]


### PR DESCRIPTION
It's rather convenient to be able to run nixops tests locally, using `libvirtd`.

Testing done:

`python2 tests.py -e 'test_gce\|test_ec2\|test_azure'`