### PR TITLE
nix/eval-machine-info.nix: fix evaluation with nixpkgs master

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -6,8 +6,7 @@
 , args
 }:
 
-with import <nixpkgs/nixos/lib/testing.nix> { inherit system; };
-with pkgs;
+with import <nixpkgs> { inherit system; };
 with lib;
 
 


### PR DESCRIPTION
The evaluation broken with https://github.com/NixOS/nixpkgs/commit/6c68fbd4e1f8beac39cb1f499ff90c78256262d6

I have no idea why this file was imported in the first place:

https://github.com/NixOS/nixops/commit/bac59ad1b04516510e9c67bbd82b3d310084b2ac#diff-6f15e27c3e048b98302b636c2b8f983bR7

I just removed it and it is still working for my `none` backend.
However since this is file is sufficiently complex I cannot
tell what the general consequence of removing is.