### PR TITLE
libvirtd build: drop support for `tmpfs` during image build

### DIFF
--- a/nix/libvirtd-image.nix
+++ b/nix/libvirtd-image.nix
@@ -39,14 +39,6 @@ in pkgs.vmTools.runInLinuxVM (
       ${pkgs.parted}/sbin/parted /dev/vda mklabel msdos
       ${pkgs.parted}/sbin/parted /dev/vda -- mkpart primary ext2 1M -1s
 
-      # TODO (@Ma27) remove this entirely after NixOS 17.09 is EOLed, in
-      # 18.03 `devtmpfs` is used which makes the block creation obsolete
-      # (see https://github.com/NixOS/nixpkgs/commit/0d27df280f7ed502bba65e2ea13469069f9b275a)
-      if [ ! -b /dev/vda1 ]; then
-        . /sys/class/block/vda1/uevent
-        mknod /dev/vda1 b $MAJOR $MINOR
-      fi
-
       # Create an empty filesystem and mount it.
       ${pkgs.e2fsprogs}/sbin/mkfs.ext4 -L nixos /dev/vda1
       ${pkgs.e2fsprogs}/sbin/tune2fs -c 0 -i 0 /dev/vda1

--- a/nix/libvirtd.nix
+++ b/nix/libvirtd.nix
@@ -22,14 +22,6 @@ let
           '';
       }
       ''
-        # TODO (@Ma27) remove this entirely after NixOS 17.09 is EOLed, in
-        # 18.03 `devtmpfs` is used which makes the block creation obsolete
-        # (see https://github.com/NixOS/nixpkgs/commit/0d27df280f7ed502bba65e2ea13469069f9b275a)
-        if [ ! -b /dev/vda1 ]; then
-          . /sys/class/block/vda1/uevent
-          mknod /dev/vda1 b $MAJOR $MINOR
-        fi
-
         mkdir /mnt
         mount /dev/vda1 /mnt
 


### PR DESCRIPTION
*Note*: caution, this patch breaks the compatibility with NixOS 17.09 and
should only be used in unstable branches.

Originally https://github.com/NixOS/nixpkgs/commit/0d27df280f7ed502bba65e2ea13469069f9b275a
dropped support for `tempfs` which broke the libvirtd image build as it
still created custom kernel nodes.

These `mkdnod` calls were wrapped by conditionls to keep support with 17.09,
but now as 17.09 is the oldstable release which only receives security
fixes (https://groups.google.com/forum/#!msg/nix-devel/7bRK8FUcC5s/CV4-i0JdBgAJ),
so it's time to drop this compliance hacks.