### PR TITLE
Expose resources to deployment.keys

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -309,13 +309,13 @@ class Deployment(object):
         except subprocess.CalledProcessError:
             raise NixEvalError
 
-    def evaluate_config(self, attr):
+    def evaluate_config(self, attr,extra_exprs=[]):
         try:
             # FIXME: use --json
             xml = subprocess.check_output(
                 ["nix-instantiate"]
                 + self.extra_nix_eval_flags
-                + self._eval_flags(self.nix_exprs) +
+                + self._eval_flags(self.nix_exprs + extra_exprs) +
                 ["--eval-only", "--xml", "--strict",
                  "--arg", "checkConfigurationOptions", "false",
                  "-A", attr], stderr=self.logger.log_file)
@@ -653,6 +653,11 @@ class Deployment(object):
             os.environ['NIX_CURRENT_LOAD'] = load_dir
 
         try:
+            # Re-evaluate info.machines in order to have phys_expr (IP's, resources, etc) available for keys
+            (_,config) = self.evaluate_config("info.machines",extra_exprs=[phys_expr])
+            for m in selected:
+                m.keys = config[m.name]['keys']
+
             configs_path = subprocess.check_output(
                 ["nix-build"]
                 + self._eval_flags(self.nix_exprs + [phys_expr]) +


### PR DESCRIPTION
Re-evaluate info.machines in order to expose resources and publicIPv4 to deployment.keys.
Addresses #959 

There may be a better way to do this, this is merely the first thing I was able to make work. Some defensive programming is needed due to the duplication evaluation, so something like this:
```
my_ip = let
     net = nodes.my-machine.config.networking;
     res = builtins.tryEval (
     if net.publicIPv4 != null then net.publicIPv4 else
     if net.privateIPv4 != null then net.privateIPv4 else "");
   in
    if res.success then res.value else "error";
...
deployment.keys."ip".text = my_ip;
```