### PR TITLE
Do not require a valid activation in order to use ssh key

### DIFF
--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -79,7 +79,7 @@ class NoneState(MachineState):
 
     def get_ssh_flags(self, *args, **kwargs):
         super_state_flags = super(NoneState, self).get_ssh_flags(*args, **kwargs)
-        if self.vm_id and self.cur_toplevel and self._ssh_public_key_deployed:
+        if self.vm_id and self._ssh_public_key_deployed:
             return super_state_flags + ["-o", "StrictHostKeyChecking=accept-new", "-i", self.get_ssh_private_key_file()]
         return super_state_flags
 


### PR DESCRIPTION
Should close #904 

Related comment: https://github.com/NixOS/nixops/issues/904#issuecomment-496311184

I also tried to have a look at `tests/none-backend.nix` in order to reproduce, but the last successful build was 2016 and I cant seem to fix it in an acceptable timeframe, so I might have a look in another PR.