### PR TITLE
Linode support for NixOps.

### DIFF
--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -1495,8 +1495,62 @@ xlink:href="https://github.com/elitak/nixos-infect">nixos-infect</link>
 </para>
 </section>
 
-<section><title>Deploying to Libvirtd (Qemu)</title>
+<section><title>Deploying to Linode</title>
 
+<para>First you will need to create an account with <link
+xlink:href="https://www.linode.com/">Linode</link>.</para>
+
+<para>Next, you need to visit <link
+xlink:href="https://cloud.linode.com/">Linode's new manager
+interface</link>, then navigate to profile and then <link
+xlink_href="https://cloud.linode.com/profile/tokens">API
+tokens</link>. From here click 'Create a Personal Access Token'. You
+should now be asked which permissions you want the API token to
+have. NixOps requires Delete access in the 'Linodes' category. Make
+sure to keep a note down the long code which appears when you confirm
+- there is no way to see it again.</para>
+
+<para>NixOps needs to know your personal API key. You can tell it by
+setting the <literal>deployment.linode.personalAPIKey</literal>
+property, or the <envvar>LINODE_PERSONAL_API_KEY</envvar> environment
+variable.</para>
+
+<para>The personal API key will be stored in the NixOps state file (an
+SQLite database), so you should make sure that this file is
+secure.</para>
+
+<para><xref linkend="ex-trivial-linode.nix" /> shows how to run +a
+<literal>Linode 2048</literal> instance in the <literal>Frankfurt,
+Germany</literal> region.</para>
+
+<example xml:id="ex-trivial-linode.nix">
+  <title><filename>trivial-linode.nix</filename>: A trivial Linode setup</title>
+  <programlisting>
+    {
+      machine = { config, pkgs, ... }: {
+        deployment.targetEnv = "linode";
+        deployment.linode = {
+          ## This is not a real API key, but it is in the correct format.
+          personalAPIKey = "2f99e7484232eh7dg8780ak41d371a945d4092150be5d36aee19d352df31a45f";
+          ## Default region is London, but we are using Frankfurt in this example.
+          region = "eu-central-1a";
+          ## Default type is a Linode 1024, but we are using a Linode 2048 in this example.
+          type = "g5-standard-1";
+        };
+      }
+    }
+  </programlisting>
+</example>
+
+<para>Installation works in a similar fashion to the Digital Ocean
+install. We create a Debian 8 (Jessie) instance, then use <link
+xlink:href="https://github.com/elitak/nixos-infect">nixos-infect</link>
+(modified to fit Linode's settings) to replace it with Nixos.
+</para>
+
+</section>
+
+<section><title>Deploying to Libvirtd (Qemu)</title>
 
 <para>In order to use libvirtd backend, a couple of manual steps need to be
 taken. Libvirtd backend is currently supported only on NixOS.

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -304,6 +304,7 @@ rec {
           digitalOcean = optionalAttrs (v.config.deployment.targetEnv == "digitalOcean") v.config.deployment.digitalOcean;
           gce = optionalAttrs (v.config.deployment.targetEnv == "gce") v.config.deployment.gce;
           hetzner = optionalAttrs (v.config.deployment.targetEnv == "hetzner") v.config.deployment.hetzner;
+          linode = optionalAttrs (v.config.deployment.targetEnv == "linode") v.config.deployment.linode;
           container = optionalAttrs (v.config.deployment.targetEnv == "container") v.config.deployment.container;
           route53 = v.config.deployment.route53;
           virtualbox =

--- a/nix/linode.nix
+++ b/nix/linode.nix
@@ -1,0 +1,57 @@
+{ config, pkgs, lib, utils, ... }:
+
+with lib;
+
+let
+  cfg = config.deployment.linode;
+in
+{
+  ###### interface
+  options = {
+    deployment.linode.personalAPIKey = mkOption {
+      default = "";
+      example = "2f99e7484232eh7dg8780ak41d371a945d4092150be5d36aee19d352df31a45f";
+      type = types.str;
+      description = ''
+        Your personal API key. Create this from https://cloud.linode.com/profile/integrations/tokens
+        Needs 'Delete' privilege for Linodes.
+        We check for this value in <envar>LINODE_PERSONAL_API_KEY</envar> before looking here.
+      '';
+    };
+
+    deployment.linode.region = mkOption {
+      default = "eu-west-1a";
+      example = "eu-west-1a";
+      type = types.str;
+      description = ''
+        The id of the region to deploy the VM into.
+
+        See https://api.linode.com/v4/regions for available regions (use the id field).
+
+        Alternatively, run `curl https://api.linode.com/v4/regions | jq ".regions[].id"`
+      '';
+    };
+
+    deployment.linode.type = mkOption {
+      default = "g5-nanode-1";
+      example = "g5-nanode-1";
+      type = types.str;
+      description = ''
+        The id of the type of VM to deploy. This determines the amount
+        of storage, memory, virtual CPUs, price, and network
+        bandwidth.
+
+        See https://api.linode.com/v4/linode/types for available types.
+
+        Alternatively, run `curl https://api.linode.com/v4/types | jq ".types[].id"`
+      '';
+    };
+  };
+
+  config = mkIf (config.deployment.targetEnv == "linode") {
+    nixpkgs.system = mkOverride 900 "x86_64-linux";
+    services.openssh.enable = true; # We need an SSH server in order to deploy our configuration.
+
+    ## TODO: do we need to muck around with Grub?
+  };
+}

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -22,6 +22,7 @@ in
       ./keys.nix
       ./gce.nix
       ./hetzner.nix
+      ./linode.nix
       ./container.nix
       ./libvirtd.nix
     ];

--- a/nixops/backends/linode_backend.py
+++ b/nixops/backends/linode_backend.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+from time import sleep
+
+import linode
+from nixops.nix_expr import Function, RawValue
+from nixops.backends import MachineDefinition, MachineState
+from nixops.util import attr_property, create_key_pair
+
+INFECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'data', 'nixos-infect.linode'))
+
+class NoInstanceIdError(Exception):
+    pass
+
+class LinodeDefinition(MachineDefinition):
+    @classmethod
+    def get_type(cls):
+        return "linode"
+
+    def __init__(self, xml, config):
+        MachineDefinition.__init__(self, xml, config)
+
+        self.region_id = config["linode"]["region"]
+        self.type_id = config["linode"]["type"]
+        self.personal_api_key = config["linode"]["personalAPIKey"]
+
+    def show_type(self):
+        return "{0} {1} {2}".format(self.get_type(), self.region_id, self.type_id)
+
+class LinodeState(MachineState):
+    @staticmethod
+    def get_type():
+        return "linode"
+
+    ## Data to be stored in statefile
+    linode_id = attr_property("linode.linodeID", None)
+    public_ipv4 = attr_property("publicIpv4", None)
+    public_ipv6 = attr_property("publicIpv6", {}, 'json')
+    private_key = attr_property("privateKey", None)
+    public_key = attr_property("public", None)
+
+    ## Temporarily cached values about the deployment
+    _deployment_name = None
+    _personal_api_key = None
+
+    ## Temporarily cached Linode API objects
+    _linode_client = None
+    _linode_instance = None
+
+    def __init__(self, depl, name, id):
+        MachineState.__init__(self, depl, name, id)
+
+        self._deployment_name = depl.name or depl.uuid
+        self.name = name
+
+        try:
+            depl.definitions
+        except AttributeError:
+            depl.evaluate()
+
+        defn = depl.definitions[name]
+
+        self._personal_api_key = defn.personal_api_key
+
+        if not self.private_key:
+            (self.private_key, self.public_key) = create_key_pair()
+
+    @staticmethod
+    def get_plan(client, type_id):
+        for t in client.linode.get_types():
+            if type_id == t.id:
+                return t
+
+        raise ValueError("Unknown type id %s" % self._type_id)
+
+    @staticmethod
+    def get_region(client, region_id):
+        for r in client.get_regions():
+            if region_id == r.id:
+                return r
+
+        raise ValueError("Unknown region id %s" % self._region_id)
+
+    @staticmethod
+    def get_kernel(client, kernel_label):
+        for k in client.linode.get_kernels():
+            if k.deprecated or not k.x64 or not k.kvm:
+                pass
+            elif k.label == kernel_label:
+                return k
+
+        raise ValueError("Unknown kernel id 'Direct Disk'")
+
+    @staticmethod
+    def get_kernel_direct_disk(client):
+        return LinodeState.get_kernel(client, "Direct Disk")
+
+    @staticmethod
+    def get_kernel_grub(client):
+        return LinodeState.get_kernel(client, "GRUB 2")
+
+    @staticmethod
+    def get_debian(client):
+        for d in client.linode.get_distributions(linode.Distribution.vendor == "Debian"):
+            if d.id == "linode/debian8":
+                return d
+
+        raise ValueError("Unknown distribution 'Debian 8'")
+
+    @staticmethod
+    def try_until_success(f):
+        try:
+            return f()
+        except linode.ApiError as e:
+            if e.status == 400 and e.errors[0] == "Linode busy.":
+                sleep(0.1)
+                return LinodeState.try_until_success(f)
+            else:
+                raise
+
+    def get_personal_api_key(self):
+        if not self._personal_api_key:
+            self._personal_api_key = os.environ.get('LINODE_PERSONAL_API_KEY')
+
+        if not self._personal_api_key:
+            raise RuntimeError("Neither deployment.linode.personalAPIKey nor the LINODE_PERSONAL_API_KEY variable was set.")
+
+        return self._personal_api_key
+
+
+    def get_client(self):
+        if not self._linode_client:
+            key = self.get_personal_api_key()
+
+            if key is None:
+                raise RuntimeError("Attempted to create A Linode client, but could not find a Linode personal API key.")
+
+            self._linode_client = linode.LinodeClient(key)
+
+        return self._linode_client
+
+    def get_linode_instance(self):
+        if not self._linode_instance:
+            if not self.linode_id:
+                raise NoInstanceIdError("Attempted to get a Linode instance, but we have no linode_id stored yet. Has this machine actually been created?")
+
+            self._linode_instance = linode.Linode(self.get_client(), self.linode_id)
+
+        return self._linode_instance
+
+    def get_ssh_private_key_file(self):
+        return self.write_ssh_private_key(self.private_key)
+
+    def get_ssh_name(self):
+        return self.public_ipv4
+
+    def get_ssh_flags(self, *args, **kwargs):
+        super_flags = super(LinodeState, self).get_ssh_flags(*args, **kwargs)
+        return super_flags + [
+            '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'StrictHostKeyChecking=no',
+            '-i', self.get_ssh_private_key_file()
+        ]
+
+    def get_physical_spec(self):
+        return {
+            'imports': [ RawValue('<nixpkgs/nixos/modules/profiles/qemu-guest.nix>') ],
+            ('boot', 'loader', 'grub'): {
+                'device': '/dev/sda',
+                'forceInstall': True
+            },
+            ('fileSystems', '/'): {
+                'device': '/dev/sda',
+                'fsType': 'ext4'
+            },
+            'swapDevices': [
+                { 'device': '/dev/sdb' }
+            ],
+            ('users', 'extraUsers', 'root', 'openssh', 'authorizedKeys', 'keys'): [self.public_key]
+        }
+
+    def start(self):
+        return self.get_linode_instance().boot()
+
+    def stop(self):
+        self.log_start("Shutting down")
+
+        instance = self.get_linode_instance()
+
+        instance.shutdown()
+        self.state = self.STOPPING
+
+        while instance.status != "offline":
+            self.log_continue(".")
+            sleep(1)
+
+        self.state = self.STOPPED
+        self.ssh_master = None
+
+        self.log_end("Shutdown complete")
+
+
+    def reboot_rescue(self):
+        instance = self.get_linode_instance()
+
+        return instance.rescue([instance.disks[0].id])
+
+    def destroy(self, wipe = False):
+        try:
+            return self.get_linode_instance().delete()
+        except NoInstanceIdError:
+            return True
+
+    def get_label(self):
+        """
+        Return a valid Linode label.
+
+        We'd like it to be descriptive, so we use the machine name.
+
+        It must be unique. Hopefully the machine name + deployment
+        name meets this criteria.
+
+        It can't be more than 32 characters, so we truncate it.
+
+        It must end with a latter or number, so we continue truncating
+        it until that is true.
+        """
+        label = (self.name + "-" + self._deployment_name)[0:30]
+
+        while not label[-1].isalnum():
+            if len(label) == 0:
+                raise RuntimeError("Could not create a valid label for machine with name %s and deployment id %s" % (self.name, self._deployment_name))
+
+            label = label[0:-1]
+
+        return label
+
+    def create(self, defn, check, allow_reboot, allow_recreate):
+        client = self.get_client()
+
+        if self.linode_id is not None:
+            instance = linode.Linode(client, self.linode_id)
+
+            try:
+                instance.status # Force a get request to check whether this instance already exists.
+                return True # We don't need to do anything to create this instance.
+            except linode.ApiError as e:
+                if e.status == 404:
+                    pass
+                else:
+                    raise
+
+
+        plan = LinodeState.get_plan(client, defn.type_id)
+
+        service = linode.Service(client, plan.id)
+
+        instance = None
+
+        try:
+            self.log_start("Creating Linode instance")
+            instance = client.linode.create_instance(
+                service,
+                LinodeState.get_region(client, defn.region_id),
+                distribution = LinodeState.get_debian(client),
+                label = self.get_label(),
+                group = "nixops-" + self._deployment_name,
+                root_ssh_key = self.public_key
+            )[0]
+
+            if not instance:
+                raise RuntimeError("Failed to create Linode instance " + self.name + " " + self._deployment_name)
+
+            self.linode_id = instance.id
+            self.public_ipv4 = instance.ipv4[0]
+            self.public_ipv6 = instance.ipv6
+
+            self.log_end("")
+            self.log_start("Booting instance into Debian 8 with standard Grub 2 kernel.")
+
+            ## Changing configuration to Grub 2 lets us use the
+            ## default Debian kernel instead of Linode's modified
+            ## kernel (which has a weird disk setup and causes
+            ## problems).
+
+            config = instance.configs[0]
+            config.kernel = LinodeState.get_kernel_grub(client)
+            config.save()
+
+            instance.boot()
+
+            self.wait_for_ssh()
+
+            self.log_end("")
+
+            self.log_start("running nixos-infect")
+            self.run_command('bash </dev/stdin 2>&1', stdin=open(INFECT_PATH))
+            self.log_end("")
+            self.stop()
+
+            self.log_start("Booting instance into Nixos")
+            ## nixos-infect installs Grub on the disk - we want to switch to using that.
+            config.kernel = LinodeState.get_kernel_direct_disk(client)
+            config.save()
+
+            instance.boot()
+
+            self.wait_for_ssh()
+
+            self.log_end("")
+
+        except:
+            if instance:
+                instance.delete()
+            self.linode_id = None
+
+            raise

--- a/nixops/data/nixos-infect.linode
+++ b/nixops/data/nixos-infect.linode
@@ -1,0 +1,168 @@
+#! /usr/bin/env bash
+
+# More info at: https://github.com/elitak/nixos-infect
+
+set -e -o pipefail
+
+makeConf() {
+  # Skip everything if main config already present
+  [[ -e /etc/nixos/configuration.nix ]] && return 0
+  # NB <<"EOF" quotes / $ ` in heredocs, <<EOF does not
+  mkdir -p /etc/nixos
+  local IFS=$'\n'; keys=($(grep -vE '^[[:space:]]*(#|$)' /root/.ssh/authorized_keys))
+  cat > /etc/nixos/configuration.nix << EOF
+{ ... }: {
+  imports = [
+    ./hardware-configuration.nix
+    $NIXOS_IMPORT
+  ];
+
+  boot.cleanTmpDir = true;
+  networking.hostName = "$(hostname)";
+  services.openssh.enable = true;
+  users.users.root.openssh.authorizedKeys.keys = [$(for key in "${keys[@]}"; do echo -n "
+    \"$key\""; done)
+  ];
+
+}
+EOF
+  # If you rerun this later, be sure to prune the filesSystems attr
+  cat > /etc/nixos/hardware-configuration.nix << EOF
+{ ... }:
+{
+  imports = [ <nixpkgs/nixos/modules/profiles/qemu-guest.nix> ];
+  boot.loader = {
+    grub = {
+      device = "/dev/sda";
+      forceInstall = true;
+    };
+  };
+  fileSystems."/" = { device = "/dev/sda"; fsType = "ext4"; };
+  swapDevices = [ { device = "/dev/sdb"; } ];
+}
+EOF
+
+  #! /usr/bin/env bash
+  # NB put your semi-sensitive (not posted to github) configuration in a separate
+  # file and include it via this customConfig() function. e.g.:
+  #  customConfig() {
+  #    cat > /etc/nixos/custom.nix << EOF
+  #    { config, lib, pkgs, ... }: {
+  #    }
+  #    EOF
+  #  }
+  #
+  # then you can add the files in configuration.nix's imports above and run something like:
+  #   cat customConfig nixos-infect | root@targethost bash
+  if [[ "$(type -t customConfig)" == "function" ]]; then customConfig; fi
+}
+
+prepareEnv() {
+  # $disk is used in makeConf()
+  for disk in vda sda; do [[ -e /dev/$disk ]] && break; done
+
+  # DigitalOcean doesn't seem to set USER while running user data
+  export USER="root"
+  export HOME="/root"
+
+  # Use adapted wget if curl is missing
+  which curl || { \
+    curl() {
+      eval "wget $(
+        (local isStdout=1
+        for arg in "$@"; do
+          case "$arg" in
+            "-o")
+              echo "-O";
+              isStdout=0
+              ;;
+            "-O")
+              isStdout=0
+              ;;
+            "-L")
+              ;;
+            *)
+              echo "$arg"
+              ;;
+          esac
+        done;
+        [[ $isStdout -eq 1 ]] && echo "-O-"
+        )| tr '\n' ' '
+      )"
+    }; export -f curl; }
+
+  # Nix installer tries to use sudo regardless of whether we're already uid 0
+  #which sudo || { sudo() { eval "$@"; }; export -f sudo; }
+  # shellcheck disable=SC2174
+  mkdir -p -m 0755 /nix
+}
+
+req() {
+  type "$1" > /dev/null 2>&1 || which "$1" > /dev/null 2>&1
+}
+
+checkEnv() {
+  # Perform some easy fixups before checking
+  which dnf && dnf install -y perl-Digest-SHA # Fedora 24
+  which bzcat || (which yum && yum install -y bzip2) \
+              || (which apt-get && apt-get install bzip2) \
+              || true
+
+  [[ "$(whoami)" == "root" ]] || { echo "ERROR: Must run as root"; return 1; }
+
+  req curl || req wget || { echo "ERROR: Missing both curl and wget"; return 1; }
+  req bzcat            || { echo "ERROR: Missing bzcat";              return 1; }
+  req groupadd         || { echo "ERROR: Missing groupadd";           return 1; }
+  req useradd          || { echo "ERROR: Missing useradd";            return 1; }
+  req ip               || { echo "ERROR: Missing ip";                 return 1; }
+  req awk              || { echo "ERROR: Missing awk";                return 1; }
+  req cut              || { echo "ERROR: Missing cut";                return 1; }
+}
+
+infect() {
+  # Add nix build users
+  # FIXME run only if necessary, rather than defaulting true
+  groupadd nixbld -g 30000 || true
+  for i in {1..10}; do useradd -c "Nix build user $i" -d /var/empty -g nixbld -G nixbld -M -N -r -s "$(which nologin)" nixbld$i || true; done
+  # TODO use addgroup and adduser as fallbacks
+  #addgroup nixbld -g 30000 || true
+  #for i in {1..10}; do adduser -DH -G nixbld nixbld$i || true; done
+
+  curl https://nixos.org/nix/install | $SHELL
+
+  # shellcheck disable=SC1090
+  source ~/.nix-profile/etc/profile.d/nix.sh
+
+  [[ -z "$NIX_CHANNEL" ]] && NIX_CHANNEL="nixos-17.03"
+  nix-channel --remove nixpkgs
+  nix-channel --add "https://nixos.org/channels/$NIX_CHANNEL" nixos
+  nix-channel --update
+
+  export NIXOS_CONFIG=/etc/nixos/configuration.nix
+
+  nix-env --set \
+    -I nixpkgs=$HOME/.nix-defexpr/channels/nixos \
+    -f '<nixpkgs/nixos>' \
+    -p /nix/var/nix/profiles/system \
+    -A system
+
+  # Remove nix installed with curl | bash
+  rm -fv /nix/var/nix/profiles/default*
+  /nix/var/nix/profiles/system/sw/bin/nix-collect-garbage
+
+  # Reify resolv.conf
+  [[ -L /etc/resolv.conf ]] && mv -v /etc/resolv.conf /etc/resolv.conf.lnk && cat /etc/resolv.conf.lnk > /etc/resolv.conf
+
+  # Stage the Nix coup d'état
+  touch /etc/NIXOS
+  echo etc/nixos                   > /etc/NIXOS_LUSTRATE
+  echo etc/resolv.conf            >> /etc/NIXOS_LUSTRATE
+  echo root/.nix-defexpr/channels >> /etc/NIXOS_LUSTRATE
+
+  /nix/var/nix/profiles/system/bin/switch-to-configuration boot
+}
+
+prepareEnv
+checkEnv
+makeConf
+infect

--- a/release.nix
+++ b/release.nix
@@ -95,6 +95,7 @@ rec {
           pysqlite
           datadog
           digital-ocean
+          linode-api
         ];
 
       # For "nix-build --run-env".

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(name='nixops',
       author_email='eelco.dolstra@logicblox.com',
       scripts=['scripts/nixops'],
       packages=['nixops', 'nixops.resources', 'nixops.backends'],
-      package_data={'nixops': ['data/nixos-infect']},
+      package_data={'nixops': ['data/nixos-infect', 'data/nixos-infect.linode']},
       cmdclass={'test': TestCommand}
       )

--- a/tests/functional/single_machine_linode_base.nix
+++ b/tests/functional/single_machine_linode_base.nix
@@ -1,0 +1,10 @@
+{
+  machine =
+    { resources, ... }:
+    {
+      deployment.targetEnv = "linode";
+      deployment.linode = {
+        personalAPIKey = "";
+      };
+    };
+}

--- a/tests/functional/single_machine_test.py
+++ b/tests/functional/single_machine_test.py
@@ -51,6 +51,13 @@ class SingleMachineTest(generic_deployment_test.GenericDeploymentTest):
         ]
         self.run_check()
 
+    @attr("linode")
+    def test_linode(self):
+        self.depl.nix_exprs = self.depl.nix_exprs + [
+            ('{0}/single_machine_linode_base.nix'.format(parent_dir))
+        ]
+        self.run_check()
+
     def check_command(self, command):
         self.depl.evaluate()
         machine = self.depl.machines.values()[0]


### PR DESCRIPTION
Linode support. Fixes https://github.com/NixOS/nixops/issues/198.

It works as follows:
 1. Deploy Debian using a standard Linux kernel (not one of Linode's special modifed ones).
 2. SSH in and run nixos-infect.
 3. Set the machine to boot from the disk you just installed Nixos on, then restart.

**Current Status According to Me**

Not ready for merge:

- One failing test (tests/functional/test_send_keys_sends_keys.py)
- Need to stop maintaining a separate copy of nixos-infect, and maintain a patch instead. Depends on: https://github.com/NixOS/nixops/pull/820
 - Linode changed their API, so it's broken at the moment. Fix in: https://github.com/NixOS/nixpkgs/pull/33928

**Tests**

I have run the tests on Linux using python2 tests.py -A linode. To run them you need to set your personal API key, which you can do in one of two ways:

-  edit tests/functional/single_machine_linode_base.nix to have my personalAPIKey set
-  set environment variable LINODE_PERSONAL_API_KEY

The tests take a lot of time to run.