### PR TITLE
Testing port 22 if the targetPort fails

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -955,6 +955,7 @@ class Deployment(object):
                         # attribute, because the machine may have been
                         # booted from an older NixOS image.
                         if not r.state_version:
+                            r.wait_for_ssh(check=True)
                             os_release = r.run_command("cat /etc/os-release", capture_stdout=True)
                             match = re.search('VERSION_ID="([0-9]+\.[0-9]+).*"', os_release)
                             if match:
@@ -962,8 +963,8 @@ class Deployment(object):
                                 r.log("setting state version to {0}".format(r.state_version))
                             else:
                                 r.warn("cannot determine NixOS version")
-
-                        r.wait_for_ssh(check=check)
+                        else:
+                            r.wait_for_ssh(check=check)
                         r.generate_vpn_key()
 
                 except:

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -196,7 +196,12 @@ def wait_for_tcp_port(ip, port, timeout=-1, open=True, callback=None):
     """Wait until the specified TCP port is open or closed."""
     n = 0
     while True:
-        if ping_tcp_port(ip, port, ensure_timeout=True) == open: return True
+        if ping_tcp_port(ip, port, ensure_timeout=True) == open: return port
+        # If we're waiting for `port` to open, and it doesn't, then
+        # maybe we're in the bootstrap phase, and OpenSSH only listens
+        # on port 22.
+        if open and port != 22:
+            if ping_tcp_port(ip, 22, ensure_timeout=True): return 22
         if not open: time.sleep(1)
         n = n + 1
         if timeout != -1 and n >= timeout: break


### PR DESCRIPTION
During the bootstrap phase, OpenSSH runs on port 22 instead of `targetPort`. This commit tries port 22 if the initial attempt on `targetPort` fails. This seems to fix #796 and #752.