### PR TITLE
nix/auto-luks.nix: remove reference to auto-generated passphrase

### DIFF
--- a/nix/auto-luks.nix
+++ b/nix/auto-luks.nix
@@ -44,16 +44,13 @@ with utils;
             default = "";
             type = types.str;
             description = ''
-              The passphrase (key file) used to decrypt the key to access
-              the volume.  If left empty, a passphrase is generated
-              automatically; this passphrase is lost when you destroy the
-              machine or underlying device, unless you copy it from
-              NixOps's state file.  Note that unless
+              The passphrase (key file) used to decrypt the key to access the
+              volume.  Note that unless
               <option>deployment.storeKeysOnMachine</option> is set to
-              <literal>false</literal>, the passphrase is stored in the
-              Nix store of the instance, so an attacker who gains access
-              to the disk containing the store can subsequently decrypt
-              the encrypted volume.
+              <literal>false</literal>, the passphrase is stored in the Nix
+              store of the instance, so an attacker who gains access to the disk
+              containing the store can subsequently decrypt the encrypted
+              volume.
             '';
           };
 


### PR DESCRIPTION
If this feature exists, it doesn't work right now due to the assertion here: https://github.com/NixOS/nixops/blob/cf47cfdf75c515967597ffd43019c5f32e7f9e41/nix/auto-luks.nix#L102