### PR TITLE
Partially mitigate StrictHostKeyChecking=no issue

### DIFF
--- a/nix/ssh-tunnel.nix
+++ b/nix/ssh-tunnel.nix
@@ -87,7 +87,7 @@ with lib;
         remoteCommand = mkAddrConf v.remoteTunnel v.remoteIPv4 v.localIPv4;
 
       in "ssh -i ${v.privateKey} -x"
-       + " -o StrictHostKeyChecking=no"
+       + " -o StrictHostKeyChecking=accept-new"
        + " -o PermitLocalCommand=yes"
        + " -o ServerAliveInterval=20"
        + " -o LocalCommand='${localCommand}'"

--- a/nixops/backends/digital_ocean.py
+++ b/nixops/backends/digital_ocean.py
@@ -76,7 +76,7 @@ class DigitalOceanState(MachineState):
         super_flags = super(DigitalOceanState, self).get_ssh_flags(*args, **kwargs)
         return super_flags + [
             '-o', 'UserKnownHostsFile=/dev/null',
-            '-o', 'StrictHostKeyChecking=no',
+            '-o', 'StrictHostKeyChecking=accept-new',
             '-i', self.get_ssh_private_key_file(),
         ]
 

--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -170,14 +170,14 @@ class HetznerState(MachineState):
             ["-o", "LogLevel=quiet",
              "-o", "UserKnownHostsFile=/dev/null",
              "-o", "GlobalKnownHostsFile=/dev/null",
-             "-o", "StrictHostKeyChecking=no"]
+             "-o", "StrictHostKeyChecking=accept-new"]
             if self.state == self.RESCUE else
             # XXX: Disabling strict host key checking will only impact the
             # behaviour on *new* keys, so it should be "reasonably" safe to do
             # this until we have a better way of managing host keys in
             # ssh_util. So far this at least avoids to accept every damn host
             # key on a large deployment.
-            ["-o", "StrictHostKeyChecking=no",
+            ["-o", "StrictHostKeyChecking=accept-new",
              "-i", self.get_ssh_private_key_file()]
         )
 

--- a/nixops/backends/libvirtd.py
+++ b/nixops/backends/libvirtd.py
@@ -92,7 +92,7 @@ class LibvirtdState(MachineState):
 
     def get_ssh_flags(self, *args, **kwargs):
         super_flags = super(LibvirtdState, self).get_ssh_flags(*args, **kwargs)
-        return super_flags + ["-o", "StrictHostKeyChecking=no",
+        return super_flags + ["-o", "StrictHostKeyChecking=accept-new",
                               "-i", self.get_ssh_private_key_file()]
 
     def get_physical_spec(self):

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -80,7 +80,7 @@ class NoneState(MachineState):
     def get_ssh_flags(self, *args, **kwargs):
         super_state_flags = super(NoneState, self).get_ssh_flags(*args, **kwargs)
         if self.vm_id and self.cur_toplevel and self._ssh_public_key_deployed:
-            return super_state_flags + ["-o", "StrictHostKeyChecking=no", "-i", self.get_ssh_private_key_file()]
+            return super_state_flags + ["-o", "StrictHostKeyChecking=accept-new", "-i", self.get_ssh_private_key_file()]
         return super_state_flags
 
     def _check(self, res):


### PR DESCRIPTION
From issue #696:

> The hardcoded -o StrictHostKeyChecking=no everywhere is a big SecOps no-no. It's quite feasible an attacker could wind up with an IP address you neglect to change after relinquishing, and have an entire host config hand-delivered to him to inspect for vulnerabilities. He wouldn't be able to MITM the the deployment, but obtaining what is essentially a dump of the host's whole filesystem is still pretty disastrous, from a defensive standpoint.

I by myself have been guilty of using this (added this to the Hetzner backend), because I did actually misunderstand the meaning of setting this option to `no`. My understanding was that it will refuse to connect whenever an existing host key is different from that in known hosts.

However, this turns out to be only true for keyboard interactive or password authentication and if we're using pubkey auth, OpenSSH will happily connect.

Now the real fix for this (already deploying with a pre-generated host key) is a bit more involved, but we can mitigate this for now, because since OpenSSH 7.5 there is the `accept-new` option to `StrictHostKeyChecking`, which does exactly what I thought "no" would do:

 >If this flag is set to ``accept-new'' then ssh will automatically add new host keys to the user known hosts files, but will not permit connections to hosts with changed host keys.