### PR TITLE
doc: libvirtd: use group write bits on /var/lib/libvirt/images

### DIFF
--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -1497,7 +1497,9 @@ add your user to libvirtd group and change firewall not to filter DHCP packets.
   executing:
   <programlisting>
   $ sudo mkdir /var/lib/libvirt/images
-  $ sudo chown myuser:libvirtd /var/lib/libvirt/images</programlisting>
+  $ sudo chgrp libvirtd /var/lib/libvirt/images
+  $ sudo chmod g+w /var/lib/libvirt/images
+  </programlisting>
 </para>
 
 <para>We're ready to create the deployment, start by creating


### PR DESCRIPTION
The current example chowns the images directory to "myuser:libvirtd" and
then uses the ability of the _user_ to write to the image directory. I
think it's better to have the directory owned by "root:libvirtd" and
rely on on the _group_ to be able to write to the images directory. That
way, more than one user is allowed to manage the deployment.

Moreover, perhaps NixOS can configure these permission bits by itself
and this manual step can be removed in the future.