### PR TITLE
Allow non-subdomains in EC2 Route53

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -1191,7 +1191,7 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
 
         self.connect_route53()
 
-        hosted_zone = ".".join(self.dns_hostname.split(".")[1:])
+        hosted_zone = self.dns_hostname
         zones = self._retry_route53(lambda: self._conn_route53.get_all_hosted_zones())
 
         def testzone(hosted_zone, zone):


### PR DESCRIPTION
This is part issue part PR. I don't actually have any idea why this was like this to begin with, but it seems deliberate. But this change works for me, so I'm opening a PR to see what ought to be done.

For some reason, you can't use `deployment.ec2.route53` to bind a non-subdomain like `foo.com` to an EC2 instance.