### PR TITLE
catch exceptions while deleting datadog resources

### DIFF
--- a/nixops/resources/datadog-monitor.py
+++ b/nixops/resources/datadog-monitor.py
@@ -54,12 +54,12 @@ class DatadogMonitorState(nixops.resources.ResourceState):
     @property
     def resource_id(self):
         return self._monitor_url + self.monitor_id if self.monitor_id else None
-    
+
     def get_definition_prefix(self):
         return "resources.datadogMonitors."
 
     def get_physical_spec(self):
-        return {'url': self._monitor_url + self.monitor_id } if self.monitor_id else {} 
+        return {'url': self._monitor_url + self.monitor_id } if self.monitor_id else {}
 
     def prefix_definition(self, attr):
         return {('resources', 'datadogMonitors'): attr}
@@ -124,5 +124,8 @@ class DatadogMonitorState(nixops.resources.ResourceState):
                 self.warn("datadog monitor with id {0} already deleted".format(self.monitor_id))
             else:
                 self.log("deleting datadog monitor ‘{0}’...".format(self.monitor_name))
-                self._dd_api.Monitor.delete(self.monitor_id)
+                response = self._dd_api.Monitor.delete(self.monitor_id)
+                if 'errors' in response.keys():
+                    raise Exception("there was errors while deleting the monitor: {}".format(
+                        str(response['errors'])))
         return True

--- a/nixops/resources/datadog-screenboard.py
+++ b/nixops/resources/datadog-screenboard.py
@@ -122,8 +122,10 @@ class DatadogScreenboardState(nixops.resources.ResourceState):
                 self.warn("datadog screenboard with id {0} already deleted".format(self.screenboard_id))
             else:
                 self.log("deleting datadog screenboard ‘{0}’...".format(self.board_title))
-                self._dd_api.Screenboard.delete(self.screenboard_id)
-
+                response = self._dd_api.Screenboard.delete(self.screenboard_id)
+                if 'errors' in response.keys():
+                    raise Exception("there was errors while deleting the screenboard: {}".format(
+                        str(response['errors'])))
     def destroy(self, wipe=False):
         self._destroy()
         return True

--- a/nixops/resources/datadog-timeboard.py
+++ b/nixops/resources/datadog-timeboard.py
@@ -130,7 +130,10 @@ class DatadogTimeboardState(nixops.resources.ResourceState):
                 self.warn("datadog timeboard with id {0} already deleted".format(self.timeboard_id))
             else:
                 self.log("deleting datadog timeboard ‘{0}’...".format(self.title))
-                self._dd_api.Timeboard.delete(self.timeboard_id)
+                response = self._dd_api.Timeboard.delete(self.timeboard_id)
+                if 'errors' in response.keys():
+                    raise Exception("there was errors while deleting the timeboard: {}".format(
+                        str(response['errors'])))
 
     def destroy(self, wipe=False):
         self._destroy()


### PR DESCRIPTION
there was some issues reported in #694, this will make the `nixops destroy` raise exceptions at least instead of failing silently.