### PR TITLE
Datadog: destroy dashboard operation failing

### DIFF
--- a/nixops/resources/datadog-timeboard.py
+++ b/nixops/resources/datadog-timeboard.py
@@ -131,7 +131,7 @@ class DatadogTimeboardState(nixops.resources.ResourceState):
             else:
                 self.log("deleting datadog timeboard ‘{0}’...".format(self.title))
                 response = self._dd_api.Timeboard.delete(self.timeboard_id)
-                if 'errors' in response.keys():
+                if response and 'errors' in response:
                     raise Exception("there was errors while deleting the timeboard: {}".format(
                         str(response['errors'])))
 


### PR DESCRIPTION
Destroying a Datadog dashboard fails because of a None (yet successful) API call response.
```
$ nixops destroy -d foo --include Standard-Dashboard

Standard-Dashboard> deleting datadog timeboard ‘cb-mfm-ort-dr Dashboard’...
Traceback (most recent call last):
...
  File "/nix/store/5845kjhkh1nr6jvvjimfmjkfrhhgn974-nixops-1.6.1pre0_abcdef/lib/python2.7/site-packages/nixops/resources/datadog-timeboard.py", line 134, in _destroy
AttributeError: 'NoneType' object has no attribute 'keys'
```
Returning a None object with no JSON formatting [seems to be a normal behavior in the Datadog API client](https://github.com/DataDog/datadogpy/blob/master/datadog/api/api_client.py#L155). 

