### PR TITLE
Add labelling for newly created GCP disks and snapshots

### DIFF
--- a/nixops/backends/gce.py
+++ b/nixops/backends/gce.py
@@ -785,14 +785,15 @@ class GCEState(MachineState, ResourceState):
             # Apply labels to snapshot just created
             self.wait_for_snapshot_initiated(snapshot_name)
 
-            self.log("updating labels of snapshot '{0}'".format(snapshot_name))
-            self.connect().connection.request(
-                '/global/snapshots/%s/setLabels' %(snapshot_name),
-                method = 'POST', data = {
-                    'labels': defn.labels,
-                    'labelFingerprint':
-                        self.connect().connection.request("/global/snapshots/{0}".format(snapshot_name), method='GET').object['labelFingerprint']
-            })
+            if defn.labels:
+                self.log("updating labels of snapshot '{0}'".format(snapshot_name))
+                self.connect().connection.request(
+                    '/global/snapshots/%s/setLabels' %(snapshot_name),
+                    method = 'POST', data = {
+                        'labels': defn.labels,
+                        'labelFingerprint':
+                            self.connect().connection.request("/global/snapshots/{0}".format(snapshot_name), method='GET').object['labelFingerprint']
+                })
 
             backup[k] = snapshot_name
             _backups[backup_id] = backup

--- a/nixops/backends/gce.py
+++ b/nixops/backends/gce.py
@@ -801,8 +801,8 @@ class GCEState(MachineState, ResourceState):
     def wait_for_snapshot_initiated(self, snapshot_name):
         while True:
             try:
-                snapshot_status = self.connect().connection.request("/global/snapshots/{0}".format(snapshot_name), method='GET').object['status']
-                if snapshot_status in "READY" "CREATING" "UPLOADING":
+                snapshot = self.connect().ex_get_snapshot(snapshot_name)
+                if snapshot.status in "READY" "CREATING" "UPLOADING":
                     self.log_end(" done")
                     break
                 else:

--- a/nixops/backends/gce.py
+++ b/nixops/backends/gce.py
@@ -806,7 +806,7 @@ class GCEState(MachineState, ResourceState):
                     self.log_end(" done")
                     break
                 else:
-                    raise Exception("snapshot '{0}' is in an unexpected state {1}".format(snapshot_name, snapshot_status))
+                    raise Exception("snapshot '{0}' is in an unexpected state {1}".format(snapshot_name, snapshot.status))
             except libcloud.common.google.ResourceNotFoundError:
                 self.log_continue(".")
                 time.sleep(1)


### PR DESCRIPTION
GCE labels are very useful for grouping together resources from the same development stage, easily searching for and separatly treating resources intended for production from the ones of development .. Among use cases are Usage reports, Billing export ..

This was done the same way as in: https://github.com/NixOS/nixops/pull/866
Also, looking in [gce.py](https://github.com/apache/libcloud/blob/trunk/libcloud/compute/drivers/gce.py ), Libcloud seem to yet only support labelling of nodes or images (none for disks and snapshots).