### PR TITLE
Improve ec2 security groups module: update to boto3

### DIFF
--- a/tests/functional/ec2-security-groups.nix
+++ b/tests/functional/ec2-security-groups.nix
@@ -1,0 +1,28 @@
+{ region ? "us-east-1"
+, ...
+}:
+
+{
+resources.ec2SecurityGroups =
+  {
+   securityGroup1 = {
+        inherit region;
+        name = "securityGroup1";
+        description = "securityGroup1 description";
+        rules = [
+          { fromPort = 22; toPort = 22; protocol = "tcp"; sourceIp = "19.10.19.93/30"; }
+          { fromPort = 80; toPort = 8080; protocol = "tcp"; sourceIp = "55.55.55.55/32"; }
+        ];
+      };
+     securityGroup2 = {
+        inherit region;
+        name = "securityGroup2";
+        description = "securityGroup2 description";
+        rules = [
+          { fromPort = 22; toPort = 22; sourceIp = "6.6.6.6"; }
+          { fromPort = 80; toPort = 80; sourceIp = "55.55.5.5/20"; }
+        ];
+      };
+   };
+}
+

--- a/tests/functional/test_deploy_ec2_security_groups.py
+++ b/tests/functional/test_deploy_ec2_security_groups.py
@@ -1,0 +1,19 @@
+from os import path
+
+from nose import tools
+
+from tests.functional import generic_deployment_test
+
+parent_dir = path.dirname(__file__)
+
+logical_spec = '%s/ec2-security-groups.nix' % (parent_dir)
+
+class TestEc2SecurityGroupsTest(generic_deployment_test.GenericDeploymentTest):
+    _multiprocess_can_split_ = True
+
+    def setup(self):
+        super(TestEc2SecurityGroupsTest, self).setup()
+        self.depl.nix_exprs = [ logical_spec ]
+
+    def test_deploy(self):
+        self.depl.deploy()


### PR DESCRIPTION
Updating ec2SecurityGroups resources module to use boto3 instead of 2. Boto3 will allow much more/newer features aws add to security groups (such as rules descriptions ...)