### PR TITLE
Do not suppress rollback exceptions

### DIFF
--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -37,10 +37,9 @@ class Connection(sqlite3.Connection):
         assert self.nesting >= 0
         if self.nesting == 0:
             if self.must_rollback:
-                try:
-                    self.rollback()
-                except sqlite3.ProgrammingError:
-                    pass
+                # Any exceptions during rollback need to be handled by
+                # the caller/user, so they are allowed to bubble up.
+                self.rollback()
             else:
                 sqlite3.Connection.__exit__(self, exception_type, exception_value, exception_traceback)
         self.lock.release()


### PR DESCRIPTION
I'm not sure what the original motivation for this try/except block
was, though it seems to have been added several years ago. I think if
an exception occurs during rollback, it needs to be either handled
(though I'm not sure there's anything we could do with it) or surfaced
to the user; silent failures can only cause problems.

(I don't mind how the failure is presented; if you'd prefer to avoid a
top-level exception here I can re-add the try/except block with an
error message.)