### PR TITLE
making sure to create directories idempotently

### DIFF
--- a/nixops/known_hosts.py
+++ b/nixops/known_hosts.py
@@ -15,7 +15,8 @@ def _rewrite(ip_address, add, public_host_key):
         # If hosts file doesn't exist, create an empty file
         if not os.path.isfile(path):
             basedir = os.path.dirname(path)
-            os.makedirs(basedir)
+            if not os.path.exists(basedir):
+                os.makedirs(basedir)
             open(path, 'a').close()
 
         with open(os.path.expanduser("~/.ssh/.known_hosts.lock"), 'w') as lockfile:


### PR DESCRIPTION
This would prevent `Errno 17` errors. It would happen when running `os.makedirs` several times.

I've had the above error in this scenario:

1. I have an existent deployment
2. Folder `~/.ssh/known_hosts` exists
3. The file `~/.ssh/known_hosts` was removed, but the folder `~/.ssh` still exists
4. Run a deploy operation
