### PR TITLE
Add support for SSH jump hosts

### DIFF
--- a/examples/jumphost-virtd.nix
+++ b/examples/jumphost-virtd.nix
@@ -1,0 +1,14 @@
+{
+
+  machine1 = # Log in and add your SSH public key to /root/.ssh/authorized_keys
+    { deployment.targetEnv = "libvirtd";
+      deployment.libvirtd.imageDir = "/var/lib/libvirt/images";
+    };
+
+  machine2 =
+    { resources, lib, ... }:
+    { deployment.targetEnv = "libvirtd";
+      deployment.libvirtd.imageDir = "/var/lib/libvirt/images";
+      deployment.jumpHost = "root@192.168.122.113"; # Update to IP of machine1
+    };
+}

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -306,7 +306,7 @@ rec {
 
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
-        { inherit (v.config.deployment) targetEnv targetPort targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys hasFastConnection;
+        { inherit (v.config.deployment) targetEnv targetPort targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys hasFastConnection jumpHost;
           nixosRelease = v.config.system.nixos.release or v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
           azure = optionalAttrs (v.config.deployment.targetEnv == "azure")  v.config.deployment.azure;
           ec2 = optionalAttrs (v.config.deployment.targetEnv == "ec2") v.config.deployment.ec2;

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -117,6 +117,18 @@ in
       '';
     };
 
+    deployment.jumpHost = mkOption {
+      example = "root@10.10.10.1:222";
+      default = null;
+      type = types.nullOr types.str;
+      description = ''
+        If set to a string, the value will be used as an SSH jump host to
+        tunnel through to the machine.
+
+        SSH connections to the jump host use the invoking users SSH key/agent.
+      '';
+    };
+
     # Computed options useful for referring to other machines in
     # network specifications.
 

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -174,7 +174,9 @@ class SSH(object):
         Start (if necessary) an SSH master connection to speed up subsequent
         SSH sessions. Returns the SSHMaster instance on success.
         """
-        flags = flags + self._get_flags()
+        base_flags = self._get_flags()
+        # Removes duplicates of switch/argument pairs in order
+        flags = base_flags + list(set(flags) - set(base_flags))
         if self._ssh_master is not None:
             master = weakref.proxy(self._ssh_master)
             if master.is_alive():
@@ -278,7 +280,9 @@ class SSH(object):
         'timeout' specifies the SSH connection timeout.
         """
         master = self.get_master(flags, timeout, user)
-        flags = flags + self._get_flags()
+        base_flags = self._get_flags()
+        # Removes duplicates of switch/argument pairs in order
+        flags = base_flags + list(set(flags) - set(base_flags))
         if logged:
             flags.append("-x")
         cmd = ["ssh"] + master.opts + flags


### PR DESCRIPTION
Adds a new option `deployment.jumpHost` that can be used with any backend to tunnel SSH connections through a bastion/jump host. Tested with the newly created example network using libvirtd backend.

Also fixes a bug I encountered in `ssh_util.py` where the flags from `MachineState.get_ssh_flag` where included twice.

Closes #1150 