### PR TITLE
filesystem options: fix use of deprecated mkOption { options = ...; }

### DIFF
--- a/doc/manual/dummy.nix
+++ b/doc/manual/dummy.nix
@@ -13,7 +13,7 @@ with lib;
 
   options = {
     fileSystems = mkOption {
-      type = with types; listOf (submodule {});
+      type = with types; loaOf (submodule {});
       description = ''
         NixOps extends NixOS' <option>fileSystem</option> option to
         allow convenient attaching of EC2 volumes.

--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -137,6 +137,19 @@ let
 
   };
 
+  fileSystemsOptions = {
+    options.ec2 = mkOption {
+      default = null;
+      type = with types; (nullOr (submodule ec2DiskOptions));
+      description = ''
+        EC2 disk to be attached to this mount point.  This is
+        shorthand for defining a separate
+        <option>deployment.ec2.blockDeviceMapping</option>
+        attribute.
+      '';
+    };
+  };
+
   isEc2Hvm =
     let
       instanceTypeGroup = builtins.elemAt (splitString "." cfg.instanceType) 0;
@@ -423,18 +436,7 @@ in
     };
 
     fileSystems = mkOption {
-      options = {
-        ec2 = mkOption {
-          default = null;
-          type = with types; (nullOr (submodule ec2DiskOptions));
-          description = ''
-            EC2 disk to be attached to this mount point.  This is
-            shorthand for defining a separate
-            <option>deployment.ec2.blockDeviceMapping</option>
-            attribute.
-          '';
-        };
-      };
+      type = with types; loaOf (submodule fileSystemsOptions);
     };
 
   };


### PR DESCRIPTION
nixos/nixpkgs@27982b408e465554b8831f492362bc87ed0ec02a removed it,
breaking nixops in the process. Migrate to the new recommended way of
enriching options.

Fixes #1086.