### PR TITLE
container backend: allow setting {local,host}Address

### DIFF
--- a/examples/container-in-libvirtd.nix
+++ b/examples/container-in-libvirtd.nix
@@ -1,0 +1,14 @@
+{
+  libvirtd = { ... }:
+    { deployment.targetEnv = "libvirtd";
+    };
+
+  container = { pkgs, resources, ... }:
+    { deployment.targetEnv = "container";
+      deployment.container.host = resources.machines.libvirtd;
+      deployment.container.localAddress = "10.235.1.2";
+      deployment.container.hostAddress = "10.235.1.1";
+
+      environment.systemPackages = [ pkgs.hello ];
+    };
+}

--- a/nix/container.nix
+++ b/nix/container.nix
@@ -27,6 +27,22 @@ in
       '';
     };
 
+    deployment.container.localAddress = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Local address of the container.
+      '';
+    };
+
+    deployment.container.hostAddress = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Host address of the container.
+      '';
+    };
+
   };
 
   config = mkIf (config.deployment.targetEnv == "container") {


### PR DESCRIPTION
With that patch it's possible to deploy containers and assign those to
different IPs rather than the next available /24 subnet from `10.233.0.0/16`.
This patch depends on #60029[1] and can only be used with NixOS 19.09
(a.k.a nixos-unstable at the time of writing).

The behavior can be tested using a simple deployment like this:

``` nix
{
  container = { resources, ... }:
    { deployment.targetEnv = "container";
      deployment.container.host = resources.machines.horst;
      deployment.container.localAddress = "10.235.1.2";
      deployment.container.hostAddress = "10.235.1.1";
    };

  # the feature is optional, by default the next free addresses
  # from 10.233.0.0/16 will be used here.
  container2 = { resources, ... }:
    { deployment.targetEnv = "container";
      deployment.container.host = resources.machines.horst;
    };

  horst = { ... }:
    { deployment.targetEnv = "libvirtd";
    };
}
```

[1] https://github.com/NixOS/nixpkgs/pull/60029