### PR TITLE
Add a resource for GCE routes

### DIFF
--- a/examples/gce-route.nix
+++ b/examples/gce-route.nix
@@ -1,0 +1,52 @@
+/**
+ * A typical scenario where we want to route all traffic to an EC2
+ * machine through a NAT Gateway in GCE, only allowing the NAT Gateway IP
+ * in the security group of the EC2 instance.
+ *
+ * This mainly deploy two machines, one in EC2 "ec2machine" and the other
+ * one in GCE "nat-instance". The goal is to route all traffic in the
+ * default network in GCE the through "nat-instance".
+ *
+ * The deployment of the Security Group isn't included in this example.
+ */
+let
+   region = "us-east-1";
+   zone = "us-east-1a";
+in
+{
+  nat-instance =
+    { pkgs, resources, lib, ... }:
+    {
+      deployment.targetEnv = "gce";
+      deployment.gce = {
+       canIpForward = true;
+       region =  "us-central1-a";
+      };
+      networking.nat.enable = true;
+    };
+
+  resources.ec2KeyPairs.my-key-pair =
+    { inherit region; };
+
+  ec2machine =
+    { resources, lib, ... }:
+    {
+      deployment.targetEnv = "ec2";
+      deployment.ec2 = {
+        inherit region zone;
+        spotInstancePrice = 245;
+        instanceType = "m4.large";
+        associatePublicIpAddress = true;
+        keyPair = resources.ec2KeyPairs.my-key-pair ;
+      };
+    };
+
+  resources.gceRoutes.lb-default =
+    { resources, ... }:
+    {
+      destination = resources.machines.ec2machine;
+      priority = 800;
+      nextHop = resources.machines.nat-instance;
+      tags = [ "worker" ] ;
+    };
+}

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -266,6 +266,7 @@ rec {
   resources.gceForwardingRules = evalResources ./gce-forwarding-rule.nix (zipAttrs resourcesByType.gceForwardingRules or []);
   resources.gseBuckets = evalResources ./gse-bucket.nix (zipAttrs resourcesByType.gseBuckets or []);
   resources.gceImages = evalResources ./gce-image.nix (gce_default_bootstrap_images // ( zipAttrs resourcesByType.gceImages  or []) );
+  resources.gceRoutes = evalResources ./gce-routes.nix (zipAttrs resourcesByType.gceRoutes or []);
 
   gce_deployments = flip filterAttrs nodes
                       ( n: v: let dc = (scrubOptionValue v).config.deployment; in dc.targetEnv == "gce" );

--- a/nix/gce-routes.nix
+++ b/nix/gce-routes.nix
@@ -29,7 +29,8 @@ with import ./lib.nix lib;
 
       destination = mkOption {
         example ="1.1.1.1/32";
-        type = types.nullOr types.str;
+        type = types.nullOr (types.either types.str (resource "machine"));
+        apply = x: if x == null || (builtins.isString x) then x else "res-" + x._name;
         description = "The destination IP range that this route applies to. If the destination IP of a packet falls in this range, it matches this route.";
       };
 
@@ -43,7 +44,8 @@ with import ./lib.nix lib;
       nextHop = mkOption {
         default = null;
         example = "NAT-gateway";
-        type = types.nullOr types.str;
+        type = types.nullOr (types.either types.str (resource "machine"));
+        apply = x: if x == null || (builtins.isString x) then x else "res-" + x._name;
         description = "Next traffic hop, Leave it empty for the default internet gateway.";
       };
 

--- a/nix/gce-routes.nix
+++ b/nix/gce-routes.nix
@@ -28,10 +28,12 @@ with import ./lib.nix lib;
       };
 
       destination = mkOption {
-        example ="1.1.1.1/32";
+        example = "1.1.1.1/32";
         type = types.nullOr (types.either types.str (resource "machine"));
         apply = x: if x == null || (builtins.isString x) then x else "res-" + x._name;
-        description = "The destination IP range that this route applies to. If the destination IP of a packet falls in this range, it matches this route.";
+        description = ''
+          The destination IP range that this route applies to. If the destination IP of a packet falls in this range, it matches this route.
+        '';
       };
 
       priority = mkOption {

--- a/nix/gce-routes.nix
+++ b/nix/gce-routes.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, uuid, name, ... }:
+
+with lib;
+with import ./lib.nix lib;
+{
+
+  options = (import ./gce-credentials.nix lib "route") // {
+
+
+      name = mkOption {
+        example = "my-route";
+        type = types.str;
+        description = "Name of the route";
+      };
+
+      description = mkOption {
+        example = "my-custom-route";
+        default = null;
+        type = types.nullOr types.str;
+        description = "Textual description of the route";
+      };
+
+      network = mkOption {
+        example = "my-custom-network";
+        default = "default";
+        type = types.str;
+        description = "Name of the network, defaults to <literal>default</literal>.";
+      };
+
+      destination = mkOption {
+        example ="1.1.1.1/32";
+        type = types.nullOr types.str;
+        description = "The destination IP range that this route applies to. If the destination IP of a packet falls in this range, it matches this route.";
+      };
+
+      priority = mkOption {
+        default = 1000;
+        example = 800;
+        type = types.int;
+        description = "Priority is used to break ties when there is more than one matching route of maximum length.";
+      };
+
+      nextHop = mkOption {
+        default = null;
+        example = "NAT-gateway";
+        type = types.nullOr types.str;
+        description = "Next traffic hop, Leave it empty for the default internet gateway.";
+      };
+
+      tags = mkOption {
+        default = null;
+        type = types.nullOr (types.listOf types.str);
+        description = ''
+          The route applies to all instances with any of these tags, or to all instances in the network if no tags are specified
+        '';
+      };
+    };
+
+  config = {
+    _type = "gce-route";
+  };
+
+}

--- a/nix/gce-routes.nix
+++ b/nix/gce-routes.nix
@@ -24,7 +24,9 @@ with import ./lib.nix lib;
         example = "my-custom-network";
         default = "default";
         type = types.str;
-        description = "Name of the network, defaults to <literal>default</literal>.";
+        description = ''
+          Name of the network, defaults to <literal>default</literal>.
+        '';
       };
 
       destination = mkOption {
@@ -32,7 +34,9 @@ with import ./lib.nix lib;
         type = types.nullOr (types.either types.str (resource "machine"));
         apply = x: if x == null || (builtins.isString x) then x else "res-" + x._name;
         description = ''
-          The destination IP range that this route applies to. If the destination IP of a packet falls in this range, it matches this route.
+          The destination IP range that this route applies to. If the
+          destination IP of a packet falls in this range, it matches
+          this route.
         '';
       };
 
@@ -40,7 +44,10 @@ with import ./lib.nix lib;
         default = 1000;
         example = 800;
         type = types.int;
-        description = "Priority is used to break ties when there is more than one matching route of maximum length.";
+        description = ''
+          Priority is used to break ties when there is more than one
+          matching route of maximum length.
+        '';
       };
 
       nextHop = mkOption {
@@ -48,14 +55,17 @@ with import ./lib.nix lib;
         example = "NAT-gateway";
         type = types.nullOr (types.either types.str (resource "machine"));
         apply = x: if x == null || (builtins.isString x) then x else "res-" + x._name;
-        description = "Next traffic hop, Leave it empty for the default internet gateway.";
+        description = ''
+          Next traffic hop, Leave it empty for the default internet gateway.
+        '';
       };
 
       tags = mkOption {
         default = null;
         type = types.nullOr (types.listOf types.str);
         description = ''
-          The route applies to all instances with any of these tags, or to all instances in the network if no tags are specified
+          The route applies to all instances with any of these tags,
+          or to all instances in the network if no tags are specified
         '';
       };
     };

--- a/nix/gce-routes.nix
+++ b/nix/gce-routes.nix
@@ -6,10 +6,10 @@ with import ./lib.nix lib;
 
   options = (import ./gce-credentials.nix lib "route") // {
 
-
       name = mkOption {
         example = "my-route";
         type = types.str;
+        default = "route-${uuid}-${name}";
         description = "Name of the route";
       };
 

--- a/nixops/resources/gce_route.py
+++ b/nixops/resources/gce_route.py
@@ -79,3 +79,16 @@ class GCERouteState(ResourceState):
                 except libcloud.common.google.ResourceExistsError:
                     raise Exception("tried creating a route that already exists.")
                 self.state = self.UP
+
+    def destroy(self, wipe=False):
+        if self.state == self.UP:
+            try:
+                route = self.connect().ex_get_route(self.route_name)
+                if not self.depl.logger.confirm("are you sure you want to destroy {0}?".format(self.full_name)):
+                    return False
+
+                self.log("destroying {0}...".format(self.full_name))
+                route.destroy()
+            except libcloud.common.google.ResourceNotFoundError:
+                self.warn("tried to destroy {0} which didn't exist".format(self.full_name))
+        return True

--- a/nixops/resources/gce_route.py
+++ b/nixops/resources/gce_route.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+# Automatic provisioning of GCE Routes.
+
+import libcloud.common.google
+
+from nixops.util import attr_property
+from nixops.gce_common import ResourceDefinition, ResourceState
+
+
+class GCERouteDefinition(ResourceDefinition):
+    """Definition of a GCE Route"""
+
+    @classmethod
+    def get_type(cls):
+        return "gce-route"
+
+    @classmethod
+    def get_resource_type(cls):
+        return "gceRoutes"
+
+    def __init__(self, xml):
+        ResourceDefinition.__init__(self, xml)
+
+        self.route_name = self.get_option_value(xml, 'name', str)
+        self.description = self.get_option_value(xml, 'description', str, optional=True)
+        self.network = self.get_option_value(xml, 'network', str)
+        self.priority = self.get_option_value(xml, 'priority', int)
+        self.nextHop = self.get_option_value(xml, 'nextHop', str, optional=True)
+        self.destination = self.get_option_value(xml, 'destination', str)
+        self.tags = self.get_option_value(xml, 'tags', "strlist", optional=True)
+
+    def show_type(self):
+        return "{0} [{1}]".format(self.get_type(), self.name)
+
+
+class GCERouteState(ResourceState):
+    """State of a GCE Route"""
+
+    route_name = attr_property("gce.route.name", None)
+    description = attr_property("gce.route.description", None)
+    network = attr_property("gce.route.network", None)
+    priority = attr_property("gce.route.priority", None)
+    nextHop = attr_property("gce.route.nextHop", None)
+    destination = attr_property("gce.route.destination", None)
+    # TODO: Store tags in the state file.
+    tags = attr_property("gce.route.tags", None)
+
+    defn_properties = ['route_name', 'priority', 'destination', 'nextHop', 'network', 'description']
+
+    nix_name = "gceRoutes"
+
+    @classmethod
+    def get_type(cls):
+        return "gce-route"
+
+    def __init__(self, depl, name, id):
+        ResourceState.__init__(self, depl, name, id)
+
+    def show_type(self):
+        s = super(GCERouteState, self).show_type()
+        if self.state == self.UP: s = "{0} [{1}]".format(s, self.name)
+        return s
+
+
+    @property
+    def full_name(self):
+        return "GCE route '{0}'".format(self.name)
+
+    def create(self, defn, check, allow_reboot, allow_recreate):
+        self.copy_credentials(defn)
+
+        if self.state != self.UP:
+            with self.depl._db:
+                self.log("creating {0}...".format(self.full_name))
+                self.copy_properties(defn)
+                try:
+                    route = self.connect().ex_create_route(defn.route_name, defn.destination, defn.priority, defn.network, defn.tags, defn.nextHop, defn.description)
+                except libcloud.common.google.ResourceExistsError:
+                    raise Exception("tried creating a route that already exists.")
+                self.state = self.UP


### PR DESCRIPTION
An example of a route is 
```
  resources.gceRoutes.lb-default = {
    name = "lb-default";
    priority = 800;
    destination = "8.8.8.8/32";
    tags = [ "workers" ];
  };

```
