### PR TITLE
nixos-infect: update channel to 18.09

### DIFF
--- a/nixops/data/nixos-infect
+++ b/nixops/data/nixos-infect
@@ -158,7 +158,7 @@ curl https://nixos.org/nix/install | sh
 
 source ~/.nix-profile/etc/profile.d/nix.sh
 
-[ -z "$NIX_CHANNEL"] && NIX_CHANNEL="nixos-17.09"
+[ -z "$NIX_CHANNEL" ] && NIX_CHANNEL="nixos-18.09"
 nix-channel --remove nixpkgs
 nix-channel --add "https://nixos.org/channels/$NIX_CHANNEL" nixos
 nix-channel --update


### PR DESCRIPTION
Not sure if 19.03 is a good idea given [the issues with azure-mgmt-*](https://github.com/NixOS/nixops/issues/1065), so sticking to 18.09.