### PR TITLE
ec2: fix broken nixops check with NVMe

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -1484,15 +1484,16 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
             res.disks_ok = True
             for device_stored, v in self.block_device_mapping.items():
                 device_real = device_name_stored_to_real(device_stored)
+                device_that_boto_expects = device_name_to_boto_expected(device_real) # boto expects only sd names
 
-                if device_stored not in instance.block_device_mapping.keys() and v.get('volumeId', None):
+                if device_that_boto_expects not in instance.block_device_mapping.keys() and v.get('volumeId', None):
                     res.disks_ok = False
                     res.messages.append("volume ‘{0}’ not attached to ‘{1}’".format(v['volumeId'], device_real))
                     volume = nixops.ec2_utils.get_volume_by_id(self.connect(), v['volumeId'], allow_missing=True)
                     if not volume:
                         res.messages.append("volume ‘{0}’ no longer exists".format(v['volumeId']))
 
-                if device_stored in instance.block_device_mapping.keys() and instance.block_device_mapping[device_stored].status != 'attached' :
+                if device_that_boto_expects in instance.block_device_mapping.keys() and instance.block_device_mapping[device_that_boto_expects].status != 'attached' :
                     res.disks_ok = False
                     res.messages.append("volume ‘{0}’ on device ‘{1}’ has unexpected state: ‘{2}’".format(v['volumeId'], device_real, instance.block_device_mapping[device_stored].status))
 


### PR DESCRIPTION
I've noticed that `nixops check` is failing to recognize NVMe devices and shows them as un-attached all the time, then tries to re-attach them with each `nixops deploy`, here's an example:
`nix-shell:~/src/nixops-unstable]$ nixops check -d XXXXX
Machines state:
+----------+--------+-----+-----------+----------+----------------+-------+---------------------------------------------------------------+
| Name     | Exists | Up  | Reachable | Disks OK | Load avg.      | Units | Notes                                                         |
+----------+--------+-----+-----------+----------+----------------+-------+---------------------------------------------------------------+
| data0    | Yes    | Yes | Yes       | No       | 1.65 1.80 1.32 |       | volume ‘vol-0e386094f39e6d82a’ not attached to ‘/dev/nvme1n1’ |
| frontend | Yes    | Yes | Yes       | No       | 0.12 0.18 0.17 |       | volume ‘vol-0b2aa0f4d7be9434b’ not attached to ‘/dev/nvme1n1’ |
+----------+--------+-----+-----------+----------+----------------+-------+---------------------------------------------------------------+
Non machines resources state:
+---------+--------+
| Name    | Exists |
+---------+--------+
| keypair | Yes    |
| sg      | Yes    |
| role    | Yes    |
+---------+--------+`
`[nix-shell:~/src/nixops-unstable]$ nixops deploy -d XXXXX
frontend> warning: device ‘/dev/nvme1n1’ was manually detached!
data0...> warning: device ‘/dev/nvme1n1’ was manually detached!
frontend> attaching volume ‘vol-0b2aa0f4d7be9434b’ as ‘/dev/nvme1n1’... 
data0...> attaching volume ‘vol-0e386094f39e6d82a’ as ‘/dev/nvme1n1’... 
building all machine configurations...
^Cerror: interrupted
error: interrupted by the user
^[[A
[nix-shell:~/src/nixops-unstable]$`

Using the device_name_to_boto_expected() function, it seems working for both 5th generation (NVMe) and older generation disks as it translates both device names 'xvdX' and 'nvmeXnX' to 'sdX'.