### PR TITLE
release.nix: Make `shellHook` work even when started from a different dir

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -96,9 +96,9 @@ rec {
         ];
 
       # For "nix-build --run-env".
-      shellHook = ''
-        export PYTHONPATH=$(pwd):$PYTHONPATH
-        export PATH=$(pwd)/scripts:${openssh}/bin:$PATH
+      shellHook = let pwd = ./nonexistent/..; in ''
+        export PYTHONPATH=${pwd}:$PYTHONPATH
+        export PATH=${pwd}/scripts:${openssh}/bin:$PATH
       '';
 
       doCheck = true;


### PR DESCRIPTION
This provides at least a workaround for #689, and seems to have no drawbacks.