### PR TITLE
automatically resolve channel uris

### DIFF
--- a/nixops/util.py
+++ b/nixops/util.py
@@ -195,7 +195,7 @@ def ansi_success(s, outfile=sys.stderr):
 
 
 def _maybe_abspath(s):
-    if s.startswith("http://") or s.startswith("https://") or s.startswith("file://"):
+    if s.startswith("http://") or s.startswith("https://") or s.startswith("file://") or s.startswith("channel:"):
         return s
     return os.path.abspath(s)
 


### PR DESCRIPTION
This is needed to get the same behavior in other nix-* commands by specifying which channel to use by just doing `-I nixpkgs=channel:nixos-17.03`