### PR TITLE
ssh: Read extra options from NIXOPS_SSHOPTS env var.

### DIFF
--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -43,12 +43,16 @@ class SSHMaster(object):
             kwargs['preexec_fn'] = os.setsid
             pass_prompts = 1
 
+        # Allow the user to provide some extra SSH flags via an env var.
+        env_flags = shlex.split(os.getenv('NIXOPS_SSHOPTS', default =""))
+
         cmd = ["ssh", "-x", self._ssh_target, "-S",
                self._control_socket, "-M", "-N", "-f",
                '-oNumberOfPasswordPrompts={0}'.format(pass_prompts),
                '-oServerAliveInterval=60',
                '-oControlPersist=600'] \
-              + (["-C"] if compress else [])
+              + (["-C"] if compress else []) \
+              + env_flags
 
         res = subprocess.call(cmd + ssh_flags, **kwargs)
         if res != 0:


### PR DESCRIPTION
This is useful for example to override performance-related SSH options,
such as:

    NIXOPS_SSHOPTS="-c aes128-gcm@openssh.com" nixops ...

can cut CPU usage by 4x vs many Linux distributions' current default of
`chacha20-poly1305@openssh.com` when copying large amounts of data via SSH.