### PR TITLE
[RDY] Format domain XML from a file to allow for more flexibility

### DIFF
--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -53,6 +53,32 @@ in
       '';
     };
 
+    deployment.libvirtd.template = mkOption {
+      type = types.str;
+      default = ''<domain type="{domain_type}">
+          <name>{name}</name>
+          <memory unit="MiB">{memory_size}</memory>
+          <vcpu>{vcpu}</vcpu>
+          {os}
+          <devices>
+              <emulator>{emulator}</emulator>
+            <disk type="file" device="disk">
+              <driver name="qemu" type="qcow2"/>
+              <source file="{diskPath}"/>
+              <target dev="hda"/>
+            </disk>
+            {interfaces}
+            <input type="keyboard" bus="usb"/>
+            <input type="mouse" bus="usb"/>
+            {extra_devices}
+          </devices>
+          {extra_domain}
+        </domain>'';
+      description = ''
+        Template for the libvirt domain. You can use all other parameters.
+      '';
+    };
+
     deployment.libvirtd.vcpu = mkOption {
       default = 1;
       type = types.int;


### PR DESCRIPTION
Related to https://github.com/NixOS/nixops/issues/883.

The PR adds a  deployment.libvirtd.template setting so that users can upload their own domain.xml. They can use a few variables that will be replaced such as {interfaces} (look at domain.xml.in for an example). 
I wonder if it wouldn't be best to accept a string instead of a filename ?

I need to test it a bit more.