### PR TITLE
libvirtd: added kernel/initrd/cmdline support

### DIFF
--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -112,6 +112,24 @@ in
       type = types.str;
       description = "Specify the type of libvirt domain to create (see '$ virsh capabilities | grep domain' for valid domain types";
     };
+
+    deployment.libvirtd.cmdline = mkOption {
+      default = "";
+      type = types.str;
+      description = "Specify the kernel cmdline (valid only with the kernel setting).";
+    };
+
+    deployment.libvirtd.initrd = mkOption {
+      default = "";
+      type = types.str;
+      description = "Specify the kernel initrd (valid only with the kernel setting).";
+    };
+
+    deployment.libvirtd.kernel = mkOption {
+      default = "";
+      type = types.str; # with types; nullOr path;
+      description = "Specify the host kernel to launch (valid for kvm).";
+    };
   };
 
   ###### implementation

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -170,7 +170,7 @@ class LibvirtdState(MachineState):
             return [
                 '<os>',
                 '    <type arch="x86_64">hvm</type>',
-                "    <kernel>%s</kernel>" % defn.kernel or '',
+                "    <kernel>%s</kernel>" % defn.kernel,
                 "    <initrd>%s</initrd>" % defn.initrd if len(defn.kernel) > 0 else "",
                 "    <cmdline>%s</cmdline>"% defn.cmdline if len(defn.kernel) > 0 else "",
                 '</os>']

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -53,7 +53,7 @@ def logged_exec(command, logger, check=True, capture_stdout=False, stdin=None,
     functionality as well.
 
     When calling with capture_stdout=True, a string is returned, which contains
-    everything the programm wrote to stdout.
+    everything the program wrote to stdout.
 
     When calling with check=False, the return code isn't checked and the
     function will return an integer which represents the return code of the


### PR DESCRIPTION
This allows ot generate the following domain part, which is useful for
kernel testing (e.g. no need to redeploy the VM).
```
  <os>
    <type arch='x86_64' machine='pc-i440fx-2.10'>hvm</type>
    <kernel>/home/teto/mykernel/build/arch/x86_64/boot/bzImage</kernel>
    <cmdline>root=/dev/sda1 earlycon=ttyS0 console=ttyS0</cmdline>
    <boot dev='hd'/>
  </os>
```