### PR TITLE
Make sure that the machine is UP before trying to destroy it in GCP

### DIFF
--- a/nixops/backends/gce.py
+++ b/nixops/backends/gce.py
@@ -652,6 +652,10 @@ class GCEState(MachineState, ResourceState):
         if not self.project:
             return True
 
+        if self.state != self.UP:
+            # The machine is down, we have nothing to do.
+            return True
+
         try:
             node = self.node()
             question = "are you sure you want to destroy {0}?"


### PR DESCRIPTION
This can cause problems since we issue API call without actually checking
if the node is up or not. One easy way to see the manifestation of this
bug is to create a deployment with a machine that has underscore in
it's  name (It's not supported in GCP). And without even deploying,
try to destroy it. The expected behavior is nothing! Since the
machine is down. However, an exception is raised because nixops tries
to call the API to get the node.