### PR TITLE
Fixes a warning when running tests.

### DIFF
--- a/tests/functional/single_machine_secret_key.nix
+++ b/tests/functional/single_machine_secret_key.nix
@@ -2,6 +2,6 @@
   machine.deployment = {
     storeKeysOnMachine = false;
 
-    keys."secret.key" = "12345";
+    keys."secret.key".text = "12345";
   };
 }


### PR DESCRIPTION
Assigning a plaintext value directly to keys.someKeyName is deprecated.