### PR TITLE
Add spot_instance_price to the reset function

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -156,6 +156,7 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
 
             self.client_token = None
             self.spot_instance_request_id = None
+            self.spot_instance_price = None
 
     def get_ssh_name(self):
         retVal = None


### PR DESCRIPTION
This will reset the spot_instance_price in the database when the machine is gone. Fixes #897.