### PR TITLE
Add new option "NIXOPS_SSHOPTS"

### DIFF
--- a/doc/manual/nixops.xml
+++ b/doc/manual/nixops.xml
@@ -199,6 +199,14 @@ cloud.</para>
 
   </varlistentry>
 
+  <varlistentry><term><envar>NIXOPS_SSHOPTS</envar></term>
+
+    <listitem><para>Extra ssh flags passed when executing
+      remote actions, useful to override things like the base ssh config
+      file.</para></listitem>
+
+  </varlistentry>
+
   <varlistentry><term><envar>EC2_ACCESS_KEY</envar></term>
     <term><envar>AWS_ACCESS_KEY_ID</envar></term>
 

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -3,6 +3,7 @@
 import os
 import re
 import subprocess
+import shlex
 
 import nixops.util
 import nixops.resources
@@ -275,10 +276,17 @@ class MachineState(nixops.resources.ResourceState):
         assert False
 
     def get_ssh_flags(self, scp=False):
+        flags = []
+        extra_opts = os.getenv('NIXOPS_SSHOPTS', None)
+        if extra_opts:
+            flags += shlex.split(extra_opts)
+
         if scp:
-            return ["-P", str(self.ssh_port)]
+            flags += ["-P", str(self.ssh_port)]
         else:
-            return ["-p", str(self.ssh_port)]
+            flags += ["-p", str(self.ssh_port)]
+
+        return flags
 
 
     def get_ssh_password(self):


### PR DESCRIPTION
This new option is an escape hatch allowing
you to pass arbitrary flags to ssh. This
was added to help do things like bootstrap
a 'none' deployment in an unusual environment.