### PR TITLE
Get rid of `mknod /dev/vda1` thanks to the introduction of `devtmpfs`

### DIFF
--- a/nix/libvirtd-image.nix
+++ b/nix/libvirtd-image.nix
@@ -39,6 +39,9 @@ in pkgs.vmTools.runInLinuxVM (
       ${pkgs.parted}/sbin/parted /dev/vda mklabel msdos
       ${pkgs.parted}/sbin/parted /dev/vda -- mkpart primary ext2 1M -1s
 
+      # TODO (@Ma27) remove this entirely after NixOS 17.09 is EOLed, in
+      # 18.03 `devtmpfs` is used which makes the block creation obsolete
+      # (see https://github.com/NixOS/nixpkgs/commit/0d27df280f7ed502bba65e2ea13469069f9b275a)
       if [ ! -b /dev/vda1 ]; then
         . /sys/class/block/vda1/uevent
         mknod /dev/vda1 b $MAJOR $MINOR

--- a/nix/libvirtd-image.nix
+++ b/nix/libvirtd-image.nix
@@ -38,8 +38,11 @@ in pkgs.vmTools.runInLinuxVM (
       # Create a single / partition.
       ${pkgs.parted}/sbin/parted /dev/vda mklabel msdos
       ${pkgs.parted}/sbin/parted /dev/vda -- mkpart primary ext2 1M -1s
-      . /sys/class/block/vda1/uevent
-      mknod /dev/vda1 b $MAJOR $MINOR
+
+      if [ ! -b /dev/vda1 ]; then
+        . /sys/class/block/vda1/uevent
+        mknod /dev/vda1 b $MAJOR $MINOR
+      fi
 
       # Create an empty filesystem and mount it.
       ${pkgs.e2fsprogs}/sbin/mkfs.ext4 -L nixos /dev/vda1

--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -22,8 +22,11 @@ let
           '';
       }
       ''
-        . /sys/class/block/vda1/uevent
-        mknod /dev/vda1 b $MAJOR $MINOR
+        if [ ! -b /dev/vda1 ]; then
+          . /sys/class/block/vda1/uevent
+          mknod /dev/vda1 b $MAJOR $MINOR
+        fi
+
         mkdir /mnt
         mount /dev/vda1 /mnt
 

--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -22,6 +22,9 @@ let
           '';
       }
       ''
+        # TODO (@Ma27) remove this entirely after NixOS 17.09 is EOLed, in
+        # 18.03 `devtmpfs` is used which makes the block creation obsolete
+        # (see https://github.com/NixOS/nixpkgs/commit/0d27df280f7ed502bba65e2ea13469069f9b275a)
         if [ ! -b /dev/vda1 ]; then
           . /sys/class/block/vda1/uevent
           mknod /dev/vda1 b $MAJOR $MINOR


### PR DESCRIPTION
see NixOS/nixpkgs@0d27df2 for further reference

With this call the build using `nix-build nix/libvirtd-image.nix` failed
as the build script attempted to recreate `/dev/vda1`:

```
loading kernel modules...
node1> mounting Nix store...
node1> mounting host's temporary directory...
node1> starting stage 2 (/nix/store/r32wfcabkjn235wdr29c8d5bl89rl5hn-vm-run-stage2)
node1> Information: You may need to update /etc/fstab.
node1>
node1> Information: You may need to update /etc/fstab.
node1>
node1> mknod: /dev/vda1: File exists
node1> [    0.822831] reboot: Power down
node1> builder for '/nix/store/wds74n3rh3cfidy16rsnr7fk0hlbb2iz-libvirtd-image.drv' failed with exit code 1
node1> cannot build derivation '/nix/store/kk872nl1mldmqym0gpry0zmnpnhmwcdl-libvirtd-ssh-image.drv': 1 dependencies couldn't be built
node1> error: build of '/nix/store/kk872nl1mldmqym0gpry0zmnpnhmwcdl-libvirtd-ssh-image.drv' failed
error: command ‘['nix-build', '-I', 'nixops=/nix/store/i9j7bm77bl0ad4wqqbfqmc3w60n9zxgr-nixops-1.5.2/share/nix/nixops', '--arg', 'networkExprs', '[ "/home/ma27/Projects/node1/nixops/libvirtd.nix" "/home/ma27/Projects/node1/nixops/cluster.nix" ]', '--arg', 'args', '{}', '--argstr', 'uuid', u'376c50fa-eca7-11e7-8960-024295226d2c', '--argstr', 'deploymentName', u'node1', '<nixops/eval-machine-info.nix>', '--arg', 'checkConfigurationOptions', 'false', '-A', 'nodes.node1.config.deployment.libvirtd.baseImage', '-o', '/tmp/nixops-tmpx5uITs/libvirtd-image-node1']’ failed on machine ‘node1’ (exit code 100)
```

Since the addition of `tmpfs` to the VM builds these to commands can be
omitted.