### PR TITLE
DO NOT MERGE: Nix 2 out of memory workaround

### DIFF
--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -150,7 +150,10 @@ let
     then "/dev/" + builtins.substring 12 100 dev
     else dev;
 
-  nixosVersion = builtins.substring 0 5 (config.system.nixos.version or config.system.nixosVersion);
+  nixosVersion =
+    if cfg.nixosAmiVersion != null
+      then cfg.nixosAmiVersion
+      else builtins.substring 0 5 (config.system.nixos.version or config.system.nixosVersion);
 
   amis = import <nixpkgs/nixos/modules/virtualisation/ec2-amis.nix>;
 
@@ -233,6 +236,17 @@ in
       description = ''
         EC2 identifier of the AMI disk image used in the virtual
         machine.  This must be a NixOS image providing SSH access.
+      '';
+    };
+
+    deployment.ec2.nixosAmiVersion = mkOption {
+      example = "17.09";
+      type = types.nullOr types.str;
+      description = ''
+        NixOS version to choose AMIs from.
+        Has no effect if <option>ami</option> is set.
+        Useful if you want the base image to be a different NixOS version
+        than the system you will eventually deploy.
       '';
     };
 


### PR DESCRIPTION
This is a workaround for the `out of memory` issue introduced with Nix 2 and present in NixOS 18.03 images (e.g. NixOS 18.03 AMIs).

It includes my fix from https://github.com/NixOS/nix/pull/2206

## How to use this workaround

Use this branch and set

```
deployment.ec2.nixosAmiVersion = "17.09";
```

for your AWS machines.

That will ensure the machine gets initially deployed with 17.09 which doesn't have the memory problem, will then get nix 2 with my patch deployed, so that in no of the two states is the problem present.

---

This is probably not intended to be merged, at least not with the hard nix override in the second patch.

However, if we made that override an option, then we could merge this.

Right now this is just to present a publicly visible workaround for people to use, until there's an official `nix` release with the fix.