### PR TITLE
[RDY] Use libvirt bindings instead of parsing output

### DIFF
--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -112,6 +112,24 @@ in
       type = types.str;
       description = "Specify the type of libvirt domain to create (see '$ virsh capabilities | grep domain' for valid domain types";
     };
+
+    deployment.libvirtd.cmdline = mkOption {
+      default = "";
+      type = types.str;
+      description = "Specify the kernel cmdline";
+    };
+
+    deployment.libvirtd.initrd = mkOption {
+      default = "";
+      type = types.str;
+      description = "Specify the kernel initrd";
+    };
+
+    deployment.libvirtd.kernel = mkOption {
+      default = "";
+      type = types.str;
+      description = "Specify the kernel we want to launch (valid for kvm)";
+    };
   };
 
   ###### implementation

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -36,7 +36,6 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
         self.keys = {k.get("name"): _extract_key_options(k) for k in
                      xml.findall("attrs/attr[@name='keys']/attrs/attr")}
 
-
 class MachineState(nixops.resources.ResourceState):
     """Base class for NixOps machine state objects."""
 
@@ -74,6 +73,9 @@ class MachineState(nixops.resources.ResourceState):
         self.ssh.register_passwd_fun(self.get_ssh_password)
         self._ssh_private_key_file = None
 
+    def __str__(self):
+        return "type"
+
     def prefix_definition(self, attr):
         return attr
 
@@ -106,6 +108,9 @@ class MachineState(nixops.resources.ResourceState):
             return None
         except nixops.ssh_util.SSHCommandFailed:
             return None
+        # except Exception as e:
+        #     self.warn("Unexpected Exception %r" % e)
+        #     return None
 
     # FIXME: Move this to ResourceState so that other kinds of
     # resources can be checked.

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -40,6 +40,7 @@ class LibvirtdDefinition(MachineDefinition):
         self.image_dir = x.find("attr[@name='imageDir']/string").get("value")
         assert self.image_dir is not None
         self.domain_type = x.find("attr[@name='domainType']/string").get("value")
+        self.kernel = x.find("attr[@name='kernel']/string").get("value")
 
         self.networks = [
             k.get("value")
@@ -175,17 +176,18 @@ class LibvirtdState(MachineState):
             ]).format(n)
 
         def _make_os(defn):
-            return '<os>',
-               ' <type arch="x86_64">hvm</type>',
-                '<boot dev="hd"/>',
-                '<kernel>{kernel}</kernel>',
-                '<initrd>{initrd}</initrd>',
-                '<cmdline>{cmdline}</cmdline>',
-            '</os>'.format(
-                    kernel='',
-                    initrd='',
-                    cmdline='',
-                    )
+            return [
+                '<os>',
+                '    <type arch="x86_64">hvm</type>',
+                '    <boot dev="hd"/>',
+                "    <kernel>%s</kernel>" % defn.kernel or '',
+                '    <initrd>{initrd}</initrd>',
+                '    <cmdline>{cmdline}</cmdline>',
+                '</os>']
+            #         kernel=defn.kernel if defn.kernel else '',
+            #         initrd=defn.initrd if defn.initrd else '',
+            #         cmdline=defn.cmdline if defn.cmdline else '',
+            #         )
 
             # '  <os>',
             # '    <type arch="x86_64">hvm</type>',
@@ -197,7 +199,7 @@ class LibvirtdState(MachineState):
             '  <name>{0}</name>',
             '  <memory unit="MiB">{1}</memory>',
             '  <vcpu>{4}</vcpu>',
-            '\n'.join(_make_os(dfn),
+            '\n'.join(_make_os(dfn)),
             '  <devices>',
             '    <emulator>{2}</emulator>',
             '    <disk type="file" device="disk">',

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -219,7 +219,9 @@ class LibvirtdState(MachineState):
         return ip
         Maybe it should return more (like ipv4/ipv6
         """
-        ifaces = self.dom.interfaceAddresses(libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT, 0)
+        # alternative is VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE
+        # VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT = qemu agent must be available
+        ifaces = self.dom.interfaceAddresses(libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE, 0)
         # ifaces = self.dom.interfaceAddresses(0)
         if (ifaces == None):
             self.log("Failed to get domain interfaces")
@@ -231,7 +233,7 @@ class LibvirtdState(MachineState):
             if val['addrs']:
                 for ipaddr in val['addrs']:
                     # print(" {0:12} {1}/{2} ".format(addr['type'], addr['addr'], addr['prefix']))
-                    return addr['addr']
+                    return ipaddr['addr']
             # if ipaddr['type'] == libvirt.VIR_IP_ADDR_TYPE_IPV4:
             #     print(ipaddr['addr'] + " VIR_IP_ADDR_TYPE_IPV4")
             # elif ipaddr['type'] == libvirt.VIR_IP_ADDR_TYPE_IPV6:
@@ -250,7 +252,8 @@ class LibvirtdState(MachineState):
 
     def _is_running(self):
         try:
-            return self.dom.info()[1] == libvirt.VIR_DOMAIN_RUNNING
+            # return self.dom.info()[1] == libvirt.VIR_DOMAIN_RUNNING
+            return dom.isActive()
         except libvirt.libvirtError:
             self.log("Domain %s is not runing" % self.vm_id)
         return False
@@ -270,7 +273,6 @@ class LibvirtdState(MachineState):
     def get_ssh_name(self):
         # assert self.private_ipv4
         self.private_ipv4 = self._parse_ip()
- 
         return self.private_ipv4
 
     def stop(self):

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -253,7 +253,7 @@ class LibvirtdState(MachineState):
     def _is_running(self):
         try:
             # return self.dom.info()[1] == libvirt.VIR_DOMAIN_RUNNING
-            return dom.isActive()
+            return self.dom.isActive()
         except libvirt.libvirtError:
             self.log("Domain %s is not runing" % self.vm_id)
         return False

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -6,11 +6,13 @@ import subprocess
 import sys
 import time
 import weakref
+import logging
 from tempfile import mkdtemp
 import nixops.util
 
 __all__ = ['SSHConnectionFailed', 'SSHCommandFailed', 'SSH']
 
+log = logging.getLogger('root')
 
 class SSHConnectionFailed(Exception):
     pass
@@ -49,6 +51,8 @@ class SSHMaster(object):
                '-oServerAliveInterval=60',
                '-oControlPersist=600']
 
+
+        log.debug("Running command : %s", cmd)
         res = subprocess.call(cmd + ssh_flags, **kwargs)
         if res != 0:
             raise SSHConnectionFailed(
@@ -122,6 +126,8 @@ class SSH(object):
         self._passwd_fun = lambda: None
         self._logger = logger
         self._ssh_master = None
+
+    # def __str__(self):
 
     def register_host_fun(self, host_fun):
         """

--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -148,6 +148,7 @@ class StateFile(object):
 
     def open_deployment(self, uuid=None):
         """Open an existing deployment."""
+        print("open deployement for uuid %r" % uuid)
         deployment = self._find_deployment(uuid=uuid)
         if deployment: return deployment
         raise Exception("could not find specified deployment in state file ‘{0}’".format(self.db_file))

--- a/release.nix
+++ b/release.nix
@@ -85,6 +85,7 @@ rec {
           boto3
           hetzner
           libcloud
+          libvirt
           azure-storage
           azure-mgmt-compute
           azure-mgmt-network

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -517,6 +517,7 @@ def op_import():
 
 
 def parse_machine(name):
+    print("Parsing machine %s" % name)
     return ("root", name) if name.find("@") == -1 else name.split("@", 1)
 
 
@@ -525,6 +526,8 @@ def op_ssh():
 
     (username, machine) = parse_machine(args.machine)
     m = depl.machines.get(machine)
+    print("machine %r" % m)
+    print("machine %s" % m)
     if not m: raise Exception("unknown machine ‘{0}’".format(machine))
     flags, command = m.ssh.split_openssh_args(args.args)
     user = None if username == "root" else username

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -522,6 +522,7 @@ def parse_machine(name):
 
 def op_ssh():
     depl = open_deployment()
+
     (username, machine) = parse_machine(args.machine)
     m = depl.machines.get(machine)
     if not m: raise Exception("unknown machine ‘{0}’".format(machine))

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ class TestCommand(Command):
 
 setup(name='nixops',
       version='@version@',
+      # version='1.5.2',
       description='NixOS cloud deployment tool',
       url='https://github.com/NixOS/nixops',
       author='Eelco Dolstra',


### PR DESCRIPTION
A bit of a WIP. 
When I try deploying my example, I get 
```
libvirt: Network Driver error : Network not found: no network with matching name 'default'
error: Network not found: no network with matching name 'default'
```
but my example.nix is very thin. 
