### PR TITLE
Support deployment keys in the container backend

### DIFF
--- a/nixops/backends/container.py
+++ b/nixops/backends/container.py
@@ -120,6 +120,8 @@ class ContainerState(MachineState):
     def create(self, defn, check, allow_reboot, allow_recreate):
         assert isinstance(defn, ContainerDefinition)
 
+        self.set_common_state(defn)
+
         if not self.client_private_key:
             (self.client_private_key, self.client_public_key) = nixops.util.create_key_pair()
 

--- a/nixops/backends/container.py
+++ b/nixops/backends/container.py
@@ -186,6 +186,8 @@ class ContainerState(MachineState):
         self.log("starting container...")
         self.host_ssh.run_command("nixos-container start {0}".format(self.vm_id))
         self.state = self.STARTING
+        self.wait_for_ssh()
+        self.send_keys()
 
     def _check(self, res):
         if not self.vm_id:

--- a/nixops/backends/container.py
+++ b/nixops/backends/container.py
@@ -104,7 +104,7 @@ class ContainerState(MachineState):
     def run_command(self, command, **kwargs):
         command = command.replace("'", r"'\''")
         return self.host_ssh.run_command(
-            "nixos-container run {0} -- bash --login -c 'HOME=/root {1}'".format(self.vm_id, command),
+            "nixos-container run {0} -- bash --login -c 'HOME=/root; {1}'".format(self.vm_id, command),
             **kwargs)
 
     def get_physical_spec(self):


### PR DESCRIPTION
We did try to use the deployment keys in the container backend and found out that the following tweaks were needed.

With the change around `run_command` I am not really sure. The problem could also be worked around by changing the order of the shell commands like the following example shows:

```
johannes@dev-johbo: ~/wo/nixops work-johbo
$ a=b echo test; (echo test)
test
test

johannes@dev-johbo: ~/wo/nixops keys-container-backend
$ a=b (echo test); echo test
-bash: syntax error near unexpected token `('
```

The shell commands are constructed in the function `send_keys`: https://github.com/NixOS/nixops/blob/master/nixops/backends/__init__.py#L242

Depending on the order does feel wrong as well though. I am not sure if we really need the `HOME=/root` fragment in `run_command` for the container backend.