### PR TITLE
fix parsing error in virtualbox backend

### DIFF
--- a/nixops/backends/virtualbox.py
+++ b/nixops/backends/virtualbox.py
@@ -108,7 +108,7 @@ class VirtualBoxState(MachineState):
         vminfo = {}
         for l in lines:
             (k, v) = l.split("=", 1)
-            vminfo[k] = v if v[0]!='"' else v[1:-1]
+            vminfo[k] = v if not len(v) or v[0]!='"' else v[1:-1]
         return vminfo
 
 


### PR DESCRIPTION
The default virtualbox config outputs options such as:

    videocapopts=

These were failing to parse with:

    error: string index out of range