### PR TITLE
disable Azure backend :(

### DIFF
--- a/doc/manual/manual.xml
+++ b/doc/manual/manual.xml
@@ -396,6 +396,12 @@
 
     <section>
       <title>Azure Resources</title>
+      <warning>
+        <para>The Azure backend in Nixops is now disabled. See <link xlink:href="https://github.com/NixOS/nixops/pull/1131">PR#1131</link>
+        </para>
+        <para>For existent deployments, Azure backend is supported in Nixops up to release 1.6.1 only.</para>
+    </warning>
+
 
       <para>This section lists resource types associated with the
       Microsoft Azure (Azure) cloud computing environment.</para>

--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -830,6 +830,12 @@ under NixOps control.
 
 
 <section xml:id="sec-deploying-to-azure"><title>Deploying to Microsoft Azure</title>
+  <warning>
+    <para>
+      The Azure backend in Nixops is now disabled. See <link xlink:href="https://github.com/NixOS/nixops/pull/1131">PR#1131</link>
+    </para>
+    <para>For existent deployments, Azure backend is supported in Nixops up to release 1.6.1 only.</para>
+  </warning>
   <para>Note: only ARM(Azure Resource Manager) mode is supported by this backend.</para>
 
   <para><xref linkend="ex-physical-multi-azure.nix" /> shows a physical

--- a/release.nix
+++ b/release.nix
@@ -89,18 +89,22 @@ rec {
           hetzner
           libcloud
           libvirt
-          azure-storage
-          azure-mgmt-compute
-          azure-mgmt-network
-          azure-mgmt-resource
-          azure-mgmt-storage
           adal
           # Go back to sqlite once Python 2.7.13 is released
           pysqlite
           datadog
           digital-ocean
           typing
-        ];
+        ] ++
+        #FIXME add back once https://github.com/NixOS/nixops/pull/1131
+        # is reverted.
+        (lib.optional false [
+          azure-storage
+          azure-mgmt-compute
+          azure-mgmt-network
+          azure-mgmt-resource
+          azure-mgmt-storage
+        ]);
 
       # For "nix-build --run-env".
       shellHook = ''


### PR DESCRIPTION
It's unfortunate but I've gave the update a shot and concluded that it will need some non-trivial amount of work to revive it (more than just few hours). I'd be happy to remove this if someone creates a PR to make it work but for now I think it would be wise to move forward with this so that we can create a new release that would be usable with NixOS 19.03.

