### PR TITLE
Update examples/terminal-server.nix

### DIFF
--- a/examples/terminal-server.nix
+++ b/examples/terminal-server.nix
@@ -5,7 +5,7 @@
     { config, pkgs, modulesPath, ... }:
 
     {
-      imports = "${modulesPath}/services/x11/terminal-server.nix";
+      imports = [ "${modulesPath}/services/x11/terminal-server.nix" ];
     
       services.xserver.desktopManager.kde4.enable = true;
       services.xserver.desktopManager.xfce.enable = true;


### PR DESCRIPTION
I encountered an evaluation error with this example. `imports` was expected to be a list, not a string.