### PR TITLE
auto-luks: require new `mountPoint` option

### DIFF
--- a/nix/auto-luks.nix
+++ b/nix/auto-luks.nix
@@ -67,6 +67,25 @@ with utils;
               luksFormat</command>.
             '';
           };
+
+          mountPoint = mkOption {
+            type = types.either (types.enum ["none"]) types.str;
+            description = ''
+              This option is required so the autoLuks module knows where the
+              device will be mounted at.  With this option we inject the
+              required <literal>_netdev</literal> mount option. Without the
+              mount option the <literal>local-fs.target</literal> would fail.
+
+              Set to the path used in the corresponding
+              <literal>fileSystems.<replaceable>path</replaceable></literal>
+              option or to <literal>null</literal> if you know what you are doing.
+
+              If you do not use the device on a mount point pass <literal>none</literal>.
+
+              WARNING: failing to provide the correct value here might render
+              the system unbootable.
+            '';
+          };
         };
       });
       description = ''
@@ -85,6 +104,12 @@ with utils;
   ###### implementation
 
   config = {
+
+    fileSystems =
+      let
+        mkFileSystemEntry = _: attrs: nameValuePair attrs.mountPoint { options = [ "_netdev" ]; };
+      in mapAttrs' mkFileSystemEntry
+          (filterAttrs (_: attrs: attrs.mountPoint != "none") config.deployment.autoLuks);
 
     systemd.services =
       let


### PR DESCRIPTION
With the upcoming systemd v242 change (https://github.com/NixOS/nixpkgs/pull/61321) in nixpkgs there will be a breaking change to how auto-luks used to work. We are going to remove a commit from the systemd fork (https://github.com/NixOS/systemd/commit/ce79214307f59fdd567271a0cad7be67e05c46ab) that was added for auto-luks to work. The
auto-luks feature will continue to work but another mount option is required to mark those `fileSystems` as not local. All mount points that carry the `_netdev` mount option are not part of the `local-fs.target` and thus not blocking the start of things like the sshd daemon.

Adding this option is (so far) the least intrusive way to ensure that systems will not break. Every user of the feature will be required to add only one more value to it's configuration.


Trying to automatically detect which mount points are mounted from the unlocked block devices is not really feasible in all/most cases. There might be another layer of indirection in between the actual (luks) device and the mount point. Good examples that will make it hard for us to guess are things like RAID, LVM, ZFS, ….

Dropping the systemd patch removes a bunch of issues and race conditions in regards to creating `/run/<service>` and `/var/lib/<service>` directories (see https://github.com/NixOS/nixpkgs/issues/47550, https://github.com/NixOS/nixpkgs/issues/53852, https://github.com/NixOS/nixpkgs/issues/53852). Those paths are usually set up using the `systemd-tempfiles.service` which is (again) part of `sysinit.target`.

This is also part of the ongoing effort to remove large a portion of our `PreStart` scripts that just create directories. In the long run there should be less custom scripting required to get a service with (temporary and persistent) state up and running.

For all the current version of NixOS this should be mostly a No-Op. In a local test against libvirtd there was no observable difference in behavior between 19.03 and the systemd PR.

Ideally we would have a way to warn users that deploy a more recent NixOS that they must use a newer NixOps version. It is still not obvious how to do that in an elegant way. Opinions are very welcome. Not updating systemd or keeping the broken sysinit behaviour isn't really an option in the long run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixops/1156)
<!-- Reviewable:end -->
