### PR TITLE
show-physical backup (aws): extract devices encryption keys

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -228,6 +228,11 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
 
                 if not is_root_device:
                     val[device_real] = { 'disk': Call(RawValue("pkgs.lib.mkOverride 10"), snap)}
+
+                    if self.block_device_mapping[device_stored]['encrypt']:
+                        device_passphrase = self.block_device_mapping[device_stored]['generatedKey']
+                        val[device_real].update({'passphrase': Call(RawValue("pkgs.lib.mkOverride 0"), device_passphrase)})
+
             val = { ('deployment', 'ec2', 'blockDeviceMapping'): val }
         else:
             val = RawValue("{{}} /* No backup found for id '{0}' */".format(backupid))


### PR DESCRIPTION
In general we use `nixops show-physical -d test backup xxxxxxx ` to get the mapping between the devices and the snapshots then we use the output to deploy a new env using these snapshot, but when using encrypted volumes, another manually (and tedious) steps to extract and put the keys in that file is needed.
This pr Aims to include that automatically. 
Not sure if this can be considered bad practice from security perspective but since the keys are already in the state file and we are just extracting and formatting them, i don't think thats an issue.
Tested this with non encrypted and encrypted volumes created as separate/non separate resources.