### PR TITLE
Check types wit mypy

### DIFF
--- a/nixops/azure_common.py
+++ b/nixops/azure_common.py
@@ -10,6 +10,7 @@ import requests
 from nixops.util import attr_property, check_wait
 import nixops.resources
 
+from typing import Dict
 from azure import *
 
 from azure.mgmt.common import SubscriptionCloudCredentials
@@ -246,7 +247,7 @@ class ResourceState(nixops.resources.ResourceState):
     app_key = attr_property("azure.appKey", None)
 
     tokens_lock = threading.Lock()
-    tokens = {}
+    tokens = {}  # type: Dict[str, Dict]
 
     def __init__(self, depl, name, id):
         nixops.resources.ResourceState.__init__(self, depl, name, id)

--- a/nixops/backends/hetzner.py
+++ b/nixops/backends/hetzner.py
@@ -285,10 +285,10 @@ class HetznerState(MachineState):
             try:
                 out = self.run_command("nixpart -p -", capture_stdout=True,
                                        stdin_string=partitions)
-            except SSHCommandFailed as cmd:
+            except SSHCommandFailed as failed_command:
                 # Exit code 100 is when the partitioner requires a reboot.
-                if cmd.exitcode == 100:
-                    self.log(cmd.message)
+                if failed_command.exitcode == 100:
+                    self.log(failed_command.message)
                     self.reboot_rescue(install, partitions)
                     return
                 else:

--- a/nixops/diff.py
+++ b/nixops/diff.py
@@ -2,6 +2,7 @@ import os
 import json
 import itertools
 
+from typing import Any, Callable, Optional, List, Dict
 import nixops.util
 
 class Diff(object):
@@ -139,16 +140,20 @@ class Diff(object):
             d = retrieve_def(d)
             return d
 
+
 class Handler(object):
     def __init__(self, keys, after=None, handle=None):
+        # type: (Dict[str, Dict[str,str]], Optional[List], Optional[Callable]) -> None
         if after is None:
             after = []
-        if handle is not None:
+        if handle is None:
+            self.handle = self._default_handle
+        else:
             self.handle = handle
         self._keys = keys
         self._dependencies = after
 
-    def handle(self):
+    def _default_handle(self):
         """
         Method that should be implemented to handle the changes
         of keys returned by get_keys()

--- a/nixops/resources/azure_dns_record_set.py
+++ b/nixops/resources/azure_dns_record_set.py
@@ -9,8 +9,8 @@ from requests import Request
 
 try:
     from urllib import quote
-except:
-    from urllib.parse import quote
+except ImportError:
+    from urllib.parse import quote # type: ignore
 
 from nixops.util import attr_property
 from nixops.azure_common import ResourceDefinition, ResourceState, ResId

--- a/nixops/resources/azure_dns_zone.py
+++ b/nixops/resources/azure_dns_zone.py
@@ -9,8 +9,8 @@ from requests import Request
 
 try:
     from urllib import quote
-except:
-    from urllib.parse import quote
+except ImportError:
+    from urllib.parse import quote # type: ignore
 
 from nixops.util import attr_property
 from nixops.azure_common import ResourceDefinition, ResourceState, ResId

--- a/nixops/resources/azure_express_route_circuit.py
+++ b/nixops/resources/azure_express_route_circuit.py
@@ -9,8 +9,8 @@ from requests import Request
 
 try:
     from urllib import quote
-except:
-    from urllib.parse import quote
+except ImportError:
+    from urllib.parse import quote  # type: ignore
 
 from nixops.util import attr_property
 from nixops.azure_common import ResourceDefinition, ResourceState, ResId, normalize_location

--- a/nixops/resources/azure_traffic_manager_profile.py
+++ b/nixops/resources/azure_traffic_manager_profile.py
@@ -9,8 +9,8 @@ from requests import Request
 
 try:
     from urllib import quote
-except:
-    from urllib.parse import quote
+except ImportError:
+    from urllib.parse import quote  # type: ignore
 
 from nixops.util import attr_property
 from nixops.azure_common import ResourceDefinition, ResourceState, ResId, normalize_location

--- a/release.nix
+++ b/release.nix
@@ -107,6 +107,10 @@ rec {
 
       doCheck = true;
 
+      postCheck = ''
+        mypy --cache-dir=/dev/null nixops
+      '';
+
       # Needed by libcloud during tests
       SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
 

--- a/release.nix
+++ b/release.nix
@@ -22,6 +22,8 @@ rec {
 
     buildInputs = [ pkgs.git pkgs.libxslt pkgs.docbook5_xsl ];
 
+    nativeBuildInputs = [ pkgs.mypy ];
+
     postUnpack = ''
       # Clean up when building from a working tree.
       if [ -d $sourceRoot/.git ]; then
@@ -94,6 +96,7 @@ rec {
           pysqlite
           datadog
           digital-ocean
+          typing
         ];
 
       # For "nix-build --run-env".

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,37 @@
+[mypy]
+python_version = 2.7 
+no_implicit_optional = True
+strict_optional = True
+
+[mypy-azure.*]
+ignore_missing_imports = True
+
+[mypy-boto.*]
+ignore_missing_imports = True
+
+[mypy-boto3.*]
+ignore_missing_imports = True
+
+[mypy-botocore.*]
+ignore_missing_imports = True
+
+[mypy-digitalocean.*]
+ignore_missing_imports = True
+
+[mypy-libcloud.*]
+ignore_missing_imports = True
+
+[mypy-datadog.*]
+ignore_missing_imports = True
+
+[mypy-adal.*]
+ignore_missing_imports = True
+
+[mypy-pysqlite2.*]
+ignore_missing_imports = True
+
+[mypy-hetzner.*]
+ignore_missing_imports = True
+
+[mypy-libvirt.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Motivation: Restore maintainability that was complained about in https://github.com/NixOS/nixpkgs/pull/48378#issuecomment-435213505

Mypy is optional typing system for python. It was designed by Guido van Rossum, the creator of python
and used on many big code bases such as Dropbox for python2 to python3 migrations.
Personally I was able to migrate a 6000 LOC non-trivial application with little test coverage in less then a day because it had type annotations. Please read the commit message descriptions for more information about the individual changes. Most types can be interfered automatically. To make a method type checked a type annotation has to be added. This also increases readability.
If this pull request is accepted I will make an effort to add semi-automatically types using the existing tests and https://github.com/dropbox/pyannotate.
I think mypy makes also sense beyond python3 migrations for a project like nixops where unittests are pretty hard due to dependencies on many external systems such as cloud apis.