### PR TITLE
EC2_backend: Fix mispelled function

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -222,7 +222,7 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
         val = {}
         if backupid in self.backups:
             for device_stored, snap in self.backups[backupid].items():
-                device_real = device_name_save_to_real(dev)
+                device_real = device_name_stored_to_real(device_stored)
 
                 is_root_device = device_real.startswith("/dev/xvda") or device_real.startswith("/dev/nvme0")
 


### PR DESCRIPTION
The `device_name_save_to_real` do not exist anywhere in nixops. 
```
[nix-shell:~/src/nixos-hardening/nix/nixops]$ nixops show-physical -d test --backup 9999999999999999
Traceback (most recent call last):
  File "/home/deploy-ops/src/nixos-hardening/nix/nixops/scripts/nixops", line 989, in <module>
    args.op()
  File "/home/deploy-ops/src/nixos-hardening/nix/nixops/scripts/nixops", line 480, in op_show_physical
    print_physical_backup_spec(args.backupid)
  File "/home/deploy-ops/src/nixos-hardening/nix/nixops/scripts/nixops", line 464, in print_physical_backup_spec
    config[m.name] = m.get_physical_backup_spec(backupid)
  File "/home/deploy-ops/src/nixos-hardening/nix/nixops/nixops/backends/ec2.py", line 225, in get_physical_backup_spec
    device_real = device_name_save_to_real(dev)
NameError: global name 'device_name_save_to_real' is not defined

[nix-shell:~/src/nixos-hardening/nix/nixops]$ vi nixops/backends/ec2.py 

[nix-shell:~/src/nixos-hardening/nix/nixops]$ nixops show-physical -d test --backup 99999999999999999
Traceback (most recent call last):
  File "/home/deploy-ops/src/nixos-hardening/nix/nixops/scripts/nixops", line 989, in <module>
    args.op()
  File "/home/deploy-ops/src/nixos-hardening/nix/nixops/scripts/nixops", line 480, in op_show_physical
    print_physical_backup_spec(args.backupid)
  File "/home/deploy-ops/src/nixos-hardening/nix/nixops/scripts/nixops", line 464, in print_physical_backup_spec
    config[m.name] = m.get_physical_backup_spec(backupid)
  File "/home/deploy-ops/src/nixos-hardening/nix/nixops/nixops/backends/ec2.py", line 225, in get_physical_backup_spec
    device_real = device_name_stored_to_real(dev)
NameError: global name 'dev' is not defined

[nix-shell:~/src/nixos-hardening/nix/nixops]$ vi nixops/backends/ec2.py 
```
After adding the change it works 
```
[nix-shell:~/src/nixos-hardening/nix/nixops]$ nixops show-physical -d test --backup 99999999999999
{
  test = { config, pkgs, ... }: {
    deployment.ec2.blockDeviceMapping."/dev/xvdg".disk = (
      pkgs.lib.mkOverride 10
      "snap-xxxxxxxxxxxxxxxx"
    );
  };
}
```