### PR TITLE
fix import cycle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: nix
-script: nix-build --quiet release.nix -A build.x86_64-linux
+before_script:
+  - sudo mkdir /etc/nix && echo 'sandbox = true' | sudo tee /etc/nix/nix.conf
+script: 
+  - nix-build --quiet release.nix -A build.x86_64-linux

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -28,6 +28,7 @@ import platform
 from nixops.util import ansi_success
 import inspect
 import time
+import importlib
 
 class NixEvalError(Exception):
     pass
@@ -1269,7 +1270,7 @@ def _create_state(depl, type, name, id):
 def _load_modules_from(dir):
     for module in os.listdir(os.path.dirname(__file__) + "/" + dir):
         if module[-3:] != '.py' or module == "__init__.py": continue
-        __import__("nixops." + dir + "." + module[:-3], globals(), locals())
+        importlib.import_module("nixops." + dir + "." + module[:-3])
 
 _load_modules_from("backends")
 _load_modules_from("resources")

--- a/nixops/diff.py
+++ b/nixops/diff.py
@@ -4,7 +4,6 @@ import itertools
 
 from typing import Any, Callable, Optional, List, Dict, Union, AnyStr
 import nixops.util
-from nixops.deployment import Deployment
 from nixops.logger import MachineLogger
 from nixops.state import StateDict
 
@@ -19,7 +18,10 @@ class Diff(object):
     UNSET = 2
 
     def __init__(self,
-                 depl,  # type: Deployment
+                 # FIXME: type should be 'nixops.deployment.Deployment'
+                 # however we have to upgrade to python3 in order
+                 # to solve the import cycle by forward declaration
+                 depl,
                  logger,  # type: MachineLogger
                  config,  # type: Dict[str, Any]
                  state,  # type: StateDict

--- a/release.nix
+++ b/release.nix
@@ -107,10 +107,13 @@ rec {
 
       doCheck = true;
 
-      # We have to unset PYTHONPATH here since it will pick enum34 which collides
-      # with python3 own module. This can be removed when nixops is ported to python3.
       postCheck = ''
+        # We have to unset PYTHONPATH here since it will pick enum34 which collides
+        # with python3 own module. This can be removed when nixops is ported to python3.
         PYTHONPATH= mypy --cache-dir=/dev/null nixops
+
+        # smoke test
+        HOME=$TMPDIR $out/bin/nixops --version
       '';
 
       # Needed by libcloud during tests


### PR DESCRIPTION
I was too confident this would have been catched by the unittests,
but as I learned most of those require configured backends.
This time I used this nixops version to deploy my server.

cc @domenkozar sorry for bothering you again.