### PR TITLE
Go back to python's sqlite module, not pysqlite2

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -92,8 +92,7 @@ rec {
           azure-mgmt-resource
           azure-mgmt-storage
           adal
-          # Go back to sqlite once Python 2.7.13 is released
-          pysqlite
+          sqlite3
           datadog
           digital-ocean
           typing

--- a/release.nix
+++ b/release.nix
@@ -92,7 +92,7 @@ rec {
           azure-mgmt-resource
           azure-mgmt-storage
           adal
-          sqlite3
+          pkgs.sqlite
           datadog
           digital-ocean
           typing

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ ignore_missing_imports = True
 [mypy-adal.*]
 ignore_missing_imports = True
 
-[mypy-pysqlite2.*]
+[mypy-sqlite3.*]
 ignore_missing_imports = True
 
 [mypy-hetzner.*]


### PR DESCRIPTION
Commit history suggests this was only meant as a temporary
workaround, and judging by history of each pysqlite2 is done
(presumably because it lives in python2 tree now)

https://pypi.org/project/pysqlite/#history
(Aug 2016)

vs.

(Actively developed)
https://github.com/python/cpython/commits/2.7/Modules/_sqlite