### PR TITLE
libvirtd: fix mknod error

### DIFF
--- a/nix/libvirtd-image.nix
+++ b/nix/libvirtd-image.nix
@@ -38,8 +38,12 @@ in pkgs.vmTools.runInLinuxVM (
       # Create a single / partition.
       ${pkgs.parted}/sbin/parted /dev/vda mklabel msdos
       ${pkgs.parted}/sbin/parted /dev/vda -- mkpart primary ext2 1M -1s
-      . /sys/class/block/vda1/uevent
-      mknod /dev/vda1 b $MAJOR $MINOR
+
+      if [ ! -b /dev/vda1 ] 
+      then
+          . /sys/class/block/vda1/uevent
+          ${pkgs.coreutils}/bin/mknod /dev/vda1 b $MAJOR $MINOR
+      fi
 
       # Create an empty filesystem and mount it.
       ${pkgs.e2fsprogs}/sbin/mkfs.ext4 -L nixos /dev/vda1

--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -22,8 +22,12 @@ let
           '';
       }
       ''
-        . /sys/class/block/vda1/uevent
-        mknod /dev/vda1 b $MAJOR $MINOR
+        if [ ! -b /dev/vda1 ] 
+        then
+            . /sys/class/block/vda1/uevent
+            mknod /dev/vda1 b $MAJOR $MINOR
+        fi
+
         mkdir /mnt
         mount /dev/vda1 /mnt
 


### PR DESCRIPTION
This changeset modifies the libvirtd image Nix expressions to only call `mknod` when the block device doesn't already exist, therefore avoiding a build failure.

ref #827