### PR TITLE
nixops script: Remove top-level Exception catch-all.

### DIFF
--- a/scripts/nixops
+++ b/scripts/nixops
@@ -993,7 +993,3 @@ except MultipleExceptions as e:
     if args.debug or args.show_trace or str(e) == "":
         e.print_all_backtraces()
     sys.exit(1)
-except Exception as e:
-    if args.debug or args.show_trace or str(e) == "": raise
-    error(str(e))
-    sys.exit(1)


### PR DESCRIPTION
Below is a small patch to fix one of my biggest gripes in using and developing nixops, and in helping colleagues and friends fix their problems.

---

Having this catch-all made it difficult to develop and troubleshoot
nixops.

For example, when adding a new backend and forgetting to add the
corresponding `option` in the `.nix` file, nixops would die simply
with

    error: 'serverType'

which is not a good indication over what went wrong.
Specifically so because `error(str(e))` removed the type of the
exception, turning `KeyError: 'serverType'` into just `serverType`.

So far, you could pass `--show-trace` or `--debug` to see
Python stack traces.
However, that requires the error to be easily reproducible
(when you see it, you have to run again with `--show-trace`),
making debugging of rare problems hard.

For an ops tool we should make debugging of rare/unknown
problems as easy as possible.
Consequently, this commit makes Python raise the `Exception`
with stack trace if we have no idea at all what the exception
type is.

The other cases (when we know what exception type it is)
remain unaffected.