### PR TITLE
rely on libvirt python bindings

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -84,6 +84,7 @@ rec {
           boto3
           hetzner
           libcloud
+          libvirt
           azure-storage
           azure-mgmt-compute
           azure-mgmt-network


### PR DESCRIPTION
Parsing command output of virsh was errorprone, different locales could
generate problems. Relying on libvirt bindings seems less error-prone.

Follow up of https://github.com/NixOS/nixops/pull/732#issuecomment-347477757