### PR TITLE
support ipv6 for scp with "none" backend

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -271,7 +271,7 @@ class MachineState(nixops.resources.ResourceState):
     def get_keys(self):
         return self.keys
 
-    def get_ssh_name(self, scp=False):
+    def get_ssh_name(self):
         assert False
 
     def get_ssh_flags(self, scp=False):
@@ -390,7 +390,7 @@ class MachineState(nixops.resources.ResourceState):
         cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
         if recursive:
             cmdline += ['-r']
-        cmdline += [source, "root@" + self.get_ssh_name(True) + ":" + target]
+        cmdline += [source, "root@" + self.get_ssh_name() + ":" + target]
         return self._logged_exec(cmdline)
 
     def download_file(self, source, target, recursive=False):
@@ -398,7 +398,7 @@ class MachineState(nixops.resources.ResourceState):
         cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
         if recursive:
             cmdline += ['-r']
-        cmdline += ["root@" + self.get_ssh_name(True) + ":" + source, target]
+        cmdline += ["root@" + self.get_ssh_name() + ":" + source, target]
         return self._logged_exec(cmdline)
 
     def get_console_output(self):

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -271,7 +271,7 @@ class MachineState(nixops.resources.ResourceState):
     def get_keys(self):
         return self.keys
 
-    def get_ssh_name(self):
+    def get_ssh_name(self, scp=False):
         assert False
 
     def get_ssh_flags(self, scp=False):
@@ -390,7 +390,7 @@ class MachineState(nixops.resources.ResourceState):
         cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
         if recursive:
             cmdline += ['-r']
-        cmdline += [source, "root@" + self.get_ssh_name() + ":" + target]
+        cmdline += [source, "root@" + self.get_ssh_name(True) + ":" + target]
         return self._logged_exec(cmdline)
 
     def download_file(self, source, target, recursive=False):
@@ -398,7 +398,7 @@ class MachineState(nixops.resources.ResourceState):
         cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
         if recursive:
             cmdline += ['-r']
-        cmdline += ["root@" + self.get_ssh_name() + ":" + source, target]
+        cmdline += ["root@" + self.get_ssh_name(True) + ":" + source, target]
         return self._logged_exec(cmdline)
 
     def get_console_output(self):

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -385,12 +385,19 @@ class MachineState(nixops.resources.ResourceState):
         if res != 0: raise Exception("unable to upload VPN key to ‘{0}’".format(self.name))
         self.public_vpn_key = public
 
+    def get_scp_name(self):
+        ssh_name = self.get_ssh_name()
+        # ipv6 addresses have to be wrapped in brackets for scp
+        if (":" in ssh_name):
+            return "[%s]" % (ssh_name)
+        return ssh_name
+
     def upload_file(self, source, target, recursive=False):
         master = self.ssh.get_master()
         cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
         if recursive:
             cmdline += ['-r']
-        cmdline += [source, "root@" + self.get_ssh_name() + ":" + target]
+        cmdline += [source, "root@" + self.get_scp_name() + ":" + target]
         return self._logged_exec(cmdline)
 
     def download_file(self, source, target, recursive=False):
@@ -398,7 +405,7 @@ class MachineState(nixops.resources.ResourceState):
         cmdline = ["scp"] + self.get_ssh_flags(True) + master.opts
         if recursive:
             cmdline += ['-r']
-        cmdline += ["root@" + self.get_ssh_name() + ":" + source, target]
+        cmdline += ["root@" + self.get_scp_name() + ":" + source, target]
         return self._logged_exec(cmdline)
 
     def get_console_output(self):

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -67,8 +67,10 @@ class NoneState(MachineState):
             self._ssh_public_key_deployed = True
         return res
 
-    def get_ssh_name(self):
+    def get_ssh_name(self, scp=False):
         assert self.target_host
+        if scp and (":" in self.target_host):
+            return "[%s]" % (self.target_host)
         return self.target_host
 
     def get_ssh_private_key_file(self):

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -67,10 +67,8 @@ class NoneState(MachineState):
             self._ssh_public_key_deployed = True
         return res
 
-    def get_ssh_name(self, scp=False):
+    def get_ssh_name(self):
         assert self.target_host
-        if scp and (":" in self.target_host):
-            return "[%s]" % (self.target_host)
         return self.target_host
 
     def get_ssh_private_key_file(self):


### PR DESCRIPTION
Motivation:

Currently, secrets cannot be deployed when `deployment.targetHost` contains an ipv6.

This is because, while sshing to a ipv6 has the same syntax, `scp` requires square brackets around the ip. This adds square brackets for calls to scp around any ip with a colon.

I'm no python developer, so please take this PR with a grain of salt. Fortunately, it's not very big ;)