### PR TITLE
Fix #709: allow EIP resource for SG sourceIP attribute

### DIFF
--- a/nix/ec2-security-group.nix
+++ b/nix/ec2-security-group.nix
@@ -1,6 +1,7 @@
 { config, lib, uuid, name, ... }:
 
 with lib;
+with import ./lib.nix lib;
 
 {
 
@@ -92,8 +93,16 @@ with lib;
 
           sourceIp = mkOption {
             default = null;
-            description = "The source IP range (CIDR notation).";
-            type = types.uniq (types.nullOr types.str);
+            description = ''
+              The source IP range (CIDR notation).
+
+              Can also be a reference to ElasticIP resource, which will be
+              suffixed with /32 CIDR notation.
+            '';
+            type = types.uniq (types.nullOr (types.either types.str (resource "elastic-ip")));
+            apply = x: if builtins.isString x
+                       then x
+                       else (if (x == null) then null else "res-" + x._name);
           };
         };
       });


### PR DESCRIPTION
Notes:
- SG resource now depends on EIP resource creation
- /32 CIDR notation is appended to limit the source

cc @AmineChikhaoui @deepfire @rbvermaa 

To build nixops I used on top of this branch:

```
nix-build -A build.x86_64-linux release.nix
```

Tested using (note that EIP is referenced now as a resource, not via `.address`):

```
# usage:
#  nixops create -d 709 709.nix
#  nixops deploy -d 709

let
  hostPkgs = import <nixpkgs> {};
  lib = hostPkgs.lib;
in with lib; let
  accessKeyId = "XXX"; 
  region      = "eu-central-1";
in {
  network.description = "repro-depl";

  repro = { config, resources, pkgs, nodes, options, ... }: {
    deployment.targetEnv        = "ec2";
    deployment.ec2.accessKeyId  = accessKeyId;
    deployment.ec2.instanceType = "t2.large";
    deployment.ec2.region       = region;
    deployment.ec2.keyPair      = resources.ec2KeyPairs.repro-kp;
    deployment.ec2.securityGroups = mkDefault [ resources.ec2SecurityGroups.repro-sg ];
    deployment.ec2.elasticIPv4 = resources.elasticIPs.repro-ip;
  };
  resources = {
    ec2KeyPairs.repro-kp       = { inherit region accessKeyId; };
    elasticIPs.repro-ip        = { inherit region accessKeyId; };
    ec2SecurityGroups.repro-sg = { resources, ... }:
      {
        inherit region accessKeyId;
        description = "repro-sg";
        rules = [{
          fromPort = 1;
          toPort   = 2;
          sourceIp = resources.elasticIPs.repro-ip;
        }];
      };
  };
}
