### PR TITLE
ec2: Recreate rules if security group was deleted

### DIFF
--- a/nixops/resources/ec2_security_group.py
+++ b/nixops/resources/ec2_security_group.py
@@ -157,17 +157,6 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
                 rule[-1] = res.public_ipv4 + '/32'
             resolved_security_group_rules.append(rule)
 
-        new_rules = set()
-        old_rules = set()
-        for rule in self.security_group_rules:
-            old_rules.add(tuple(rule))
-        for rule in resolved_security_group_rules:
-            tupled_rule = tuple(rule)
-            if not tupled_rule in old_rules:
-                new_rules.add(tupled_rule)
-            else:
-                old_rules.remove(tupled_rule)
-
         if self.state == self.MISSING or self.state == self.UNKNOWN:
             self._connect()
             try:
@@ -178,6 +167,17 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
                 if self.state != self.UNKNOWN or e.error_code != u'InvalidGroup.Duplicate':
                     raise
             self.state = self.STARTING #ugh
+
+        new_rules = set()
+        old_rules = set()
+        for rule in self.security_group_rules:
+            old_rules.add(tuple(rule))
+        for rule in resolved_security_group_rules:
+            tupled_rule = tuple(rule)
+            if not tupled_rule in old_rules:
+                new_rules.add(tupled_rule)
+            else:
+                old_rules.remove(tupled_rule)
 
         if new_rules:
             self.logger.log("adding new rules to EC2 security group ‘{0}’...".format(self.security_group_name))

--- a/nixops/resources/ec2_security_group.py
+++ b/nixops/resources/ec2_security_group.py
@@ -157,12 +157,16 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
                 rule[-1] = res.public_ipv4 + '/32'
             resolved_security_group_rules.append(rule)
 
+        security_group_was_created = False
         if self.state == self.MISSING or self.state == self.UNKNOWN:
             self._connect()
             try:
                 self.logger.log("creating EC2 security group ‘{0}’...".format(self.security_group_name))
                 grp = self._conn.create_security_group(self.security_group_name, self.security_group_description, defn.vpc_id)
                 self.security_group_id = grp.id
+                # If group creation succeeded, the group wasn't there before,
+                # in which case also its rules must be (re-)created below.
+                security_group_was_created = True
             except boto.exception.EC2ResponseError as e:
                 if self.state != self.UNKNOWN or e.error_code != u'InvalidGroup.Duplicate':
                     raise
@@ -170,8 +174,9 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
 
         new_rules = set()
         old_rules = set()
-        for rule in self.security_group_rules:
-            old_rules.add(tuple(rule))
+        if not security_group_was_created:  # old_rules stays {}
+            for rule in self.security_group_rules:
+                old_rules.add(tuple(rule))
         for rule in resolved_security_group_rules:
             tupled_rule = tuple(rule)
             if not tupled_rule in old_rules:


### PR DESCRIPTION
Fixes #684.

The change was very simple: If we notice that the Security Group is gone, we write down that this means that all its rules are missing as well.

See the commit messages for details.