### PR TITLE
ec2/eval-machine-info: Change config.system.nixosVersion to config.system.nixos.version, because the former doesn't exist in newer releases of nixos

### DIFF
--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -150,7 +150,7 @@ let
     then "/dev/" + builtins.substring 12 100 dev
     else dev;
 
-  nixosVersion = builtins.substring 0 5 config.system.nixosVersion;
+  nixosVersion = builtins.substring 0 5 config.system.nixos.version;
 
   amis = import <nixpkgs/nixos/modules/virtualisation/ec2-amis.nix>;
 

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -303,7 +303,7 @@ rec {
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
         { inherit (v.config.deployment) targetEnv targetPort targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys hasFastConnection;
-          nixosRelease = v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
+          nixosRelease = v.config.system.nixosRelease or (removeSuffix v.config.system.nixos.versionSuffix v.config.system.nixos.version);
           azure = optionalAttrs (v.config.deployment.targetEnv == "azure")  v.config.deployment.azure;
           ec2 = optionalAttrs (v.config.deployment.targetEnv == "ec2") v.config.deployment.ec2;
           digitalOcean = optionalAttrs (v.config.deployment.targetEnv == "digitalOcean") v.config.deployment.digitalOcean;


### PR DESCRIPTION
I bumped into this bug while doing development work on a nixpkgs and wanting to pull in latest master of nixpkgs to base my work on.
All of a sudden I was getting an error that nixops couldn't find config.system.nixosVersion, even tho I had the relevant entries in rename.nix, and I found in the version module that the variable had been renamed to config.system.nixos.version.

I've verified that with this patch, nixops works again when running from nixpkgs master, so my guess is that its just a matter of time before this change trickles down to the channels and thus breaking nixops.