### PR TITLE
EC2: broken ssh-tunneling with NixOs 17.09

### DIFF
--- a/nix/ssh-tunnel.nix
+++ b/nix/ssh-tunnel.nix
@@ -87,7 +87,7 @@ with lib;
         remoteCommand = mkAddrConf v.remoteTunnel v.remoteIPv4 v.localIPv4;
 
       in "ssh -i ${v.privateKey} -x"
-       + " -o StrictHostKeyChecking=no"
+       + " -o StrictHostKeyChecking=" + (if ((builtins.substring 0 5 lib.nixpkgsVersion) < "18.03") then "no" else "accept-new")
        + " -o PermitLocalCommand=yes"
        + " -o ServerAliveInterval=20"
        + " -o LocalCommand='${localCommand}'"


### PR DESCRIPTION
It seems like StrictHostKeyChecking option "accept-new" only works for newer OpenSSH versions (I think 7.5) thus using it brakes ssh-tunneling for NixOs 17.09 and earlier. I propose to use a check on `(builtins.substring 0 5 lib.nixpkgsVersion)` to have that only for NixOs 18.03 and later, even though it's said insecure per [#696](https://github.com/NixOS/nixops/issues/696) (a user will still has the option to upgrade OpenSSH or NixOs).

This was tested with NixOs 17.09:
`[root@ip-172-30-2-217:~]# cat /nix/store/7j38b3hmxzk60naxiqsdk583wj9inpzg-unit-script/bin/ssh-tunnel-stage-start
#! /nix/store/jgw8hxx7wzkyhb2dr9hwsd9h2caaasdc-bash-4.4-p12/bin/bash -e
ssh -i /root/.ssh/id_charon_vpn -x -o StrictHostKeyChecking=no -o PermitLocalCommand=yes -o ServerAliveInterval=20 -o LocalCommand='ip addr add 192.168.105.3/32 peer 192.168.105.4 dev tun10004 && ip link set tun10004 up' -w 10004:10003 stage-unencrypted -p 22 'ip addr add 192.168.105.4/32 peer 192.168.105.3 dev tun10003 && ip link set tun10003 up'
[root@ip-172-30-2-217:~]# nixos-version 
17.09.git.2169304 (Hummingbird)
[root@ip-172-30-2-217:~]# ssh -V
OpenSSH_7.5p1, OpenSSL 1.0.2o  27 Mar 2018
[root@ip-172-30-2-217:~]#`

, also with NixOs 18.03:
`[root@ip-172-30-2-217:~]# cat /nix/store/ljj30m8cln55fib9gqr7bva8bygzyznz-unit-script/bin/ssh-tunnel-stage-start
#! /nix/store/lw7xaqhakk0i1c631m3cvac3x4lc5gr5-bash-4.4-p12/bin/bash -e
ssh -i /root/.ssh/id_charon_vpn -x -o StrictHostKeyChecking=accept-new -o PermitLocalCommand=yes -o ServerAliveInterval=20 -o LocalCommand='ip addr add 192.168.105.3/32 peer 192.168.105.4 dev tun10004 && ip link set tun10004 up' -w 10004:10003 stage-unencrypted -p 22 'ip addr add 192.168.105.4/32 peer 192.168.105.3 dev tun10003 && ip link set tun10003 up'
[root@ip-172-30-2-217:~]# nixos-version
18.03.git.a18112a (Impala)
[root@ip-172-30-2-217:~]# `