### PR TITLE
deployment.py: handle checking DiffStateEngineResourceState

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -1257,10 +1257,12 @@ def _create_definition(xml, config, type_name):
 
 def _create_state(depl, type, name, id):
     """Create a resource state object of the desired type."""
-
     for cls in _subclasses(nixops.resources.ResourceState):
-        if type == cls.get_type():
-            return cls(depl, name, id)
+        try:
+            if type == cls.get_type():
+                return cls(depl, name, id)
+        except NotImplementedError:
+            pass
 
     raise nixops.deployment.UnknownBackend("unknown resource type ‘{0}’".format(type))
 


### PR DESCRIPTION
Doing some ... weird ... stuff .. I found:

_subclasses returns:

[<class 'nixops.resources.DiffEngineResourceState'>,
 <class 'nixops.backends.none.NoneState'>,
 <class 'nixops.resources.ssh_keypair.SSHKeyPairState'>]

which can cause the comparisons to happen in the wrong order, resulting in

  File /nix/store/iym5qcmlwbxi7f66mh7bsv4jfnybhgrs-python2.7-nixops-1.6.1pre0_abcdef/lib/python2.7/site-packages/nixops/resources/__init__.py, line 40, in get_type
    raise NotImplementedError(get_type)
NotImplementedError: get_type

...oops

This handles that and allows continued comparisons.