### PR TITLE
Fix section id of "Deploying to a NixOS machine"

### DIFF
--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -336,7 +336,7 @@ in
 
 </section>
 
-<section xml:id="sec-deploying-to-ec2"><title>Deploying to a NixOS machine</title>
+<section xml:id="sec-deploying-to-physical-nixos"><title>Deploying to a NixOS machine</title>
 
 <para>To deploy to a machine that is already running NixOS, simply set
 <varname>deployment.targetHost</varname> to the IP address or host name of the machine,


### PR DESCRIPTION
"Deploying to a NixOS machine" and "Deploying
to Amazon EC2" currently share a section id. Here's a quick fix for that.