### PR TITLE
Fix iam roles permissions

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -919,6 +919,7 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
             # instance has been provisioned.
             self._cancel_spot_request()
         else: # not self.vm_id
+            pass
             #if defn.instance_profile.startswith("arn:") :
             #common_args['instance_profile_arn'] = defn.instance_profile
             #else:

--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -918,6 +918,17 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
             # Cancel spot instance request, it isn't needed after the
             # instance has been provisioned.
             self._cancel_spot_request()
+        else: # not self.vm_id
+            #if defn.instance_profile.startswith("arn:") :
+            #common_args['instance_profile_arn'] = defn.instance_profile
+            #else:
+            #common_args['instance_profile_name'] = defn.instance_profile
+            # use DescribeIamInstanceProfileAssociations to list profiles on instance
+            # call AssociateIamInstanceProfile and DisassociateIamInstanceProfile based on state
+            # TODO #785, query the instance profiles defined on the ec2 instance, then compare against defn.instance_profile
+            # use DisassociateIamInstanceProfile to remove any that dont belong
+            # and use AssociateIamInstanceProfile to attach any that belong and are missing
+
 
         # There is a short time window during which EC2 doesn't
         # know the instance ID yet.  So wait until it does.


### PR DESCRIPTION
this PR adds proper error messages to the IAM permission errors, rather then silently assuming things dont exist
it also documents how to solve #785 
the AWS policy that gives the minimum required to manage IAM roles is in [1]

[1] https://gist.github.com/cleverca22/4d4a846bcca3a406e03d8b29926b057d