### PR TITLE
libvirtd: Add support for remote libvirt URIs

### DIFF
--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -1525,15 +1525,6 @@ add your user to libvirtd group and change firewall not to filter DHCP packets.
 </programlisting>
 </para>
 
-<para>Next we have to make sure our user has access to create images by
-  executing:
-  <programlisting>
-  $ sudo mkdir /var/lib/libvirt/images
-  $ sudo chgrp libvirtd /var/lib/libvirt/images
-  $ sudo chmod g+w /var/lib/libvirt/images
-  </programlisting>
-</para>
-
 <para>We're ready to create the deployment, start by creating
 <literal>example.nix</literal>:
 
@@ -1601,6 +1592,101 @@ deployment.libvirtd.extraDevicesXML = ''
 <tip>In order to log in you have to set a (root) password.</tip>
 </para>
 </note>
+
+<section>
+<title>Remote libvirtd server</title>
+
+<para>
+By default, NixOps uses the local libvirtd daemon (<literal>qemu:///system</literal>). It is also possible to
+deploy to a
+<link xlink:href="https://libvirt.org/remote.html">remote libvirtd server</link>.
+Remote deployment requires a couple of things:
+
+<itemizedlist>
+
+  <listitem>Pointing <code>deployment.libvirtd.URI</code> to the
+    <link xlink:href="https://libvirt.org/remote.html">remote libvirtd server</link>
+    instead of <literal>qemu:///system</literal>.
+  </listitem>
+
+  <listitem>
+    Configuring the network to ensure the VM running on the remote server is
+    reachable from the local machine. This is required so that NixOps can reach the
+    newly created VM by SSH to finish the deployment.
+  </listitem>
+
+</itemizedlist>
+</para>
+
+<para>Example: suppose the remote libvirtd server is located at 10.2.0.15.</para>
+
+<para>
+First, create a new <link
+xlink:href="https://wiki.libvirt.org/page/TaskRoutedNetworkSetupVirtManager">routed
+virtual network</link> on the libvirtd server. In this example we'll use the
+192.168.122.0/24 network named <literal>routed</literal>.
+</para>
+
+<para>
+Next, add a route to the virtual network via the remote libvirtd server. This
+can be done by running this command on the local machine:
+
+<screen>
+# ip route add to 192.168.122.0/24 via 10.2.0.15
+</screen>
+</para>
+
+<para>
+Now, create a NixOps configuration file <literal>remote-libvirtd.nix</literal>:
+
+<programlisting>{
+  example = {
+    deployment.targetEnv = "libvirtd";
+    deployment.libvirtd.URI = "qemu+ssh://10.2.0.15/system";
+    deployment.libvirtd.networks = [ "routed" ];
+  };
+}
+</programlisting>
+</para>
+
+<para>
+Finally, deploy it with NixOps:
+
+<screen>
+$ nixops create -d remote-libvirtd ./remote-libvirtd.nix
+$ nixops deploy -d remote-libvirtd
+</screen>
+</para>
+
+</section>
+
+<section>
+<title>Libvirtd storage pools</title>
+
+<para>
+By default, NixOps uses the <literal>default</literal>
+<link xlink:href="https://libvirt.org/storage.html">storage pool</link> which
+usually corresponds to the <filename>/var/lib/libvirt/images</filename>
+directory. You can choose another storage pool with the
+<code>deployment.libvirtd.storagePool</code> option:
+
+<programlisting>
+{
+  example = {
+    deployment.targetEnv = "libvirtd";
+    deployment.libvirtd.storagePool = "mystoragepool";
+  };
+}
+</programlisting>
+</para>
+
+<warning>
+  <para>NixOps has only been tested with storage pools of type <code>dir</code> (filesystem directory).
+    Attempting to use a storage pool of any other type with NixOps may not work as expected.
+  </para>
+</warning>
+
+</section>
 
 </section>
 

--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -45,11 +45,11 @@ in
   ###### interface
 
   options = {
-    deployment.libvirtd.imageDir = mkOption {
-      type = types.path;
-      default = "/var/lib/libvirt/images";
+    deployment.libvirtd.storagePool = mkOption {
+      type = types.str;
+      default = "default";
       description = ''
-        Directory to store VM image files. Note that it should be writable both by you and by libvirtd daemon.
+        The storage pool where the virtual disk is be created.
       '';
     };
 

--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -53,6 +53,14 @@ in
       '';
     };
 
+    deployment.libvirtd.URI = mkOption {
+      type = types.str;
+      default = "qemu:///system";
+      description = ''
+        Connection URI.
+      '';
+    };
+
     deployment.libvirtd.vcpu = mkOption {
       default = 1;
       type = types.int;

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -1,21 +1,19 @@
 # -*- coding: utf-8 -*-
 
-from distutils import spawn
-import os
 import copy
 import json
+import os
 import random
 import shutil
-import string
-import subprocess
 import time
 from xml.etree import ElementTree
 
 import libvirt
 
-from nixops.backends import MachineDefinition, MachineState
 import nixops.known_hosts
 import nixops.util
+from nixops.backends import MachineDefinition, MachineState
+
 
 # to prevent libvirt errors from appearing on screen, see
 # https://www.redhat.com/archives/libvirt-users/2017-August/msg00011.html
@@ -262,9 +260,8 @@ class LibvirtdState(MachineState):
                 '    <type arch="x86_64">hvm</type>',
                 "    <kernel>%s</kernel>" % defn.kernel,
                 "    <initrd>%s</initrd>" % defn.initrd if len(defn.kernel) > 0 else "",
-                "    <cmdline>%s</cmdline>"% defn.cmdline if len(defn.kernel) > 0 else "",
+                "    <cmdline>%s</cmdline>" % defn.cmdline if len(defn.kernel) > 0 else "",
                 '</os>']
-
 
         domain_fmt = "\n".join([
             '<domain type="{5}">',

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -3,6 +3,7 @@
 from distutils import spawn
 import os
 import copy
+import json
 import random
 import shutil
 import string
@@ -34,12 +35,11 @@ class LibvirtdDefinition(MachineDefinition):
         self.extra_devices = x.find("attr[@name='extraDevicesXML']/string").get("value")
         self.extra_domain = x.find("attr[@name='extraDomainXML']/string").get("value")
         self.headless = x.find("attr[@name='headless']/bool").get("value") == 'true'
-        self.image_dir = x.find("attr[@name='imageDir']/string").get("value")
-        assert self.image_dir is not None
         self.domain_type = x.find("attr[@name='domainType']/string").get("value")
         self.kernel = x.find("attr[@name='kernel']/string").get("value")
         self.initrd = x.find("attr[@name='initrd']/string").get("value")
         self.cmdline = x.find("attr[@name='cmdline']/string").get("value")
+        self.storage_pool_name = x.find("attr[@name='storagePool']/string").get("value")
 
         self.networks = [
             k.get("value")
@@ -55,6 +55,8 @@ class LibvirtdState(MachineState):
     primary_mac = nixops.util.attr_property("libvirtd.primaryMAC", None)
     domain_xml = nixops.util.attr_property("libvirtd.domainXML", None)
     disk_path = nixops.util.attr_property("libvirtd.diskPath", None)
+    storage_volume_name = nixops.util.attr_property("libvirtd.storageVolume", None)
+    storage_pool_name = nixops.util.attr_property("libvirtd.storagePool", None)
     vcpu = nixops.util.attr_property("libvirtd.vcpu", None)
 
     @classmethod
@@ -64,6 +66,8 @@ class LibvirtdState(MachineState):
     def __init__(self, depl, name, id):
         MachineState.__init__(self, depl, name, id)
         self._dom = None
+        self._pool = None
+        self._vol = None
 
     def connect(self):
         self.conn = libvirt.open('qemu:///system')
@@ -80,6 +84,18 @@ class LibvirtdState(MachineState):
             except Exception as e:
                 self.log("Warning: %s" % e)
         return self._dom
+
+    @property
+    def pool(self):
+        if self._pool is None:
+            self._pool = self.conn.storagePoolLookupByName(self.storage_pool_name)
+        return self._pool
+
+    @property
+    def vol(self):
+        if self._vol is None:
+            self._vol = self.pool.storageVolLookupByName(self.storage_volume_name)
+        return self._vol
 
     def get_console_output(self):
         # TODO update with self.uri when https://github.com/NixOS/nixops/pull/824 gets merged
@@ -117,13 +133,20 @@ class LibvirtdState(MachineState):
         assert isinstance(defn, LibvirtdDefinition)
         self.set_common_state(defn)
         self.primary_net = defn.networks[0]
+        self.storage_pool_name = defn.storage_pool_name
+
         if not self.primary_mac:
             self._generate_primary_mac()
-        self.domain_xml = self._make_domain_xml(defn)
-        self.connect()
 
         if not self.client_public_key:
             (self.client_private_key, self.client_public_key) = nixops.util.create_key_pair()
+
+        if self.storage_volume_name is None:
+            self._prepare_storage_volume()
+            self.storage_volume_name = self.vol.name()
+
+        self.domain_xml = self._make_domain_xml(defn)
+        self.connect()
 
         if self.vm_id is None:
             # By using "define" we ensure that the domain is
@@ -133,32 +156,67 @@ class LibvirtdState(MachineState):
                 self.log('Failed to register domain XML with the hypervisor')
                 return False
 
-            newEnv = copy.deepcopy(os.environ)
-            newEnv["NIXOPS_LIBVIRTD_PUBKEY"] = self.client_public_key
-            base_image = self._logged_exec(
-                ["nix-build"] + self.depl._eval_flags(self.depl.nix_exprs) +
-                ["--arg", "checkConfigurationOptions", "false",
-                 "-A", "nodes.{0}.config.deployment.libvirtd.baseImage".format(self.name),
-                 "-o", "{0}/libvirtd-image-{1}".format(self.depl.tempdir, self.name)],
-                capture_stdout=True, env=newEnv).rstrip()
-
-            if not os.access(defn.image_dir, os.W_OK):
-                raise Exception('{} is not writable by this user or it does not exist'.format(defn.image_dir))
-
-            self.disk_path = self._disk_path(defn)
-            shutil.copyfile(base_image + "/disk.qcow2", self.disk_path)
-            # Rebase onto empty backing file to prevent breaking the disk image
-            # when the backing file gets garbage collected.
-            self._logged_exec(["qemu-img", "rebase", "-f", "qcow2", "-b",
-                               "", self.disk_path])
-            os.chmod(self.disk_path, 0660)
             self.vm_id = self._vm_id()
 
         self.start()
         return True
 
-    def _disk_path(self, defn):
-        return "{0}/{1}.img".format(defn.image_dir, self._vm_id())
+    def _prepare_storage_volume(self):
+        self.logger.log("preparing disk image...")
+        newEnv = copy.deepcopy(os.environ)
+        newEnv["NIXOPS_LIBVIRTD_PUBKEY"] = self.client_public_key
+        base_image = self._logged_exec(
+            ["nix-build"] + self.depl._eval_flags(self.depl.nix_exprs) +
+            ["--arg", "checkConfigurationOptions", "false",
+             "-A", "nodes.{0}.config.deployment.libvirtd.baseImage".format(self.name),
+             "-o", "{0}/libvirtd-image-{1}".format(self.depl.tempdir, self.name)],
+            capture_stdout=True, env=newEnv).rstrip()
+
+        temp_disk_path = os.path.join(self.depl.tempdir, 'disk.qcow2')
+        shutil.copyfile(base_image + "/disk.qcow2", temp_disk_path)
+        # Rebase onto empty backing file to prevent breaking the disk image
+        # when the backing file gets garbage collected.
+        self._logged_exec(["qemu-img", "rebase", "-f", "qcow2", "-b",
+                           "", temp_disk_path])
+
+        self.logger.log("uploading disk image...")
+        image_info = self._get_image_info(temp_disk_path)
+        self._vol = self._create_volume(image_info['virtual-size'], image_info['actual-size'])
+        self._upload_volume(temp_disk_path, image_info['actual-size'])
+
+    def _get_image_info(self, filename):
+        output = self._logged_exec(["qemu-img", "info", "--output", "json", filename], capture_stdout=True)
+        return json.loads(output)
+
+    def _create_volume(self, virtual_size, actual_size):
+        xml = '''
+        <volume>
+          <name>{name}</name>
+          <capacity>{virtual_size}</capacity>
+          <allocation>{actual_size}</allocation>
+          <target>
+            <format type="qcow2"/>
+          </target>
+        </volume>
+        '''.format(
+            name="{}.qcow2".format(self._vm_id()),
+            virtual_size=virtual_size,
+            actual_size=actual_size,
+        )
+        vol = self.pool.createXML(xml)
+        self._vol = vol
+        return vol
+
+    def _upload_volume(self, filename, actual_size):
+        stream = self.conn.newStream()
+        self.vol.upload(stream, offset=0, length=actual_size)
+
+        def read_file(stream, nbytes, f):
+            return f.read(nbytes)
+
+        with open(filename, 'rb') as f:
+            stream.sendAll(read_file, f)
+            stream.finish()
 
     def _make_domain_xml(self, defn):
         qemu_executable = "qemu-system-x86_64"
@@ -216,7 +274,7 @@ class LibvirtdState(MachineState):
             self._vm_id(),
             defn.memory_size,
             qemu,
-            self._disk_path(defn),
+            self.vol.path(),
             defn.vcpu,
             defn.domain_type
         )
@@ -281,14 +339,20 @@ class LibvirtdState(MachineState):
         self.state = self.STOPPED
 
     def destroy(self, wipe=False):
-        if not self.vm_id:
-            return True
         self.log_start("destroying... ")
-        self.stop()
-        if self.dom.undefine() != 0:
-            self.log("Failed undefining domain")
-            return False
+
+        if self.vm_id is not None:
+            self.stop()
+            if self.dom.undefine() != 0:
+                self.log("Failed undefining domain")
+                return False
 
         if (self.disk_path and os.path.exists(self.disk_path)):
+            # the deployment was created by an older NixOps version that did
+            # not use the libvirtd API for uploading disk images
             os.unlink(self.disk_path)
+
+        if self.storage_volume_name is not None:
+            self.vol.delete()
+
         return True


### PR DESCRIPTION
This PR adds support for deploying to remote libvirtd hosts via `qemu+ssh://...` or `qemu+tcp://...` URIs.

- [x] Make the URI configurable instead of hardcoging it to `qemu:///system`.
- [x] Use libvirt API to upload the disk image instead of using the local image directory.
- [x] Use libvirt API to determing the QEMU executable instead of using `/run/current-system/sw/bin/qemu-system-x86_64`.
- [x] Error handling.
- [x] Backward compatibility.
- [x] Update documentation and examples.