### PR TITLE
Add domainType option to libvirt backend.

### DIFF
--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -106,6 +106,12 @@ in
       type = types.str;
       description = "Additional XML appended at the end of domain xml. See https://libvirt.org/formatdomain.html";
     };
+
+    deployment.libvirtd.domainType = mkOption {
+      default = "kvm";
+      type = types.str;
+      description = "Specify the type of libvirt domain to create (see '$ virsh capabilities | grep domain' for valid domain types";
+    };
   };
 
   ###### implementation

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -33,6 +33,7 @@ class LibvirtdDefinition(MachineDefinition):
         self.headless = x.find("attr[@name='headless']/bool").get("value") == 'true'
         self.image_dir = x.find("attr[@name='imageDir']/string").get("value")
         assert self.image_dir is not None
+        self.domain_type = x.find("attr[@name='domainType']/string").get("value")
 
         self.networks = [
             k.get("value")
@@ -146,7 +147,7 @@ class LibvirtdState(MachineState):
             ]).format(n)
 
         domain_fmt = "\n".join([
-            '<domain type="kvm">',
+            '<domain type="{5}">',
             '  <name>{0}</name>',
             '  <memory unit="MiB">{1}</memory>',
             '  <vcpu>{4}</vcpu>',
@@ -175,7 +176,8 @@ class LibvirtdState(MachineState):
             defn.memory_size,
             qemu,
             self._disk_path(defn),
-            defn.vcpu
+            defn.vcpu,
+            defn.domain_type
         )
 
     def _parse_ip(self):


### PR DESCRIPTION
The libvirt backend is currently hard-coded to use the kvm domain.  This is an efficient domain and good as the default, but not always available.

In my case I needed to run nixops to create a libvirt VM while running NixOS in a VMWare Fusion VM.  This patch allows:

    { example = { config, pkgs, ... }:
      { deployment.targetEnv = "libvirtd";
        deployment.libvirtd.domainType = "qemu";
       };
    }
