### PR TITLE
fix: makes sure `.format` does not implicitly convert `unicode` to `str`

### DIFF
--- a/nixops/nix_expr.py
+++ b/nixops/nix_expr.py
@@ -156,7 +156,7 @@ def py2nix(value, initial_indentation=0, maxwidth=80, inline=False):
             ("\t", "\\t"),
         ])
 
-        inline_variant = RawValue('"{0}"'.format(encoded))
+        inline_variant = RawValue(u'"{0}"'.format(encoded))
 
         if for_attribute:
             return inline_variant.value


### PR DESCRIPTION
Currently, `'"{0}"'.format(encoded)` implicitly convert `encoded` (already a `unicode` string) into a `str` (byte) string, which causes an error if the `encoded` variable actually contains non-ascii characters. See [anonbadger's blog post](https://anonbadger.wordpress.com/2016/01/05/python2-string-format-and-unicode/) for more details on the issue.

Nixops fails on my session because the `encoded` variable, representing the nix file path, contains an 'é' character:
```python
u'/home/adam/D\xe9veloppement/nixops/test/trivial.nix'
```

Converting the `'"{0}"'` byte string (`str`) to `unicode` fixes #869.