### PR TITLE
Encrypted links: always check for id_charon_vpn and re-create in case it doesn't exists

### DIFF
--- a/nix/auto-luks.nix
+++ b/nix/auto-luks.nix
@@ -97,7 +97,7 @@ with utils;
             mapperDevice' = escapeSystemdPath mapperDevice;
             mapperDevice'' = mapperDevice' + ".device";
 
-            keyFile = config.deployments.keys."luks-${name}".path;
+            keyFile = config.deployment.keys."luks-${name}".path;
 
           in assert attrs.passphrase != ""; nameValuePair "cryptsetup-${name}"
 

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -215,7 +215,6 @@ class MachineState(nixops.resources.ResourceState):
         for k, opts in self.get_keys().items():
             self.log("uploading key ‘{0}’...".format(k))
             tmp = self.depl.tempdir + "/key-" + self.name
-
             if 'destDir' not in opts:
                 raise Exception("Key '{}' has no 'destDir' specified.".format(k))
 
@@ -359,11 +358,10 @@ class MachineState(nixops.resources.ResourceState):
             + ([] if self.has_fast_connection else ["--gzip", "--use-substitutes"]),
             env=env)
 
-    def generate_vpn_key(self, check=False):
+    def generate_vpn_key(self):
         key_missing = False
         try:
-            if check:
-                self.run_command("test -f /root/.ssh/id_charon_vpn")
+            self.run_command("test -f /root/.ssh/id_charon_vpn")
         except nixops.ssh_util.SSHCommandFailed:
             key_missing = True
 

--- a/nixops/backends/azure_vm.py
+++ b/nixops/backends/azure_vm.py
@@ -1240,6 +1240,8 @@ class AzureState(MachineState, ResourceState):
                 key_name = disk['name']
                 keys["luks-" + key_name] = {
                     'text': self.generated_encryption_keys[d_id],
+                    'keyFile': '/run/keys/'+ "luks-" + key_name,
+                    'destDir': '/run/keys/',
                     'group': 'root',
                     'permissions': '0600',
                     'user': 'root'

--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -225,7 +225,8 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
         # make the old way of defining keys work.
         for k, v in self.block_device_mapping.items():
             if v.get('encrypt', False) and v.get('passphrase', "") == "" and v.get('generatedKey', "") != "" and v.get('encryptionType', "luks") == "luks":
-                keys["luks-" + _sd_to_xvd(k).replace('/dev/', '')] = { 'text': v['generatedKey'], 'group': 'root', 'permissions': '0600', 'user': 'root'}
+                key_name = "luks-" + _sd_to_xvd(k).replace('/dev/', '')
+                keys[key_name] = { 'text': v['generatedKey'], 'keyFile': '/run/keys/' + key_name, 'destDir': '/run/keys', 'group': 'root', 'permissions': '0600', 'user': 'root'}
         return keys
 
 

--- a/nixops/backends/gce.py
+++ b/nixops/backends/gce.py
@@ -830,7 +830,8 @@ class GCEState(MachineState, ResourceState):
         # the final nix-build).
         for k, v in self.block_device_mapping.items():
             if v.get('encrypt', False) and v.get('passphrase', "") == "" and v.get('generatedKey', "") != "":
-                keys["luks-" + (v['disk_name'] or v['disk'])] = { 'text': v['generatedKey'], 'group': 'root', 'permissions': '0600', 'user': 'root'}
+                key_name = "luks-" + (v['disk_name'] or v['disk'])
+                keys[key_name] = { 'text': v['generatedKey'], 'keyFile': '/run/keys' + key_name, 'destDir': '/run/keys', 'group': 'root', 'permissions': '0600', 'user': 'root'}
         return keys
 
     def get_ssh_name(self):

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -936,7 +936,7 @@ class Deployment(object):
                                 r.warn("cannot determine NixOS version")
 
                         r.wait_for_ssh(check=check)
-                        r.generate_vpn_key(check=check)
+                        r.generate_vpn_key()
 
                 except:
                     r._errored = True


### PR DESCRIPTION
* Always check for id_charon_vpn file and create it if doesn't exist, this will allow ssh encrypted tunnels services to automatically recover especially in cases where an EC2 spot instance was lost and redeployed (which needed a deploy with --check before)
* Fix some issues with encrypted filesystems that were introduced by #664