### PR TITLE
Allow specifying arbitrary SSH configuration for nodes

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -303,7 +303,7 @@ rec {
 
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
-        { inherit (v.config.deployment) targetEnv targetPort targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys hasFastConnection;
+        { inherit (v.config.deployment) targetEnv targetPort targetHost sshConfigOptionsFile encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys hasFastConnection;
           nixosRelease = v.config.system.nixos.release or v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
           azure = optionalAttrs (v.config.deployment.targetEnv == "azure")  v.config.deployment.azure;
           ec2 = optionalAttrs (v.config.deployment.targetEnv == "ec2") v.config.deployment.ec2;

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -65,6 +65,12 @@ in
       '';
     };
 
+    deployment.sshConfigOptionsFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Arbitrary SSH configuration options file.";
+    };
+
     deployment.alwaysActivate = mkOption {
       type = types.bool;
       default = true;

--- a/nix/ssh-tunnel.nix
+++ b/nix/ssh-tunnel.nix
@@ -30,6 +30,11 @@ with lib;
             type = types.int;
             description = "Port number that SSH listens to on the remote machine.";
           };
+          sshConfigOptionsFile = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            description = "Arbitrary SSH configuration option file.";
+          };
           privateKey = mkOption {
             type = types.path;
             description = "Path to the private key file used to connect to the remote machine.";
@@ -91,6 +96,7 @@ with lib;
        + " -o PermitLocalCommand=yes"
        + " -o ServerAliveInterval=20"
        + " -o LocalCommand='${localCommand}'"
+       + (if v.sshConfigOptionsFile == null then "" else " -F ${v.sshConfigOptionsFile}")
        + " -w ${toString v.localTunnel}:${toString v.remoteTunnel}"
        + " ${v.target} -p ${toString v.targetPort}"
        + " '${remoteCommand}'";

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -198,8 +198,8 @@ class MachineState(nixops.resources.ResourceState):
         """Reboot this machine and wait until it's up again."""
         self.reboot(hard=hard)
         self.log_start("waiting for the machine to finish rebooting...")
-        # !!! TODO
-        nixops.util.wait_for_tcp_port(self.get_ssh_name(), self.ssh_port, open=False, callback=lambda: self.log_continue("."))
+        while self.try_ssh():
+            self.log_continue(".")
         self.log_continue("[down]")
         self.wait_for_ssh()
         self.state = self.UP
@@ -312,6 +312,9 @@ class MachineState(nixops.resources.ResourceState):
     def address_to(self, r):
         """Return the IP address to be used to access resource "r" from this machine."""
         return r.public_ipv4
+
+    def try_ssh(self):
+        return self.ssh.try_ssh()
 
     def wait_for_ssh(self, check=False):
         """Wait until the SSH port is open on this machine."""

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -198,10 +198,10 @@ class MachineState(nixops.resources.ResourceState):
         """Reboot this machine and wait until it's up again."""
         self.reboot(hard=hard)
         self.log_start("waiting for the machine to finish rebooting...")
+        # !!! TODO
         nixops.util.wait_for_tcp_port(self.get_ssh_name(), self.ssh_port, open=False, callback=lambda: self.log_continue("."))
         self.log_continue("[down]")
-        nixops.util.wait_for_tcp_port(self.get_ssh_name(), self.ssh_port, callback=lambda: self.log_continue("."))
-        self.log_end("[up]")
+        self.wait_for_ssh()
         self.state = self.UP
         self.ssh_pinged = True
         self._ssh_pinged_this_time = True

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -317,7 +317,7 @@ class MachineState(nixops.resources.ResourceState):
         """Wait until the SSH port is open on this machine."""
         if self.ssh_pinged and (not check or self._ssh_pinged_this_time): return
         self.log_start("waiting for SSH...")
-        nixops.util.wait_for_tcp_port(self.get_ssh_name(), self.ssh_port, callback=lambda: self.log_continue("."))
+        self.ssh.wait_for_ssh(callback=lambda: self.log_continue("."))
         self.log_end("")
         if self.state != self.RESCUE:
             self.state = self.UP

--- a/nixops/backends/azure_vm.py
+++ b/nixops/backends/azure_vm.py
@@ -15,7 +15,6 @@ from azure.storage.blob import BlobService
 
 import nixops
 from nixops import known_hosts
-from nixops.util import wait_for_tcp_port, ping_tcp_port
 from nixops.util import attr_property, create_key_pair, generate_random_string, check_wait
 from nixops.nix_expr import Call, RawValue
 

--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -186,12 +186,11 @@ class HetznerState(MachineState):
             # so only wait for the reboot to finish when deploying real
             # systems.
             self.log_start("waiting for rescue system...")
-            while self.try_ssh():
-                self.log_continue(".")
+            dotlog = lambda: self.log_continue(".")  # NOQA
+            self.wait_for_ssh(callback=dotlog, up=False)
             self.log_continue("[down]")
 
-            while not self.try_ssh():
-                self.log_continue(".")
+            self.wait_for_ssh(callback=dotlog, up=True)
             self.log_end("[up]")
         self.state = self.RESCUE
 

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -88,7 +88,7 @@ class NoneState(MachineState):
             res.exists = False
             return
         res.exists = True
-        res.is_up = nixops.util.ping_tcp_port(self.target_host, self.ssh_port)
+        res.is_up = self.try_ssh()
         if res.is_up:
             MachineState._check(self, res)
 

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -468,6 +468,7 @@ class Deployment(object):
                     ('networking', 'p2pTunnels', 'ssh', m2.name): {
                         'target': '{0}-unencrypted'.format(m2.name),
                         'targetPort': m2.ssh_port,
+                        'sshConfigOptionsFile': m2.ssh_config_options_file,
                         'localTunnel': local_tunnel,
                         'remoteTunnel': remote_tunnel,
                         'localIPv4': local_ipv4,

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -306,12 +306,11 @@ class SSH(object):
         except nixops.ssh_util.SSHConnectionFailed:
             return False
 
-
-    def wait_for_ssh(self, user=None, attempts=-1, timeout=5, callback=None):
-        """Wait until the remote's SSH is up."""
+    def wait_for_ssh(self, user=None, attempts=-1, timeout=5, callback=None, up=True):
+        """Wait until the remote's SSH is up or down based on the «up» parameter."""
         attempt = 0
         while True:
-            if self.try_ssh(user=user, timeout=timeout)
+            if self.try_ssh(user=user, timeout=timeout) == up
                 return True
             else
                 attempt += 1
@@ -319,7 +318,6 @@ class SSH(object):
                 if callback: callback()
         raise Exception("timed out waiting for SSH on ‘{1}’".format(
             self._get_target(user)))
-
 
     def enable_compression(self):
         self._compress = True

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -310,9 +310,9 @@ class SSH(object):
         """Wait until the remote's SSH is up or down based on the «up» parameter."""
         attempt = 0
         while True:
-            if self.try_ssh(user=user, timeout=timeout) == up
+            if self.try_ssh(user=user, timeout=timeout) == up:
                 return True
-            else
+            else:
                 attempt += 1
                 if attempts != -1 and attempt >= attempts: break
                 if callback: callback()

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -299,7 +299,7 @@ class SSH(object):
             else:
                 return res
 
-    def try_ssh(self, user=None, timeout=-1):
+    def try_ssh(self, user=None):
         try:
             self.run_command('true', timeout=1, user=user, flags=['-q'])
             return True

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -299,9 +299,9 @@ class SSH(object):
             else:
                 return res
 
-    def try_ssh(self, user=None):
+    def try_ssh(self, user=None, timeout=1):
         try:
-            self.run_command('true', timeout=1, user=user, flags=['-q'])
+            self.run_command('true', timeout=timeout, user=user, flags=['-q'])
             return True
         except nixops.ssh_util.SSHConnectionFailed:
             return False

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -311,10 +311,9 @@ class SSH(object):
         """Wait until the remote's SSH is up."""
         attempt = 0
         while True:
-            try:
-                self.run_command('true', timeout=timeout, user=user, flags=['-q'])
+            if self.try_ssh(user=user, timeout=timeout)
                 return True
-            except nixops.ssh_util.SSHConnectionFailed:
+            else
                 attempt += 1
                 if attempts != -1 and attempt >= attempts: break
                 if callback: callback()

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -309,14 +309,14 @@ class SSH(object):
 
     def wait_for_ssh(self, user=None, attempts=-1, timeout=5, callback=None):
         """Wait until the remote's SSH is up."""
-        n = 0
+        attempt = 0
         while True:
             try:
-                self.run_command('true', timeout=5, user=user, flags=['-q'])
+                self.run_command('true', timeout=timeout, user=user, flags=['-q'])
                 return True
             except nixops.ssh_util.SSHConnectionFailed:
-                n = n + 1
-                if timeout != -1 and n >= timeout: break
+                attempt += 1
+                if attempts != -1 and attempt >= attempts: break
                 if callback: callback()
         raise Exception("timed out waiting for SSH on ‘{1}’".format(
             self._get_target(user)))

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -299,12 +299,20 @@ class SSH(object):
             else:
                 return res
 
-    def wait_for_ssh(self, user=None, timeout=-1, callback=None):
+    def try_ssh(self, user=None, timeout=-1):
+        try:
+            self.run_command('true', timeout=1, user=user, flags=['-q'])
+            return True
+        except nixops.ssh_util.SSHConnectionFailed:
+            return False
+
+
+    def wait_for_ssh(self, user=None, attempts=-1, timeout=5, callback=None):
         """Wait until the remote's SSH is up."""
         n = 0
         while True:
             try:
-                self.run_command('true', timeout=5, user=user)
+                self.run_command('true', timeout=5, user=user, flags=['-q'])
                 return True
             except nixops.ssh_util.SSHConnectionFailed:
                 n = n + 1

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -299,5 +299,20 @@ class SSH(object):
             else:
                 return res
 
+    def wait_for_ssh(self, user=None, timeout=-1, callback=None):
+        """Wait until the remote's SSH is up."""
+        n = 0
+        while True:
+            try:
+                self.run_command('true', timeout=5, user=user)
+                return True
+            except nixops.ssh_util.SSHConnectionFailed:
+                n = n + 1
+                if timeout != -1 and n >= timeout: break
+                if callback: callback()
+        raise Exception("timed out waiting for SSH on ‘{1}’".format(
+            self._get_target(user)))
+
+
     def enable_compression(self):
         self._compress = True


### PR DESCRIPTION
I'd like to deploy to nodes only available behind a bastion server. This patch letsyou do this:

```
  my-node.deployment.sshConfigOptionsFile = ./ssh-config;
```

and ./ssh-config:

```
ProxyCommand ssh 10.5.3.111 -A -W %h:%p
ForwardAgent yes
LogLevel VERBOSE
```

Initial testing shows this works, I'll do further testing tomorrow.