### PR TITLE
aws | route53:  normalise DNS hostname;  fix #1013

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -1257,7 +1257,7 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
         import boto.route53
         import boto.route53.record
 
-        self.dns_hostname = defn.dns_hostname
+        self.dns_hostname = defn.dns_hostname.lower()
         self.dns_ttl = defn.dns_ttl
         self.route53_access_key_id = defn.route53_access_key_id or nixops.ec2_utils.get_access_key_id()
         self.route53_use_public_dns_name = defn.route53_use_public_dns_name


### PR DESCRIPTION
Normalise the hostname, before doing any update calculations.

Tested to fix #1013 -- a deployment with machines containing uppercase `deployment.route53.hostName` successfully completes.