### PR TITLE
deployment keys: disable service if no key destinations are in /run/

### DIFF
--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -227,7 +227,9 @@ in
 
     systemd.services = (
       { nixops-keys =
-        { enable = config.deployment.keys != {};
+        { enable = any (key: hasPrefix "/run/" key.destDir) (
+            attrValues config.deployment.keys
+          );
           description = "Waiting for NixOps Keys";
           wantedBy = [ "keys.target" ];
           before = [ "keys.target" ];


### PR DESCRIPTION
The `nixops-keys` service only needs to be enabled if the destination of one or more keys is a volatile directory (`/run/`).

This was causing an issue for me with the nixpkgs httpd (apache2) module.  Said module creates a systemd service dependent on `keys.target`.  I don't use deployment keys with httpd, but I do have other nixops modules with deployment keys whose destinations are non-volatile (not in `/run/`).  When restarting the server locally (not with nixops), the `nixops-keys` service just waits for `/run/keys/done` to be created, so httpd won't start.  In order to start httpd, I have to use nixops to resend the keys that the system already has.