### PR TITLE
Json output option for show-option

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -369,7 +369,7 @@ class Deployment(object):
                 self.definitions[name] = defn
 
 
-    def evaluate_option_value(self, machine_name, option_name, xml=False, include_physical=False):
+    def evaluate_option_value(self, machine_name, option_name, json=False, xml=False, include_physical=False):
         """Evaluate a single option of a single machine in the deployment specification."""
 
         exprs = self.nix_exprs
@@ -387,6 +387,7 @@ class Deployment(object):
                 ["--eval-only", "--strict",
                  "--arg", "checkConfigurationOptions", "false",
                  "-A", "nodes.{0}.config.{1}".format(machine_name, option_name)]
+                + (["--json"] if json else [])
                 + (["--xml"] if xml else []),
                 stderr=self.logger.log_file)
         except subprocess.CalledProcessError:

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -631,7 +631,7 @@ def op_show_option():
     depl = open_deployment()
     if args.include_physical:
         depl.evaluate()
-    sys.stdout.write(depl.evaluate_option_value(args.machine, args.option, xml=args.xml, include_physical=args.include_physical))
+    sys.stdout.write(depl.evaluate_option_value(args.machine, args.option, json=args.json, xml=args.xml, include_physical=args.include_physical))
 
 
 def check_rollback_enabled():
@@ -930,6 +930,7 @@ subparser.set_defaults(op=op_show_option)
 subparser.add_argument('machine', metavar='MACHINE', help='identifier of the machine')
 subparser.add_argument('option', metavar='OPTION', help='option name')
 subparser.add_argument('--xml', action='store_true', help='print the option value in XML format')
+subparser.add_argument('--json', action='store_true', help='print the option value in JSON format')
 subparser.add_argument('--include-physical', action='store_true', help='include the physical specification in the evaluation')
 
 subparser = add_subparser('list-generations', help='list previous configurations to which you can roll back')


### PR DESCRIPTION
This adds a `--json` flag to the `show-option` command that simply passes `--json` to `nix-instantiate` much like `--xml` does.