### PR TITLE
RDS: support vpc-security-groups for RDS-instances/dbSubnetGroups

### DIFF
--- a/nix/ec2-rds-dbinstance.nix
+++ b/nix/ec2-rds-dbinstance.nix
@@ -18,6 +18,14 @@ with import ./lib.nix lib;
       description = "Amazon RDS region.";
     };
 
+    zone = mkOption {
+      # NOTE: We're making this required in NixOps but the api can handle
+      # choosing the zone. Making this required will prevent having
+      # the diff engine trigger the zone handler in each deploy.
+      type = types.str;
+      description = "AWS availability zone.";
+    };
+
     multiAZ = mkOption {
       default = false;
       type = types.bool;

--- a/nix/ec2-rds-dbinstance.nix
+++ b/nix/ec2-rds-dbinstance.nix
@@ -82,11 +82,20 @@ with import ./lib.nix lib;
     };
 
     securityGroups = mkOption {
-      default = [ "default" ];
+      default = [];
       type = types.listOf (types.either types.str (resource "ec2-rds-security-group"));
       apply = map (x: if builtins.isString x then x else "res-" + x._name);
       description = ''
         List of names of DBSecurityGroup to authorize on this DBInstance.
+      '';
+    };
+
+    vpcSecurityGroups = mkOption {
+      default = [];
+      type = types.listOf (types.either types.str (resource "ec2-security-group"));
+      apply = map (x: if builtins.isString x then x else "res-" + x._name);
+      description = ''
+        List of names of EC2SecurityGroup to authorize on this DBInstance.
       '';
     };
 

--- a/nix/ec2-rds-dbinstance.nix
+++ b/nix/ec2-rds-dbinstance.nix
@@ -107,6 +107,15 @@ with import ./lib.nix lib;
       '';
     };
 
+    subnetGroup = mkOption {
+      default = null;
+      type = with types; nullOr (either str (resource "ec2-rds-subnet-group"));
+      apply = x: if builtins.isString x then x else x._name;
+      description = ''
+        A DB subnet group to associate with this DB instance.
+      '';
+    };
+
   };
 
   config._type = "ec2-rds-dbinstance";

--- a/nix/ec2-rds-dbsubnet-group.nix
+++ b/nix/ec2-rds-dbsubnet-group.nix
@@ -1,0 +1,38 @@
+{ config, lib, uuid, name, ... }:
+
+with lib;
+with import ./lib.nix lib;
+
+{
+
+  imports = [ ./common-ec2-auth-options.nix ];
+
+  options = {
+
+    groupName = mkOption {
+      type = types.str;
+      description = ''
+        Name of the RDS DB subnet group.
+      '';
+    };
+
+    description = mkOption {
+      type = types.str;
+      description = ''
+        Description of the RDS DB subnet group.
+      ''; 
+    };
+
+    subnetIds = mkOption {
+      default = [ ];
+      type = types.listOf (types.either types.str (resource "vpc-subnet"));
+      apply = map (x: if builtins.isString x then x else "res-" + x._name + "." + x._type + "." + "subnetId");
+      description = ''
+        The EC2 Subnet IDs for the DB subnet group.
+      '';
+    };
+
+  };
+
+  config._type = "ec2-rds-subnet-group";
+}

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -97,6 +97,7 @@ rec {
   resources.elasticIPs = evalResources ./elastic-ip.nix (zipAttrs resourcesByType.elasticIPs or []);
   resources.rdsDbInstances = evalResources ./ec2-rds-dbinstance.nix (zipAttrs resourcesByType.rdsDbInstances or []);
   resources.rdsDbSecurityGroups = evalResources ./ec2-rds-dbsecurity-group.nix (zipAttrs resourcesByType.rdsDbSecurityGroups or []);
+  resources.rdsDbSubnetGroups = evalResources ./ec2-rds-dbsubnet-group.nix (zipAttrs resourcesByType.rdsDbSubnetGroups or []);
   resources.route53RecordSets = evalResources ./route53-recordset.nix (zipAttrs resourcesByType.route53RecordSets or []);
   resources.elasticFileSystems = evalResources ./elastic-file-system.nix (zipAttrs resourcesByType.elasticFileSystems or []);
   resources.elasticFileSystemMountTargets = evalResources ./elastic-file-system-mount-target.nix (zipAttrs resourcesByType.elasticFileSystemMountTargets or []);

--- a/nixops/resources/ec2_rds_dbinstance.py
+++ b/nixops/resources/ec2_rds_dbinstance.py
@@ -249,15 +249,15 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
                     if dbinstance.status == 'deleting':
                         self.logger.log("RDS instance `{0}` is being deleted, waiting...".format(dbinstance.id))
                         while True:
+                            dbinstance.update()
+                            self.log_continue("[{0}] ".format(dbinstance.status))
                             if dbinstance.status == 'deleting':
-                                continue
+                                time.sleep(6)
                             else:
                                 break
-                            self.log_continue("[{0}] ".format(dbinstance.status))
-                            time.sleep(6)
-
-                    self.logger.log("RDS instance `{0}` is MISSING but already exists, synchronizing state".format(dbinstance.id))
-                    self.state = self.UP
+                    else:
+                        self.logger.log("RDS instance `{0}` is MISSING but already exists, synchronizing state".format(dbinstance.id))
+                        self.state = self.UP
 
                 if not dbinstance and self.state == self.UP:
                     self.logger.log("RDS instance `{0}` state is UP but does not exist!")

--- a/nixops/resources/ec2_rds_dbsubnet_group.py
+++ b/nixops/resources/ec2_rds_dbsubnet_group.py
@@ -1,0 +1,164 @@
+import boto3
+import botocore.exceptions
+import botocore.errorfactory
+
+import nixops.util
+import nixops.resources
+import nixops.ec2_utils
+from nixops.resources.ec2_common import EC2CommonState
+
+
+class EC2RDSDbSubnetGroupDefinition(nixops.resources.ResourceDefinition):
+
+    @classmethod
+    def get_type(cls):
+        return "ec2-rds-dbsubnet-group"
+
+    @classmethod
+    def get_resource_type(cls):
+        return "rdsDbSubnetGroups"
+
+    def __init__(self, xml):
+        nixops.resources.ResourceDefinition.__init__(self, xml)
+        self.region = xml.find("attrs/attr[@name='region']/string").get("value")
+        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get("value")
+
+        self.group_name = xml.find("attrs/attr[@name='groupName']/string").get("value")
+        self.description = xml.find("attrs/attr[@name='description']/string").get("value")
+        self.subnet_ids = []
+        for s in xml.findall("attrs/attr[@name='subnetIds']/list"):
+            for s_str in s.findall("string"):
+                s_name = s_str.get("value")
+                self.subnet_ids.append(s_name)
+
+    def show_type(self):
+        return "{0}".format(self.get_type())
+
+
+class EC2RDSDbSubnetGroupState(nixops.resources.ResourceState):
+
+    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+
+    region = nixops.util.attr_property("ec2.region", None)
+    access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
+
+    group_name = nixops.util.attr_property("rdsDbSubnetGroups.groupName", None)
+    description = nixops.util.attr_property("rdsDbSubnetGroups.description", None)
+    subnet_ids = nixops.util.attr_property("rdsDbSubnetGroups.subnetIds", [], 'json')
+
+    @classmethod
+    def get_type(cls):
+        return "ec2-rds-dbsubnet-group"
+
+    def __init__(self, depl, name, id):
+        nixops.resources.ResourceState.__init__(self, depl, name, id)
+        self._conn = None
+
+    def show_type(self):
+        s = super(EC2RDSDbSubnetGroupState, self).show_type()
+        return "{0} [{1}]".format(s, self.region)
+
+    @property
+    def resource_id(self):
+        return self.group_name
+
+    def _connect(self):
+        if self._conn:
+            return
+        (access_key_id, secret_access_key) = nixops.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+        self._conn = boto3.session.Session(region_name=self.region,
+                                           aws_access_key_id=access_key_id,
+                                           aws_secret_access_key=secret_access_key)
+
+    def _try_fetch_dbsubnet_group(self, group_name):
+        dbsubnet_group = None
+        rdsclient = self._conn.client('rds')
+        try:
+            response = rdsclient.describe_db_subnet_groups(
+                DBSubnetGroupName=group_name
+            )
+            dbsubnet_group = response['DBSubnetGroups'][0]
+        except rdsclient.exceptions.DBSubnetGroupNotFoundFault as e:
+            dbsubnet_group = None
+        return dbsubnet_group
+
+    def _compare_instance_group_name(self, group_name):
+        return unicode(self.group_name).lower() == unicode(group_name).lower()
+
+    def create(self, defn, check, allow_reboot, allow_recreate):
+        with self.depl._db:
+            self.access_key_id = defn.access_key_id or nixops.ec2_utils.get_access_key_id()
+            if not self.access_key_id:
+                raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+            self.region = defn.region
+
+        self._connect()
+        rdsclient = self._conn.client('rds')
+        dbsubnet_group = self._try_fetch_dbsubnet_group(defn.group_name)
+        subnet_ids = []
+        for s in defn.subnet_ids:
+            if s.startswith("res-"):
+                res = self.depl.get_typed_resource(s[4:].split(".")[0], "vpc-subnet")
+                subnet_ids.append(res._state['subnetId'])
+            else:
+                subnet_ids.append(s)
+
+        if self.state == self.UP:
+            if dbsubnet_group and not self._compare_instance_group_name(defn.group_name):
+                raise Exception("group_name changed but RDS dbsubnet_group with group_name=%s already exists" % defn.group_name)
+            dbsubnet_group = self._try_fetch_dbsubnet_group(self.group_name)
+
+        with self.depl._db:
+            if check or self.state == self.MISSING or self.state == self.UNKNOWN:
+                if dbsubnet_group and (self.state == self.MISSING or self.state == self.UNKNOWN):
+                    self.logger.log("RDS dbsubnet_group '%s' is MISSING but already exists, synchronizing state" % defn.group_name)
+                    self.state = self.UP
+
+                if not dbsubnet_group and self.state == self.UP:
+                    self.logger.log("RDS dbsubnet_group '%s' state is UP but does not exist!" % self.group_name)
+                    if not allow_recreate:
+                        raise Exception("RDS dbsubnet_group is UP but does not exist, set --allow-recreate to recreate")
+                    self.state = self.MISSING
+
+                if not dbsubnet_group and (self.state == self.MISSING or self.state == self.UNKNOWN):
+                    self.logger.log("creating RDS dbsubnet_group %s" % defn.group_name)
+
+                    rdsclient.create_db_subnet_group(
+                        DBSubnetGroupName=defn.group_name,
+                        DBSubnetGroupDescription=defn.description,
+                        SubnetIds=subnet_ids)
+                    self.state = self.STARTING
+
+            self.group_name = defn.group_name
+            self.description = defn.description
+            self.subnet_ids = subnet_ids
+            self.state = self.UP
+
+    def destroy(self, wipe=False):
+        if self.state == self.UP or self.state == self.STARTING:
+            if not self.depl.logger.confirm("are you sure you want to destroy RDS dbsubnet_group '%s'?" % self.group_name):
+                return False
+            self._connect()
+            rdsclient = self._conn.client('rds')
+
+            dbsubnet_group = None
+            if self.group_name:
+                dbsubnet_group = self._try_fetch_dbsubnet_group(self.group_name)
+
+            if dbsubnet_group:
+                self.logger.log("destroying RDS dbsubnet_group '%s'" % self.group_name)
+                try:
+                    rdsclient.delete_db_subnet_group(DBSubnetGroupName=self.group_name)
+                except botocore.exceptions.ClientError as error:
+                    if error.response['Error']['Code'] == 'DBSubnetGroupNotFound':
+                        self.logger.log("RDS dbsubnet_group '%s' does not exist, skipping." % self.group_name)
+                    else:
+                        raise error
+
+            with self.depl._db:
+                self.state = self.MISSING
+                self.region = None
+                self.group_name = None
+                self.description = None
+                self.subnet_ids = None
+        return True

--- a/tests/functional/ec2-rds-dbinstance-with-vpc-sg.nix
+++ b/tests/functional/ec2-rds-dbinstance-with-vpc-sg.nix
@@ -1,0 +1,30 @@
+let
+  region = "us-east-1";
+in
+{
+  network.description = "NixOps Test";
+
+  resources.rdsDbInstances.test-rds-instance =
+    { resources, ... }:
+    {
+      inherit region;
+      id = "myOtherDatabaseIsAFilesystem";
+      instanceClass = "db.r3.large";
+      allocatedStorage = 30;
+      masterUsername = "administrator";
+      masterPassword = "testing123";
+      port = 5432;
+      engine = "postgres";
+      dbName = "helloDarling";
+      vpcSecurityGroups = [ resources.ec2SecurityGroups.test-rds-sg ];
+    };
+
+  resources.ec2SecurityGroups.test-rds-sg =
+    {
+      inherit region;
+      description = "testing sg for rds";
+      rules = [
+        { toPort = 5432; fromPort = 5432; sourceIp = "0.0.0.0/0"; }
+      ];
+    };
+}

--- a/tests/functional/test_ec2_rds_dbinstance.py
+++ b/tests/functional/test_ec2_rds_dbinstance.py
@@ -8,6 +8,7 @@ parent_dir = path.dirname(__file__)
 
 logical_spec = '%s/ec2-rds-dbinstance.nix' % (parent_dir)
 sg_spec = '%s/ec2-rds-dbinstance-with-sg.nix' % (parent_dir)
+vpc_sg_spec ='%s/ec2-rds-dbinstance-with-vpc-sg.nix' % (parent_dir)
 
 class TestEc2RdsDbinstanceTest(generic_deployment_test.GenericDeploymentTest):
     _multiprocess_can_split_ = True
@@ -21,4 +22,8 @@ class TestEc2RdsDbinstanceTest(generic_deployment_test.GenericDeploymentTest):
 
     def test_deploy_with_sg(self):
         self.depl.nix_exprs = [ sg_spec ]
+        self.depl.deploy()
+
+    def test_deploy_with_vpc_sg(self):
+        self.depl.nix_exprs = [ vpc_sg_spec ]
         self.depl.deploy()


### PR DESCRIPTION
This PR builds on #937.

This PR adds the dbSubnetGroup resource and allows adding RDS instances to it, in order to use vpc-security-groups with rds-instances.