### PR TITLE
get release from config.system.nixos.release as fallback

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -303,7 +303,7 @@ rec {
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
         { inherit (v.config.deployment) targetEnv targetPort targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys hasFastConnection;
-          nixosRelease = v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
+          nixosRelease = v.config.system.nixosRelease or v.config.system.nixos.release or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
           azure = optionalAttrs (v.config.deployment.targetEnv == "azure")  v.config.deployment.azure;
           ec2 = optionalAttrs (v.config.deployment.targetEnv == "ec2") v.config.deployment.ec2;
           digitalOcean = optionalAttrs (v.config.deployment.targetEnv == "digitalOcean") v.config.deployment.digitalOcean;


### PR DESCRIPTION
Not sure why but recently started seeing eval problems
complaining about lack of nixosVersion, this fix
tries to get "config.system.nixos.release" after
failing to get config.system.nixosRelease,
inspired by recent plymouth change:

0500cf79afeb3e0c61458b202b361064397a7776

I've no idea when/if/why nixosVersion should be used,
hopefully it's the most legacy of the options...?

Sorry for less-than-thorough background research
on this PR, hopefully it's still useful!