### PR TITLE
Don't use port open check to determine if reboot completed. Fixes #856.

### DIFF
--- a/nixops/backends/azure_vm.py
+++ b/nixops/backends/azure_vm.py
@@ -953,7 +953,8 @@ class AzureState(MachineState, ResourceState):
             self.log("sending hard reset to Azure machine...")
             self.cmc().virtual_machines.restart(self.resource_group, self.machine_name)
             self.state = self.STARTING
-            self.ssh.reset()
+            if reset:
+                self.ssh.reset()
         else:
             MachineState.reboot(self, hard=hard)
         self.ssh_pinged = False

--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -318,6 +318,10 @@ class HetznerState(MachineState):
             server.reboot('hard')
             self.log_end("done.")
             self.state = self.STARTING
+            # Note we always reset the connection because on a hard reboot, the
+            # other side may not have a chance to terminate the SSH connection,
+            # (send TCP RST), which could lead to the control master process
+            # still being alive and hanging until the TCP connection times out.
             self.ssh.reset()
         else:
             MachineState.reboot(self, hard=hard)


### PR DESCRIPTION
See #856

The old approach, waiting for the machine to not having an open
port, and then waiting for it to be open again, was insufficient,
because of the race condition that the machine rebooted so quickly
that the port was immediately open again without nixops noticing
that it went down. I experienced this on a Hetzner cloud server.

The new approach checks the `last reboot` on the remote side
to change, which is not racy.