### PR TITLE
Allow AWS temporary credentials with session tokens

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -287,9 +287,9 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
             return
 
         # Get the secret access key from the environment or from ~/.ec2-keys.
-        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.route53_access_key_id)
+        creds = nixops.ec2_utils.fetch_aws_secret_key_boto2(self.route53_access_key_id)
 
-        self._conn_route53 = boto.connect_route53(access_key_id, secret_access_key)
+        self._conn_route53 = boto.connect_route53(**creds)
 
 
     def _get_spot_instance_request_by_id(self, request_id, allow_missing=False):

--- a/nixops/resources/cloudwatch_log_group.py
+++ b/nixops/resources/cloudwatch_log_group.py
@@ -60,9 +60,8 @@ class CloudWatchLogGroupState(nixops.resources.ResourceState):
     def connect(self):
         if self._conn: return
         assert self.region
-        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-        self._conn = boto.logs.connect_to_region(
-            region_name=self.region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+        creds = nixops.ec2_utils.fetch_aws_secret_key_boto2(self.access_key_id)
+        self._conn = boto.logs.connect_to_region(region_name=self.region, **creds)
 
     def _destroy(self):
         if self.state != self.UP: return

--- a/nixops/resources/cloudwatch_log_stream.py
+++ b/nixops/resources/cloudwatch_log_stream.py
@@ -60,9 +60,8 @@ class CloudWatchLogStreamState(nixops.resources.ResourceState):
     def connect(self):
         if self._conn: return
         assert self.region
-        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-        self._conn = boto.logs.connect_to_region(
-            region_name=self.region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+        creds = nixops.ec2_utils.fetch_aws_secret_key_boto2(self.access_key_id)
+        self._conn = boto.logs.connect_to_region(region_name=self.region, **creds)
 
     def _destroy(self):
         if self.state != self.UP: return

--- a/nixops/resources/cloudwatch_metric_alarm.py
+++ b/nixops/resources/cloudwatch_metric_alarm.py
@@ -74,11 +74,8 @@ class CloudwatchMetricAlarmState(nixops.resources.ResourceState):
 
     def boto_session(self, region):
         if self._boto_session is None:
-            (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-            self._boto_session = boto3.session.Session(
-                                               aws_access_key_id=access_key_id,
-                                               aws_secret_access_key=secret_access_key,
-                                               region_name=self.region)
+            creds = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+            self._boto_session = boto3.session.Session(region_name=self.region, **creds)
         return self._boto_session
 
     def create(self, defn, check, allow_reboot, allow_recreate):

--- a/nixops/resources/ec2_common.py
+++ b/nixops/resources/ec2_common.py
@@ -57,12 +57,11 @@ class EC2CommonState():
         if hasattr(self, '_client'):
             if self._client: return self._client
         assert self._state['region']
-        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+        creds = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
         self._client = boto3.session.Session().client(
             service_name=service,
             region_name=self._state['region'],
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=secret_access_key)
+            **creds)
         return self._client
 
     def reset_client(self):

--- a/nixops/resources/ec2_rds_dbinstance.py
+++ b/nixops/resources/ec2_rds_dbinstance.py
@@ -95,9 +95,8 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
 
     def _connect(self):
         if self._conn: return
-        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-        self._conn = boto.rds.connect_to_region(
-            region_name=self.region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+        creds = nixops.ec2_utils.fetch_aws_secret_key_boto2(self.access_key_id)
+        self._conn = boto.rds.connect_to_region(region_name=self.region, **creds)
 
     def _exists(self):
         return self.state != self.MISSING and self.state != self.UNKNOWN

--- a/nixops/resources/efs_common.py
+++ b/nixops/resources/efs_common.py
@@ -8,10 +8,10 @@ class EFSCommonState():
     def _get_client(self, access_key_id=None, region=None):
         if self._client: return self._client
 
-        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(access_key_id or self.access_key_id)
+        creds = nixops.ec2_utils.fetch_aws_secret_key(access_key_id or self.access_key_id)
 
-        self._client = boto3.session.Session().client('efs', region_name=region or self.region, \
-                                                     aws_access_key_id=access_key_id, \
-                                                     aws_secret_access_key=secret_access_key)
+        self._client = boto3.session.Session().client('efs',
+                                                      region_name=region or self.region,
+                                                      **creds)
 
         return self._client

--- a/nixops/resources/iam_role.py
+++ b/nixops/resources/iam_role.py
@@ -75,9 +75,8 @@ class IAMRoleState(nixops.resources.ResourceState):
 
     def connect(self):
         if self._conn: return
-        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-        self._conn = boto.connect_iam(
-            aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+        creds = nixops.ec2_utils.fetch_aws_secret_key_boto2(self.access_key_id)
+        self._conn = boto.connect_iam(**creds)
 
 
     def _destroy(self):

--- a/nixops/resources/route53_health_check.py
+++ b/nixops/resources/route53_health_check.py
@@ -74,10 +74,8 @@ class Route53HealthCheckState(nixops.resources.ResourceState):
 
     def boto_session(self):
         if self._boto_session is None:
-            (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-            self._boto_session = boto3.session.Session(
-                                               aws_access_key_id=access_key_id,
-                                               aws_secret_access_key=secret_access_key)
+            creds = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+            self._boto_session = boto3.session.Session(**creds)
         return self._boto_session
 
     def resolve_health_check(self, id):

--- a/nixops/resources/route53_hosted_zone.py
+++ b/nixops/resources/route53_hosted_zone.py
@@ -66,10 +66,8 @@ class Route53HostedZoneState(nixops.resources.ResourceState):
 
     def boto_session(self):
         if self._boto_session is None:
-            (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-            self._boto_session = boto3.session.Session(
-                                               aws_access_key_id=access_key_id,
-                                               aws_secret_access_key=secret_access_key)
+            creds = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+            self._boto_session = boto3.session.Session(**creds)
         return self._boto_session
 
     def create(self, defn, check, allow_reboot, allow_recreate):

--- a/nixops/resources/route53_recordset.py
+++ b/nixops/resources/route53_recordset.py
@@ -79,10 +79,8 @@ class Route53RecordSetState(nixops.resources.ResourceState):
 
     def boto_session(self):
         if self._boto_session is None:
-            (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-            self._boto_session = boto3.session.Session(
-                                               aws_access_key_id=access_key_id,
-                                               aws_secret_access_key=secret_access_key)
+            creds = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+            self._boto_session = boto3.session.Session(**creds)
         return self._boto_session
 
     def create(self, defn, check, allow_reboot, allow_recreate):

--- a/nixops/resources/s3_bucket.py
+++ b/nixops/resources/s3_bucket.py
@@ -69,10 +69,9 @@ class S3BucketState(nixops.resources.ResourceState):
 
     def connect(self):
         if self._conn: return
-        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+        creds = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
         self._conn = boto3.session.Session(region_name=self.region if self.region != "US" else "us-east-1",
-                                           aws_access_key_id=access_key_id,
-                                           aws_secret_access_key=secret_access_key)
+                                           **creds)
 
     def create(self, defn, check, allow_reboot, allow_recreate):
 

--- a/nixops/resources/sns_topic.py
+++ b/nixops/resources/sns_topic.py
@@ -65,9 +65,8 @@ class SNSTopicState(nixops.resources.ResourceState):
     def connect(self):
         if self._conn: return
         assert self.region
-        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-        self._conn = boto.sns.connect_to_region(
-            region_name=self.region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+        creds = nixops.ec2_utils.fetch_aws_secret_key_boto2(self.access_key_id)
+        self._conn = boto.sns.connect_to_region(region_name=self.region, **creds)
 
     def _destroy(self):
         if self.state != self.UP: return

--- a/nixops/resources/sqs_queue.py
+++ b/nixops/resources/sqs_queue.py
@@ -72,9 +72,8 @@ class SQSQueueState(nixops.resources.ResourceState):
     def connect(self):
         if self._conn: return
         assert self.region
-        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-        self._conn = boto.sqs.connect_to_region(
-            region_name=self.region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+        creds = nixops.ec2_utils.fetch_aws_secret_key_boto2(self.access_key_id)
+        self._conn = boto.sqs.connect_to_region(region_name=self.region, **creds)
 
 
     def _destroy(self):


### PR DESCRIPTION
This allows passing the session token of AWS temporary credentials to boto. This helps when the AWS credentials came from assuming a role or using a MFA token.

I just hacked this up now and it works for my ec2/route53 test. If the approach seems right to you, I can add some documentation and check that the use case of #938 can work by specifying an empty access_key_id.
