### PR TITLE
libvirt: undefine domain on "nixops destroy"

### DIFF
--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -231,6 +231,7 @@ class LibvirtdState(MachineState):
             return True
         self.log_start("destroying... ")
         self.stop()
+        self._logged_exec(["virsh", "-c", "qemu:///system", "undefine", self.vm_id])
         if (self.disk_path and os.path.exists(self.disk_path)):
             os.unlink(self.disk_path)
         return True


### PR DESCRIPTION
This fixes a regression introduced in commit e4105635c18f ("libvirtd:
create "persistent" instead of "transient" domains"). Now that domains
are persistent, we must de-allocate resources with "virsh undefine".