### PR TITLE
libvirt: fail early when defining domain

### DIFF
--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -123,6 +123,13 @@ class LibvirtdState(MachineState):
             (self.client_private_key, self.client_public_key) = nixops.util.create_key_pair()
 
         if self.vm_id is None:
+            # By using "define" we ensure that the domain is
+            # "persistent", as opposed to "transient" (i.e. removed on reboot).
+            self._dom = self.conn.defineXML(self.domain_xml)
+            if self._dom is None:
+                self.log('Failed to register domain XML with the hypervisor')
+                return False
+
             newEnv = copy.deepcopy(os.environ)
             newEnv["NIXOPS_LIBVIRTD_PUBKEY"] = self.client_public_key
             base_image = self._logged_exec(
@@ -143,9 +150,6 @@ class LibvirtdState(MachineState):
                                "", self.disk_path])
             os.chmod(self.disk_path, 0660)
             self.vm_id = self._vm_id()
-            # By using "define" we ensure that the domain is
-            # "persistent", as opposed to "transient" (i.e. removed on reboot).
-            self._dom = self.conn.defineXML(self.domain_xml)
 
         self.start()
         return True


### PR DESCRIPTION
so that it prevents creating unnecessary ressources that wre not cleaned
on failure (with a wrong domain XML).