### PR TITLE
Adding option --devices to backup operation

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -434,9 +434,6 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
         self.connect()
 
         self.log("backing up machine ‘{0}’ using id ‘{1}’".format(self.name, backup_id))
-        for d in devices:
-            self.log(" - {0}".format(d))
-
         backup = {}
         _backups = self.backups
         for k, v in self.block_device_mapping.items():

--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -430,23 +430,27 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
             self.backups = _backups
 
 
-    def backup(self, defn, backup_id):
+    def backup(self, defn, backup_id, devices=[]):
         self.connect()
 
         self.log("backing up machine ‘{0}’ using id ‘{1}’".format(self.name, backup_id))
+        for d in devices:
+            self.log(" - {0}".format(d))
+
         backup = {}
         _backups = self.backups
         for k, v in self.block_device_mapping.items():
-            snapshot = self._retry(lambda: self._conn.create_snapshot(volume_id=v['volumeId']))
-            self.log("+ created snapshot of volume ‘{0}’: ‘{1}’".format(v['volumeId'], snapshot.id))
+            if devices == [] or _sd_to_xvd(k) in devices:
+                snapshot = self._retry(lambda: self._conn.create_snapshot(volume_id=v['volumeId']))
+                self.log("+ created snapshot of volume ‘{0}’: ‘{1}’".format(v['volumeId'], snapshot.id))
 
-            snapshot_tags = {}
-            snapshot_tags.update(defn.tags)
-            snapshot_tags.update(self.get_common_tags())
-            snapshot_tags['Name'] = "{0} - {3} [{1} - {2}]".format(self.depl.description, self.name, k, backup_id)
+                snapshot_tags = {}
+                snapshot_tags.update(defn.tags)
+                snapshot_tags.update(self.get_common_tags())
+                snapshot_tags['Name'] = "{0} - {3} [{1} - {2}]".format(self.depl.description, self.name, k, backup_id)
 
-            self._retry(lambda: self._conn.create_tags([snapshot.id], snapshot_tags))
-            backup[k] = snapshot.id
+                self._retry(lambda: self._conn.create_tags([snapshot.id], snapshot_tags))
+                backup[k] = snapshot.id
         _backups[backup_id] = backup
         self.backups = _backups
 

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -827,7 +827,7 @@ class Deployment(object):
             nixops.parallel.run_tasks(nr_workers=len(self.active), tasks=self.machines.itervalues(), worker_fun=worker)
 
 
-    def backup(self, include=[], exclude=[]):
+    def backup(self, include=[], exclude=[], devices=[]):
         self.evaluate_active(include, exclude)
         backup_id = datetime.now().strftime("%Y%m%d%H%M%S")
 
@@ -838,7 +838,7 @@ class Deployment(object):
                 res = subprocess.call(["ssh", "root@" + ssh_name] + m.get_ssh_flags() + ["sync"])
                 if res != 0:
                     m.logger.log("running sync failed on {0}.".format(m.name))
-            m.backup(self.definitions[m.name], backup_id)
+            m.backup(self.definitions[m.name], backup_id, devices)
 
         nixops.parallel.run_tasks(nr_workers=5, tasks=self.active.itervalues(), worker_fun=worker)
 

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -334,7 +334,7 @@ def op_backup():
     depl = open_deployment()
 
     def do_backup():
-        backup_id = depl.backup(include=args.include or [], exclude=args.exclude or [])
+        backup_id = depl.backup(include=args.include or [], exclude=args.exclude or [], devices=args.devices or [])
         print backup_id
 
     if args.force:
@@ -898,6 +898,7 @@ subparser.add_argument('--include', nargs='+', metavar='MACHINE-NAME', help='per
 subparser.add_argument('--exclude', nargs='+', metavar='MACHINE-NAME', help='do not perform backup actions on the specified machines')
 subparser.add_argument('--freeze', dest='freeze_fs', action="store_true", default=False, help='freeze filesystems for non-root filesystems that support this (e.g. xfs)')
 subparser.add_argument('--force', dest='force', action="store_true", default=False, help='start new backup even if previous is still running')
+subparser.add_argument('--devices', nargs='+', metavar='DEVICE-NAME', help='only backup the specified devices')
 
 subparser = add_subparser('backup-status', help='get status of backups')
 subparser.set_defaults(op=op_backup_status)


### PR DESCRIPTION
Adding a **--devices** option to the backup operation would be useful to avoid taking backups of devices that aren't needed to, like root volumes in EC2 and GCE, with a consecutive cost saving. This is already the case for the restore operation and it was done the same way here.

This was tested for EC2 and GCE (it seems like adding the --devices arg parser will require doing the change for all ec2.py, gce.py and azure_vm.py). Thanks.
`$ nixops backup -d gcp-environment --devices n-54ac0d1963df11e886810a29f7962a18-frontend-data
frontend.> backing up GCE machine 'n-54ac0d1963df11e886810a29f7962a18-frontend' using ID '20180824095544'
frontend.> initiating snapshotting of disk 'n-54ac0d1963df11e886810a29f7962a18-frontend-data': 'backup-20180824095544-e886810a29f7962a18-frontend-data'
frontend.> . done
20180824095544
`

`
$ nixops backup -d ec2-environment --devices /dev/xvdg 
deploy.......> backing up machine ‘deploy’ using id ‘20180824090046’
deploy.......>  - /dev/xvdg
deploy.......> + created snapshot of volume ‘vol-0a74338263b9bfda2’: ‘snap-0a58c587da879156c’
20180824090046
`
