### PR TITLE
Add RDS DB security group resource and make it possible to attach it to an rds instance

### DIFF
--- a/examples/ec2-rds-dbinstance.nix
+++ b/examples/ec2-rds-dbinstance.nix
@@ -6,17 +6,16 @@ in
   network.description = "NixOps RDS Testing";
 
   resources.rdsDbSecurityGroups.test-rds-sg =
-  { resources, ... }:
-  {
-    inherit region accessKeyId;
-    groupName = "test-nixops";
-    description = "testing sg for rds";
-    rules = [
-      {
-        cidrIp = "0.0.0.0/0";
-      }
-    ];
-  };
+    {
+      inherit region accessKeyId;
+      groupName = "test-nixops";
+      description = "testing sg for rds";
+      rules = [
+        {
+          cidrIp = "0.0.0.0/0";
+        }
+      ];
+    };
 
   resources.rdsDbInstances.test-rds-instance =
     { resources, ... }:

--- a/examples/ec2-rds-dbinstance.nix
+++ b/examples/ec2-rds-dbinstance.nix
@@ -1,0 +1,36 @@
+let
+  region = "us-east-1";
+  accessKeyId = "AKIA...";
+in
+{
+  network.description = "NixOps RDS Testing";
+
+  resources.rdsDbSecurityGroups.test-rds-sg =
+  { resources, ... }:
+  {
+    inherit region accessKeyId;
+    groupName = "test-nixops";
+    description = "testing sg for rds";
+    rules = [
+      {
+        cidrIp = "0.0.0.0/0";
+      }
+    ];
+  };
+
+  resources.rdsDbInstances.test-rds-instance =
+    { resources, ... }:
+    {
+      inherit region accessKeyId;
+      id = "test-multi-az";
+      instanceClass = "db.r3.large";
+      allocatedStorage = 30;
+      masterUsername = "administrator";
+      masterPassword = "testing123";
+      port = 5432;
+      engine = "postgres";
+      dbName = "testNixOps";
+      multiAZ = true;
+      securityGroups = [ resources.rdsDbSecurityGroups.test-rds-sg ];
+    };
+}

--- a/nix/ec2-rds-dbinstance.nix
+++ b/nix/ec2-rds-dbinstance.nix
@@ -1,6 +1,7 @@
 { config, lib, uuid, name, ... }:
 
 with lib;
+with import ./lib.nix lib;
 
 {
 
@@ -82,8 +83,8 @@ with lib;
 
     securityGroups = mkOption {
       default = [ "default" ];
-      type = types.listOf (types.either types.str (resource "ec2-rds-dbsecuritygroup"));
-      apply = map (x: if builtins.isString x then x else "res-" + x.name);
+      type = types.listOf (types.either types.str (resource "ec2-rds-security-group"));
+      apply = map (x: if builtins.isString x then x else "res-" + x._name);
       description = ''
         List of names of DBSecurityGroup to authorize on this DBInstance.
       '';

--- a/nix/ec2-rds-dbinstance.nix
+++ b/nix/ec2-rds-dbinstance.nix
@@ -81,7 +81,7 @@ with lib;
     };
 
     securityGroups = mkOption {
-      default = [];
+      default = [ "default" ];
       type = types.listOf (types.either types.str (resource "ec2-rds-dbsecuritygroup"));
       apply = map (x: if builtins.isString x then x else "res-" + x.name);
       description = ''

--- a/nix/ec2-rds-dbinstance.nix
+++ b/nix/ec2-rds-dbinstance.nix
@@ -80,6 +80,15 @@ with lib;
       description = "The endpoint address of the database instance.  This is set by NixOps.";
     };
 
+    securityGroups = mkOption {
+      default = [];
+      type = types.listOf (types.either types.str (resource "ec2-rds-dbsecuritygroup"));
+      apply = map (x: if builtins.isString x then x else "res-" + x.name);
+      description = ''
+        List of names of DBSecurityGroup to authorize on this DBInstance.
+      '';
+    };
+
   };
 
   config._type = "ec2-rds-dbinstance";

--- a/nix/ec2-rds-dbsecurity-group.nix
+++ b/nix/ec2-rds-dbsecurity-group.nix
@@ -1,0 +1,66 @@
+{ config, lib, uuid, name, ... }:
+
+with lib;
+
+{
+
+  options = {
+
+    name = mkOption {
+      type = types.str;
+      description = ''
+        Name of the RDS DB security group.
+      '';
+    };
+
+    description = mkOption {
+      type = types.str;
+      description = ''
+        Description of the RDS DB security group.
+      ''; 
+    };
+
+    region = mkOption {
+      type = types.str;
+      description = "Amazon RDS DB security group region.";
+    };
+
+    accessKeyId = mkOption {
+      default = "";
+      type = types.str;
+      description = "The AWS Access Key ID.";
+    };
+
+    rules = mkOption {
+      default = [];
+      type = with types; listOf (submodule {
+        options = mkOption {
+          cidrIp = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+          };
+
+          securityGroupName = mkOption {
+            type = types.nullOr (types.either types.str (resource "ec2-security-group"));
+            apply = x: if (!x isString) then x.name else x;
+            default = null;
+          };
+
+          securityGroupId = mkOption {
+            type = types.nullOr (types.either types.str (resource "ec2-security-group"));
+            apply = x: if (!x isString) then x.groupId else x;
+            default = null;
+          };
+
+          securityGroupOwnerId = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+          };
+        };
+      });
+    };
+
+  };
+
+  config._type = "ec2-rds-security-group";
+}

--- a/nix/ec2-rds-dbsecurity-group.nix
+++ b/nix/ec2-rds-dbsecurity-group.nix
@@ -42,14 +42,12 @@ with import ./lib.nix lib;
           };
 
           securityGroupName = mkOption {
-            type = types.nullOr (types.either types.str (resource "ec2-security-group"));
-            apply = x: if (builtins.isString x || builtins.isNull x) then x else "res-" + x.name;
+            type = types.nullOr types.str;
             default = null;
           };
 
           securityGroupId = mkOption {
-            type = types.nullOr (types.either types.str (resource "ec2-security-group"));
-            apply = x: if (builtins.isString x || builtins.isNull x) then x else "res-" + x.groupId;
+            type = types.nullOr types.str;
             default = null;
           };
 

--- a/nix/ec2-rds-dbsecurity-group.nix
+++ b/nix/ec2-rds-dbsecurity-group.nix
@@ -7,7 +7,7 @@ with import ./lib.nix lib;
 
   options = {
 
-    name = mkOption {
+    groupName = mkOption {
       type = types.str;
       description = ''
         Name of the RDS DB security group.

--- a/nix/ec2-rds-dbsecurity-group.nix
+++ b/nix/ec2-rds-dbsecurity-group.nix
@@ -43,13 +43,13 @@ with import ./lib.nix lib;
 
           securityGroupName = mkOption {
             type = types.nullOr (types.either types.str (resource "ec2-security-group"));
-            apply = x: if (builtins.isString x || builtins.isNull x) then x else x.name;
+            apply = x: if (builtins.isString x || builtins.isNull x) then x else "res-" + x.name;
             default = null;
           };
 
           securityGroupId = mkOption {
             type = types.nullOr (types.either types.str (resource "ec2-security-group"));
-            apply = x: if (builtins.isString x || builtins.isNull x) then x else x.groupId;
+            apply = x: if (builtins.isString x || builtins.isNull x) then x else "res-" + x.groupId;
             default = null;
           };
 

--- a/nix/ec2-rds-dbsecurity-group.nix
+++ b/nix/ec2-rds-dbsecurity-group.nix
@@ -1,6 +1,7 @@
 { config, lib, uuid, name, ... }:
 
 with lib;
+with import ./lib.nix lib;
 
 {
 
@@ -34,7 +35,7 @@ with lib;
     rules = mkOption {
       default = [];
       type = with types; listOf (submodule {
-        options = mkOption {
+        options = {
           cidrIp = mkOption {
             type = types.nullOr types.str;
             default = null;
@@ -42,13 +43,13 @@ with lib;
 
           securityGroupName = mkOption {
             type = types.nullOr (types.either types.str (resource "ec2-security-group"));
-            apply = x: if (!x isString) then x.name else x;
+            apply = x: if (builtins.isString x || builtins.isNull x) then x else x.name;
             default = null;
           };
 
           securityGroupId = mkOption {
             type = types.nullOr (types.either types.str (resource "ec2-security-group"));
-            apply = x: if (!x isString) then x.groupId else x;
+            apply = x: if (builtins.isString x || builtins.isNull x) then x else x.groupId;
             default = null;
           };
 

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -96,6 +96,7 @@ rec {
   resources.ebsVolumes = evalResources ./ebs-volume.nix (zipAttrs resourcesByType.ebsVolumes or []);
   resources.elasticIPs = evalResources ./elastic-ip.nix (zipAttrs resourcesByType.elasticIPs or []);
   resources.rdsDbInstances = evalResources ./ec2-rds-dbinstance.nix (zipAttrs resourcesByType.rdsDbInstances or []);
+  resources.rdsDbSecurityGroups = evalResources ./ec2-rds-dbsecurity-group.nix (zipAttrs resourcesByType.rdsDbSecurityGroups or []);
   resources.elasticFileSystems = evalResources ./elastic-file-system.nix (zipAttrs resourcesByType.elasticFileSystems or []);
   resources.elasticFileSystemMountTargets = evalResources ./elastic-file-system-mount-target.nix (zipAttrs resourcesByType.elasticFileSystemMountTargets or []);
   resources.cloudwatchLogGroups = evalResources ./cloudwatch-log-group.nix (zipAttrs resourcesByType.cloudwatchLogGroups or []);

--- a/nixops/resources/ec2_common.py
+++ b/nixops/resources/ec2_common.py
@@ -44,7 +44,7 @@ class EC2CommonState():
 
         self.update_tags_using(updater, user_tags=user_tags, check=check)
 
-    def get_client(self):
+    def get_client(self, service="ec2"):
         '''
         Generic method to get a cached AWS client or create it.
         '''
@@ -56,7 +56,11 @@ class EC2CommonState():
             if self._client: return self._client
         assert self._state['region']
         (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-        self._client = boto3.session.Session().client('ec2', region_name=self._state['region'], aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+        self._client = boto3.session.Session().client(
+            service_name=service,
+            region_name=self._state['region'],
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key)
         return self._client
 
     def reset_client(self):

--- a/nixops/resources/ec2_rds_dbinstance.py
+++ b/nixops/resources/ec2_rds_dbinstance.py
@@ -132,7 +132,15 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
             'rds_dbinstance_instance_class', 'rds_dbinstance_db_name', 'rds_dbinstance_master_username',
             'rds_dbinstance_master_password', 'rds_dbinstance_allocated_storage')
 
-        return { attr : getattr(defn, attr) for attr in attrs if getattr(defn, attr) != getattr(self, attr) }
+        def get_state_attr(attr):
+            # handle boolean type in the state to avoid triggering false
+            # diffs
+            if attr == 'rds_dbinstance_multi_az':
+                return bool(getattr(self, attr))
+            else:
+                return getattr(self, attr)
+
+        return { attr : getattr(defn, attr) for attr in attrs if getattr(defn, attr) != get_state_attr(attr) }
 
     def _requires_reboot(self, defn):
         diff = self._diff_defn(defn)

--- a/nixops/resources/ec2_rds_dbinstance.py
+++ b/nixops/resources/ec2_rds_dbinstance.py
@@ -201,7 +201,7 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
         for sg in config:
             if sg.startswith("res-"):
                 res = self.depl.get_typed_resource(sg[4:].split(".")[0], "ec2-rds-dbsecurity-group")
-                security_groups.append(res.security_group_name)
+                security_groups.append(res._state['groupName'])
             else:
                 security_groups.append(sg)
         return security_groups

--- a/nixops/resources/ec2_rds_dbsecurity_group.py
+++ b/nixops/resources/ec2_rds_dbsecurity_group.py
@@ -4,6 +4,8 @@ import botocore.exceptions
 import nixops.util
 import nixops.resources
 import nixops.ec2_utils
+from nixops.resources.ec2_common import EC2CommonState
+from nixops.diff import Diff, Handler
 
 class EC2RDSDbSecurityGroupDefinition(nixops.resources.ResourceDefinition):
 
@@ -18,95 +20,135 @@ class EC2RDSDbSecurityGroupDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
-class EC2RDSDbSecurityGroupState(nixops.resources.ResourceState):
+class EC2RDSDbSecurityGroupState(nixops.resources.DiffEngineResourceState, EC2CommonState):
 
     state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
     access_key_id = nixops.util.attr_property("accessKeyId", None)
-    region = nixops.util.attr_property("region", None)
-    security_group_name = nixops.util.attr_property("securityGroupName", None)
-    security_group_description = nixops.util.attr_property("securityGroupDescription", None)
-    rules = nixops.util.attr_property("rules", [], "json")
+    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED
 
     @classmethod
     def get_type(cls):
         return "ec2-rds-dbsecurity-group"
 
     def __init__(self, depl, name, id):
-        nixops.resources.ResourceState.__init__(self, depl, name, id)
-        self._client = None
+        nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
+        self.handle_create_rds_db_sg = Handler(['groupName', 'region', 'description'], handle=self.realize_create_sg)
+        self.handle_rules = Handler(['rules'], after=[self.handle_create_rds_db_sg], handle=self.realize_rules_change)
 
     def show_type(self):
         s = super(EC2RDSDbSecurityGroupState, self).show_type()
-        return "{0} [{1}]".format(s, self.region)
+        return "{0} [{1}]".format(s, self._state.get('region', None))
 
     @property
     def resource_id(self):
-        return self.security_group_name
+        return self._state.get('groupName', None)
 
-    def get_client(self):
-        assert self.region
-        if self._client is not None:
-            return self._client
-        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-        self._client = boto3.session.Session().client(service_name='rds', region_name=self.region,
-                                                      aws_access_key_id=access_key_id,
-                                                      aws_secret_access_key=secret_access_key)
-        return self._client
+    def _check(self):
+        if self._state.get('groupName', None) is None:
+            return
+        if self.state == self.UP:
+            response = self.get_client("rds").describe_db_security_groups(
+                DBSecurityGroupName=self._state['groupName'])
+            if len(response['DBSecurityGroups']) < 1:
+                self.warn("RDS db security group {} not found, performing destroy to sync the state ...".format(self._state['groupName']))
+                self._destroy()
+            else:
+                rules = []
+                def generate_rule(rule):
+                    # FIXME note that we're forcing sg name to None here
+                    # as it causes InvalidParameterCombination errors
+                    # during revoke diff handling since sg name and id
+                    # can't be used together and the api returns both
+                    # anyway. This might also cause some unnecessary diff
+                    # handling when the config has securityGroupName set
+                    # and we run nixops check as it will persist the id
+                    # instead.
+                    return {
+                        'securityGroupId': rule.get('EC2SecurityGroupId', None),
+                        'securityGroupName': None,
+                        'securityGroupOwnerId': rule.get('EC2SecurityGroupOwnerId', None),
+                        'cidrIp': rule.get('CIDRIP', None)
+                    }
 
-    def create(self, defn, check, allow_reboot, allow_recreate):
-        self.access_key_id = defn.config["accessKeyId"] or nixops.ec2_utils.get_access_key_id()
+                for rule in response['DBSecurityGroups'][0].get('EC2SecurityGroups', []):
+                    rules.append(generate_rule(rule))
+                for rule in response['DBSecurityGroups'][0].get('IPRanges', []):
+                    rules.append(generate_rule(rule))
 
-        self.region  = defn.config["region"]
+                with self.depl._db:
+                    self._state['rules'] = rules
 
-        if self.state == self.MISSING:
-            self.log("creating rds db security group {}".format(defn.config['name']))
-            self.get_client().create_db_security_group(DBSecurityGroupName=defn.config['name'],
-                    DBSecurityGroupDescription=defn.config['description'])
+    def realize_create_sg(self, allow_recreate):
+        config = self.get_defn()
+        if self.state == self.UP:
+            if not allow_recreate:
+                raise Exception(
+                    "RDS security group {} definition changed and it needs to be recreated"
+                    " use --allow-recreate if you want to create a new one"
+                    .format(self._state['groupName']))
 
-            with self.depl._db:
-                self.state = self.UP
-                self.security_group_name = defn.config['name']
-                self.security_group_description = defn.config['description']
+            self.warn("RDS security group definition changed, recreating ...")
+            self._destroy()
+            self.reset_client() #FIXME ideally this should be detected automatically
 
-        rules_to_remove = [r for r in self.rules if r not in defn.config['rules'] ]
-        rules_to_add = [r for r in defn.config['rules'] if r not in self.rules]
+        self.log("creating RDS security group {}".format(config['groupName']))
+        self._state['region'] = config['region']
+        self.get_client("rds").create_db_security_group(
+            DBSecurityGroupName=config['groupName'],
+            DBSecurityGroupDescription=config['description'])
+        with self.depl._db:
+            self.state = self.UP
+            self._state['groupName'] = config['groupName']
+            self._state['description'] = config['description']
+
+    def realize_rules_change(self, allow_recreate):
+        config = self.get_defn()
+
+        rules_to_remove = [r for r in self._state.get('rules', []) if r not in config['rules']]
+        rules_to_add = [r for r in config['rules'] if r not in self._state.get('rules', [])]
 
         for rule in rules_to_remove:
+            self.log("removing old rules from RDS security group {} ...".format(self._state['groupName']))
             kwargs = self.process_rule(rule)
-            self.get_client().revoke_db_security_group_ingress(**kwargs)
+            self.get_client("rds").revoke_db_security_group_ingress(**kwargs)
 
         for rule in rules_to_add:
+            self.log("adding new rules to RDS security group {} ...".format(self._state['groupName']))
             kwargs = self.process_rule(rule)
-            self.get_client().authorize_db_security_group_ingress(**kwargs)
+            self.get_client("rds").authorize_db_security_group_ingress(**kwargs)
 
         with self.depl._db:
-            self.rules = defn.config['rules']
+            self._state['rules'] = config['rules']
 
     def process_rule(self, config):
         # FIXME do more checks before passing the args to the boto api call
         args = dict()
-        args['DBSecurityGroupName'] = self.security_group_name
+        args['DBSecurityGroupName'] = self._state['groupName']
         args['CIDRIP'] = config.get('cidrIp', None)
         args['EC2SecurityGroupName'] = config.get('securityGroupName', None)
         args['EC2SecurityGroupId'] = config.get('securityGroupId', None)
         args['EC2SecurityGroupOwnerId'] = config.get('securityGroupOwnerId', None)
-        return { attr : args[attr] for attr in args if args[attr] is not None }
+        return {attr : args[attr] for attr in args if args[attr] is not None}
 
-    def destroy(self, wipe=True):
+    def _destroy(self):
         if self.state != self.UP:
-            return True
-        self.log("destroying rds db security group {}".format(self.security_group_name))
+            return
+        self.log("destroying rds db security group {}".format(self._state['groupName']))
         try:
-            self.get_client().delete_db_security_group(DBSecurityGroupName=self.security_group_name)
+            self.get_client("rds").delete_db_security_group(DBSecurityGroupName=self._state['groupName'])
         except botocore.exceptions.ClientError as error:
             if error.response['Error']['Code'] == 'DBSecurityGroupNotFound':
-                self.warn("rds security group {} already deleted".format(self.security_group_name))
+                self.warn("rds security group {} already deleted".format(self._state['groupName']))
             else:
                 raise error
 
         with self.depl._db:
             self.state = self.MISSING
-            self.security_group_name = None
-            self.security_group_description = None
-            self.rules = None
+            self._state['groupName'] = None
+            self._state['region'] = None
+            self._state['description'] = None
+            self._state['rules'] = None
+
+    def destroy(self, wipe=True):
+        self._destroy()
         return True

--- a/nixops/resources/ec2_rds_dbsecurity_group.py
+++ b/nixops/resources/ec2_rds_dbsecurity_group.py
@@ -99,7 +99,10 @@ class EC2RDSDbSecurityGroupState(nixops.resources.ResourceState):
         try:
             self.get_client().delete_db_security_group(DBSecurityGroupName=self.security_group_name)
         except botocore.exceptions.ClientError as error:
-            raise error
+            if error.response['Error']['Code'] == 'DBSecurityGroupNotFound':
+                self.warn("rds security group {} already deleted".format(self.security_group_name))
+            else:
+                raise error
 
         with self.depl._db:
             self.state = self.MISSING

--- a/nixops/resources/ec2_rds_dbsecurity_group.py
+++ b/nixops/resources/ec2_rds_dbsecurity_group.py
@@ -1,0 +1,94 @@
+import boto3
+import botocore.exceptions
+
+import nixops.util
+import nixops.resources
+import nixops.ec2_utils
+
+class EC2RDSDbSecurityGroupDefinition(nixops.resources.ResourceDefinition):
+
+    @classmethod
+    def get_type(cls):
+        return "ec2-rds-dbsecurity-group"
+
+    @classmethod
+    def get_resource_type(cls):
+        return "rdsDbSecurityGroups"
+
+    def show_type(self):
+        return "{0}".format(self.get_type())
+
+class EC2RDSDbSecurityGroupState(nixops.resources.ResourceState):
+
+    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    access_key_id = nixops.util.attr_property("accessKeyId", None)
+    region = nixops.util.attr_property("region", None)
+    security_group_name = nixops.util.attr_property("securityGroupName", None)
+    security_group_description = nixops.util.attr_property("securityGroupDescription", None)
+    rules = nixops.util.attr_property("rules", [], "json")
+
+    @classmethod
+    def get_type(cls):
+        return "ec2-rds-dbsecurity-group"
+
+    def __init__(self, depl, name, id):
+        nixops.resources.ResourceState.__init__(self, depl, name, id)
+        self._client = None
+
+    def show_type(self):
+        s = super(EC2RDSDbSecurityGroupState, self).show_type()
+        return "{0} [{1}]".format(s, self.region)
+
+    @property
+    def resource_id(self):
+        return self.security_group_name
+
+    def get_client(self):
+        assert self.region
+        if self._client is not None:
+            return self._client
+        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+        self._client = boto3.session.Session().client(service_name='rds', region_name=self.region,
+                                                      aws_access_key_id=access_key_id,
+                                                      aws_secret_access_key=secret_access_key)
+        return self._client
+
+    def create(self, defn, check, allow_reboot, allow_recreate):
+        self.access_key_id = defn.config["accessKeyId"] or nixops.ec2_utils.get_access_key_id()
+
+        self.region  = defn.config["region"]
+
+        if self.state == self.MISSING:
+            self.log("creating rds db security group {}".format(self.security_group_name))
+            self.get_client().create_db_security_group(DBSecurityGroupName=defn.config['name'],
+                    DBSecurityGroupDescription=defn.config['description'])
+
+        with self.depl._db:
+            self.state = self.UP
+            self.security_group_name = defn.config['name']
+            self.security_group_description = defn.config['description']
+
+    def process_rule(self, config):
+        # FIXME do more checks before passing the args to the boto api call
+        args = dict()
+        args['DBSecurityGroupName'] = self.security_group_name
+        args['CIDRIP'] = config['cidrIp']
+        args['EC2SecurityGroupName'] = config['securityGroupName']
+        args['EC2SecurityGroupId'] = config['securityGroupId']
+        args['EC2SecurityGroupOwnerId'] = config['securityGroupOwnerId']
+        return args
+
+    def destroy(self, wipe=True):
+        if self.state != self.UP:
+            return True
+
+        self.log("destroying rds db security group {}".format(self.security_group_name))
+        try:
+            self.get_client().delete_db_security_group(DBSecurityGroupName=self.security_group_name)
+        except botocore.exceptions.ClientError as error:
+            raise error
+
+        with self.depl._db:
+            self.state = self.MISSING
+            self.security_group_name = None
+            self.security_group_description = None

--- a/nixops/resources/ec2_rds_dbsecurity_group.py
+++ b/nixops/resources/ec2_rds_dbsecurity_group.py
@@ -33,8 +33,13 @@ class EC2RDSDbSecurityGroupState(nixops.resources.DiffEngineResourceState, EC2Co
 
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
-        self.handle_create_rds_db_sg = Handler(['groupName', 'region', 'description'], handle=self.realize_create_sg)
-        self.handle_rules = Handler(['rules'], after=[self.handle_create_rds_db_sg], handle=self.realize_rules_change)
+        self.handle_create_rds_db_sg = Handler(
+            ['groupName', 'region', 'description'],
+            handle=self.realize_create_sg)
+        self.handle_rules = Handler(
+            ['rules'],
+            after=[self.handle_create_rds_db_sg],
+            handle=self.realize_rules_change)
 
     def show_type(self):
         s = super(EC2RDSDbSecurityGroupState, self).show_type()

--- a/nixops/resources/ec2_rds_dbsecurity_group.py
+++ b/nixops/resources/ec2_rds_dbsecurity_group.py
@@ -93,7 +93,6 @@ class EC2RDSDbSecurityGroupState(nixops.resources.ResourceState):
     def destroy(self, wipe=True):
         if self.state != self.UP:
             return True
-
         self.log("destroying rds db security group {}".format(self.security_group_name))
         try:
             self.get_client().delete_db_security_group(DBSecurityGroupName=self.security_group_name)

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -776,7 +776,8 @@ subparser.add_argument('--all',  action='store_true', help='show all deployments
 subparser.add_argument('--plain',  action='store_true', help='do not pretty-print the output')
 subparser.add_argument('--no-eval', action='store_true', help='do not evaluate the deployment specification')
 
-subparser = add_subparser('check', help='check the state of the machines in the network')
+subparser = add_subparser('check', help='check the state of the machines in the network'
+                          ' (note that this might alter the internal nixops state to consolidate with the real state of the resource)')
 subparser.set_defaults(op=op_check)
 subparser.add_argument('--all',  action='store_true', help='check all deployments')
 subparser.add_argument('--include', nargs='+', metavar='MACHINE-NAME', help='check only the specified machines')

--- a/tests/functional/ec2-rds-dbinstance-with-sg.nix
+++ b/tests/functional/ec2-rds-dbinstance-with-sg.nix
@@ -1,0 +1,34 @@
+let
+  region = "us-east-1";
+in
+{
+  network.description = "NixOps Test";
+
+  resources.rdsDbInstances.test-rds-instance =
+    { resources, ... }:
+    {
+      inherit region;
+      id = "myOtherDatabaseIsAFilesystem";
+      instanceClass = "db.r3.large";
+      allocatedStorage = 30;
+      masterUsername = "administrator";
+      masterPassword = "testing123";
+      port = 5432;
+      engine = "postgres";
+      dbName = "helloDarling";
+      securityGroups = [ resources.rdsDbSecurityGroups.test-rds-sg ];
+    };
+
+  resources.rdsDbSecurityGroups.test-rds-sg =
+    {
+      inherit region;
+      groupName = "test-nixops";
+      description = "testing sg for rds";
+      rules = [
+        {
+          cidrIp = "0.0.0.0/0";
+        }
+      ];
+    };
+
+}

--- a/tests/functional/test_ec2_rds_dbinstance.py
+++ b/tests/functional/test_ec2_rds_dbinstance.py
@@ -7,6 +7,7 @@ from tests.functional import generic_deployment_test
 parent_dir = path.dirname(__file__)
 
 logical_spec = '%s/ec2-rds-dbinstance.nix' % (parent_dir)
+sg_spec = '%s/ec2-rds-dbinstance-with-sg.nix' % (parent_dir)
 
 class TestEc2RdsDbinstanceTest(generic_deployment_test.GenericDeploymentTest):
     _multiprocess_can_split_ = True
@@ -16,4 +17,8 @@ class TestEc2RdsDbinstanceTest(generic_deployment_test.GenericDeploymentTest):
         self.depl.nix_exprs = [ logical_spec ]
 
     def test_deploy(self):
+        self.depl.deploy()
+
+    def test_deploy_with_sg(self):
+        self.depl.nix_exprs = [ sg_spec ]
         self.depl.deploy()

--- a/tests/functional/test_ec2_rds_dbinstance.py
+++ b/tests/functional/test_ec2_rds_dbinstance.py
@@ -16,10 +16,4 @@ class TestEc2RdsDbinstanceTest(generic_deployment_test.GenericDeploymentTest):
         self.depl.nix_exprs = [ logical_spec ]
 
     def test_deploy(self):
-        #self.depl.debug = True
         self.depl.deploy()
-
-    # def check_command(self, command):
-    #     self.depl.evaluate()
-    #     resource = self.depl.resources.values()[0]
-    #     return machine.run_command(command)


### PR DESCRIPTION
Previously, rds instances are created with the default rds db security group which as far as I can see don't have any rules by default, so the rds instance resource is quite unusable atm.

This adds RDS db security groups as resources as well as an option to specify a list of security groups an RDS instance can run in.