### PR TITLE
Allow to add a nixpkgs prefix that isn't a path but a string

### DIFF
--- a/doc/manual/default.nix
+++ b/doc/manual/default.nix
@@ -20,7 +20,7 @@ let
     ${pkgs.libxslt.bin or pkgs.libxslt}/bin/xsltproc \
       --stringparam revision '${revision}' \
       --stringparam program 'nixops' \
-      -o $out ${nixpkgs + /nixos/doc/manual/options-to-docbook.xsl} ${optionsXML}
+      -o $out ${nixpkgs + "/nixos/doc/manual/options-to-docbook.xsl"} ${optionsXML}
   '';
 
 in optionsDocBook

--- a/doc/manual/resource.nix
+++ b/doc/manual/resource.nix
@@ -15,7 +15,7 @@ let
   optionsDocBook = pkgs.runCommand "options-db.xml" {} ''
     ${pkgs.libxslt.bin or pkgs.libxslt}/bin/xsltproc \
       --stringparam revision '${revision}' \
-      -o $out ${nixpkgs + /nixos/doc/manual/options-to-docbook.xsl} ${optionsXML}
+      -o $out ${nixpkgs + "/nixos/doc/manual/options-to-docbook.xsl"} ${optionsXML}
   '';
 
 in optionsDocBook


### PR DESCRIPTION
This allows to make a release using a string for nixpkgs:

See https://discourse.nixos.org/t/what-am-i-doing-wrong-here

TL;DR as unstable and stable diverge, it's necessary to explicitly build nixops with a stable `nixpkgs`, with something like:
```nix
let
  # nixos-18.09-small Released on 2019-03-02
  stableTarball = builtins.fetchTarball {
    url = "https://github.com/NixOs/nixpkgs-channels/archive/80754f5cfd69d0caf8cff6795d3ce6d99479abde.tar.gz";
    sha256 = "1v8g68gqgij389dssh6ry5x1zlhpgcgwjac0rgrh8146gf9hq74f";
  };
  pkgs = import <nixpkgs> {};
  remoteVirtNixOpsPkg = /home/azazel/wip/nixos/nixops;
  nixOpsRelease = import "${remoteVirtNixOpsPkg}/release.nix" {nixpkgs=stableTarball;};
in
  nixOpsRelease.build.${pkgs.system}
```

this patch allows to do that now that builtins.toPath is essentially a noop