### PR TITLE
nixops/reboot: ask the user to confirm the reboot before actually doing it

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -188,6 +188,9 @@ class MachineState(nixops.resources.ResourceState):
 
     def reboot_sync(self, hard=False):
         """Reboot this machine and wait until it's up again."""
+        if not self.depl.logger.confirm("are you sure you want to reboot {0}".format(self.name)):
+            self.depl.logger.get_logger_for(self.name).warn("Not rebooting...")
+            return False
         self.reboot(hard=hard)
         self.log_start("waiting for the machine to finish rebooting...")
         nixops.util.wait_for_tcp_port(self.get_ssh_name(), self.ssh_port, open=False, callback=lambda: self.log_continue("."))

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -434,6 +434,8 @@ def op_destroy():
 
 def op_reboot():
     depl = open_deployment()
+    if args.confirm:
+        depl.logger.set_autoresponse("y")
     depl.reboot_machines(include=args.include or [],
                          exclude=args.exclude or [],
                          wait=(not args.no_wait),


### PR DESCRIPTION
When one runs `nixops reboot` accidentally, it should be
confirmed that the reboot is actually intended (unless those warnings
are explicitly disabled with `--confirm`).