### PR TITLE
[WIP]: Rewritting to use boto3

### DIFF
--- a/nix/ec2-keypair.nix
+++ b/nix/ec2-keypair.nix
@@ -17,6 +17,11 @@ with lib;
       description = "AWS region.";
     };
 
+    profile = mkOption {
+      type = types.str;
+      description = "Name of the profile.";
+    };
+
     accessKeyId = mkOption {
       default = "";
       type = types.str;

--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -175,6 +175,17 @@ in
 
   options = {
 
+    deployment.ec2.profile = mkOption {
+      default = null;
+      example = "dev-Administrator";
+      type = types.str;
+      description = ''
+        The profile name as defined in <filename>~/.aws/config</filename>
+        If left empty it will be left to boto to decide, which means it will
+        check <envvar>AWS_PROFILE</envvar> and use "default".
+      '';
+    };
+
     deployment.ec2.accessKeyId = mkOption {
       default = "";
       example = "AKIABOGUSACCESSKEY";

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 import os
 import re
-import subprocess
 
 from typing import List
 
-import nixops.util
 import nixops.resources
 import nixops.ssh_util
+import nixops.util
+
 
 class MachineDefinition(nixops.resources.ResourceDefinition):
     """Base class for NixOps machine definitions."""
@@ -315,7 +317,7 @@ class MachineState(nixops.resources.ResourceState):
 
     def write_ssh_private_key(self, private_key):
         key_file = "{0}/id_nixops-{1}".format(self.depl.tempdir, self.name)
-        with os.fdopen(os.open(key_file, os.O_CREAT | os.O_WRONLY, 0600), "w") as f:
+        with os.fdopen(os.open(key_file, os.O_CREAT | os.O_WRONLY, 0o600), "w") as f:
             f.write(private_key)
         self._ssh_private_key_file = key_file
         return key_file

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -118,13 +118,16 @@ class MachineState(nixops.resources.ResourceState):
     def check(self):
         """Check machine state."""
         res = CheckResult()
-        self._check(res)
+        self._machine_check(res)
         return res
 
-    def _check(self, res):
+    def _machine_check(self, res):
+        # type: (CheckResult) -> None
+
         avg = self.get_load_avg()
-        if avg == None:
-            if self.state == self.UP: self.state = self.UNREACHABLE
+        if avg is None:
+            if self.state == self.UP:
+                self.state = self.UNREACHABLE
             res.is_reachable = False
         else:
             self.state = self.UP
@@ -140,11 +143,13 @@ class MachineState(nixops.resources.ResourceState):
             res.in_progress_units = []
             for l in out:
                 match = re.match("^([^ ]+) .* failed .*$", l)
-                if match: res.failed_units.append(match.group(1))
+                if match:
+                    res.failed_units.append(match.group(1))
 
                 # services that are in progress
                 match = re.match("^([^ ]+) .* activating .*$", l)
-                if match: res.in_progress_units.append(match.group(1))
+                if match:
+                    res.in_progress_units.append(match.group(1))
 
                 # Currently in systemd, failed mounts enter the
                 # "inactive" rather than "failed" state.  So check for

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -4,6 +4,8 @@ import os
 import re
 import subprocess
 
+from typing import List
+
 import nixops.util
 import nixops.resources
 import nixops.ssh_util
@@ -275,6 +277,7 @@ class MachineState(nixops.resources.ResourceState):
         assert False
 
     def get_ssh_flags(self, scp=False):
+        # type: (bool) -> List[str]
         if scp:
             return ["-P", str(self.ssh_port)]
         else:

--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -2,35 +2,28 @@
 
 from __future__ import absolute_import, print_function
 
-import os
-import os.path
-import sys
+import datetime
+import math
 import re
 import time
-import math
-import shutil
-import calendar
+from xml.etree.ElementTree import Element
+
 import boto.ec2
 import boto.ec2.blockdevicemapping
 import boto.ec2.networkinterface
+import boto3
 import botocore.exceptions
+from typing import Any, Dict, Iterable, List, Optional
 
-from . import MachineDefinition, MachineState
-from ..nix_expr import Function, Call, RawValue
-from ..resources.ebs_volume import EBSVolumeState
-from ..resources.elastic_ip import ElasticIPState
-import nixops.resources.ec2_common
-from ..util import device_name_to_boto_expected, device_name_stored_to_real, device_name_user_entered_to_stored
 import nixops.ec2_utils
 import nixops.known_hosts
-import nixops.util
+import nixops.resources.ec2_common
 import nixops.resources.ec2_keypair
-from xml import etree
-import datetime
-import boto3
-from typing import Any, Dict, Optional, List, Iterable
+import nixops.util
+from . import MachineDefinition, MachineState
 from ..ec2_utils import key_value_to_ec2_key_value
-from xml.etree.ElementTree import Element
+from ..nix_expr import Call, Function, RawValue
+from ..util import device_name_stored_to_real, device_name_to_boto_expected, device_name_user_entered_to_stored
 
 
 class EC2InstanceDisappeared(Exception):

--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -749,7 +749,7 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
         return instance
 
     def create_instance(self, defn, zone, user_data, ebs_optimized, args):
-        # type: (EC2Definition, str, str, bool, Dict[str, Any]) -> Any
+        # type: (EC2Definition, Optional[str], str, bool, Dict[str, Any]) -> Any
         IamInstanceProfile = {}  # type: Dict[str, str]
         if defn.instance_profile.startswith("arn:"):
             IamInstanceProfile["Arn"] = defn.instance_profile
@@ -1032,9 +1032,6 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
                 elif zone != volume.availability_zone:
                     raise Exception("unable to start EC2 instance ‘{0}’ in zone ‘{1}’ because volume ‘{2}’ is in zone ‘{3}’"
                                     .format(self.name, zone, v['disk'], volume.availability_zone))
-
-            if zone is None:
-                raise Exception("unable to start EC2 instance '{0}' because zone was not provided".format(self.name))
 
             # Do we want an EBS-optimized instance?
             prefer_ebs_optimized = False

--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -1639,20 +1639,22 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
                     res.messages.append("  * {0}".format(e.description))
                     res.messages.append("  * {0} - {1}".format(e.not_before, e.not_after))
 
-
     def reboot(self, hard=False):
+        # type: (bool) -> None
+
         self.log("rebooting EC2 machine...")
         instance = self._get_instance()
         instance.reboot()
         self.state = self.STARTING
 
-
     def get_console_output(self):
+        # type: () -> str
+
         if not self.vm_id:
             raise Exception("cannot get console output of non-existant machine ‘{0}’".format(self.name))
-        self.connect()
-        return self._conn.get_console_output(self.vm_id).output or "(not available)"
 
+        ec2 = self.session().client('ec2')
+        return ec2.get_console_output(InstanceId=self.vm_id)['Output'] or "(not available)"
 
     def next_charge_time(self):
         if not self.start_time:

--- a/nixops/ec2_utils.py
+++ b/nixops/ec2_utils.py
@@ -194,7 +194,7 @@ def wait_for_volume_available(session, volume_id, logger, states=None):
         # Allow volume to be missing due to eventual consistency.
         volume = get_volume_by_id(session, volume_id, allow_missing=True)
         if volume:
-            logger.log_continue("[{0}] ".format(volume.status))
+            logger.log_continue("[{0}] ".format(volume.state))
             return volume.state in states
         else:
             logger.log_continue("[missing] ")

--- a/nixops/ec2_utils.py
+++ b/nixops/ec2_utils.py
@@ -3,28 +3,20 @@
 from __future__ import absolute_import
 
 import os
-import time
 import random
+import time
 
-from botocore import credentials
-from typing import Optional, Callable, List, TypeVar, Dict, Mapping, TYPE_CHECKING, Container, Any, cast, NoReturn, \
-    Union
-
-import nixops.util
-
-import boto3
 import boto.ec2
 import boto.vpc
-import logging
-from boto.exception import EC2ResponseError
-from boto.exception import SQSError
-from boto.exception import BotoServerError
-from botocore.exceptions import ClientError
-from boto.pyami.config import Config
-
-import botocore.session
+import boto3
 import botocore.exceptions
+import botocore.session
+from boto.pyami.config import Config
+from botocore import credentials
+from botocore.exceptions import ClientError
+from typing import Any, Callable, Container, Dict, List, Mapping, Optional, TYPE_CHECKING, TypeVar
 
+import nixops.util
 from nixops.resources import ResourceState
 
 if TYPE_CHECKING:
@@ -77,8 +69,6 @@ def fetch_aws_secret_key(access_key_id):
 
 def session(**kwargs):
     # type: (**str) -> boto3.Session
-    # TODO: remove me
-    print("session", kwargs)
 
     kwargs = kwargs.copy()
     profile = kwargs.pop('profile_name', None)
@@ -95,7 +85,6 @@ def session(**kwargs):
 
 def connect(region, profile, access_key_id):
     """Connect to the specified EC2 region using the given access key."""
-    print("connect", region, profile, access_key_id)
     assert region
     credentials = fetch_aws_secret_key(access_key_id)
     if credentials:
@@ -111,7 +100,6 @@ def connect(region, profile, access_key_id):
     return conn
 
 def connect_ec2_boto3(region, profile, access_key_id):
-    print("connect3", region, profile, access_key_id)
     assert region
     credentials = fetch_aws_secret_key(access_key_id)
     if credentials:

--- a/nixops/resources/ebs_volume.py
+++ b/nixops/resources/ebs_volume.py
@@ -4,15 +4,14 @@
 
 from __future__ import absolute_import
 
-import time
-import boto.ec2
-import nixops.util
+import boto3
+import botocore.exceptions
+
 import nixops.ec2_utils
 import nixops.resources
-import botocore.exceptions
 import nixops.resources.ec2_common
+import nixops.util
 
-import boto3
 
 class EBSVolumeDefinition(nixops.resources.ResourceDefinition):
     """Definition of an EBS volume."""

--- a/nixops/resources/ec2_common.py
+++ b/nixops/resources/ec2_common.py
@@ -1,13 +1,21 @@
+from __future__ import absolute_import
+
 import socket
 import getpass
 
 import boto3
+from typing import Dict, Mapping, Optional, Callable
 
 import nixops.util
 import nixops.resources
+import nixops.ec2_utils
 from nixops.diff import Diff, Handler
 
-class EC2CommonState():
+from . import ResourceState
+from ..ec2_utils import key_value_to_ec2_key_value
+
+
+class EC2CommonState(ResourceState):
 
     COMMON_EC2_RESERVED = ['accessKeyId', 'ec2.tags']
 
@@ -17,6 +25,7 @@ class EC2CommonState():
     tags = nixops.util.attr_property("ec2.tags", {}, 'json')
 
     def get_common_tags(self):
+        # type: () -> Dict[str, str]
         tags = {'CharonNetworkUUID': self.depl.uuid,
                 'CharonMachineName': self.name,
                 'CharonStateFile': "{0}@{1}:{2}".format(getpass.getuser(), socket.gethostname(), self.depl._db.db_file)}
@@ -25,9 +34,15 @@ class EC2CommonState():
         return tags
 
     def get_default_name_tag(self):
+        # type: () -> str
         return "{0} [{1}]".format(self.depl.description, self.name)
 
-    def update_tags_using(self, updater, user_tags={}, check=False):
+    def update_tags_using(self, updater, user_tags=None, check=False):
+        # type: (Callable[[Mapping[str, str]], None], Optional[Mapping[str, str]], bool) -> None
+
+        if user_tags is None:
+            user_tags = {}
+
         tags = {'Name': self.get_default_name_tag()}
         tags.update(user_tags)
         tags.update(self.get_common_tags())
@@ -36,11 +51,19 @@ class EC2CommonState():
             updater(tags)
             self.tags = tags
 
-    def update_tags(self, id, user_tags={}, check=False):
+    def update_tags(self, session, id, user_tags=None, check=False):
+        # type: (boto3.Session, str, Optional[Dict[str, str]], bool) -> None
+
+        if user_tags is None:
+            user_tags = {}
 
         def updater(tags):
+            # type: (Mapping[str, str]) -> None
+
+            ec2 = session.client('ec2')
+
             # FIXME: handle removing tags.
-            self._retry(lambda: self._conn.create_tags([id], tags))
+            self._retry(lambda: ec2.create_tags(Resources=[id], Tags=key_value_to_ec2_key_value(tags)))
 
         self.update_tags_using(updater, user_tags=user_tags, check=check)
 

--- a/nixops/resources/ec2_common.py
+++ b/nixops/resources/ec2_common.py
@@ -1,16 +1,14 @@
 from __future__ import absolute_import
 
-import socket
 import getpass
+import socket
 
 import boto3
-from typing import Dict, Mapping, Optional, Callable
+from typing import Callable, Dict, Mapping, Optional
 
-import nixops.util
-import nixops.resources
 import nixops.ec2_utils
-from nixops.diff import Diff, Handler
-
+import nixops.resources
+import nixops.util
 from . import ResourceState
 from ..ec2_utils import key_value_to_ec2_key_value
 

--- a/nixops/resources/ec2_keypair.py
+++ b/nixops/resources/ec2_keypair.py
@@ -2,9 +2,14 @@
 
 # Automatic provisioning of EC2 key pairs.
 
-import nixops.util
-import nixops.resources
+from __future__ import absolute_import
+
+import boto3
+import botocore.client
+
 import nixops.ec2_utils
+import nixops.resources
+import nixops.util
 
 
 class EC2KeyPairDefinition(nixops.resources.ResourceDefinition):
@@ -12,19 +17,25 @@ class EC2KeyPairDefinition(nixops.resources.ResourceDefinition):
 
     @classmethod
     def get_type(cls):
+        # type: () -> str
         return "ec2-keypair"
 
     @classmethod
     def get_resource_type(cls):
+        # type: () -> str
         return "ec2KeyPairs"
 
     def __init__(self, xml):
-        nixops.resources.ResourceDefinition.__init__(self, xml)
+        # type: (...) -> None
+        super(EC2KeyPairDefinition, self).__init__(xml)
+
         self.keypair_name = xml.find("attrs/attr[@name='name']/string").get("value")
         self.region = xml.find("attrs/attr[@name='region']/string").get("value")
+        self.profile = xml.find("attrs/attr[@name='profile']/string").get("value")
         self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get("value")
 
     def show_type(self):
+        # type: () -> str
         return "{0} [{1}]".format(self.get_type(), self.region)
 
 
@@ -35,104 +46,94 @@ class EC2KeyPairState(nixops.resources.ResourceState):
     keypair_name = nixops.util.attr_property("ec2.keyPairName", None)
     public_key = nixops.util.attr_property("publicKey", None)
     private_key = nixops.util.attr_property("privateKey", None)
+    profile = nixops.util.attr_property("ec2.profile", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     region = nixops.util.attr_property("ec2.region", None)
-
 
     @classmethod
     def get_type(cls):
         return "ec2-keypair"
 
-
     def __init__(self, depl, name, id):
-        nixops.resources.ResourceState.__init__(self, depl, name, id)
-        self._conn = None
-
+        super(EC2KeyPairState, self).__init__(depl, name, id)
+        self._session = None  # type: boto3.session.Session
 
     def show_type(self):
         s = super(EC2KeyPairState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
-        return s
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
 
+        return s
 
     @property
     def resource_id(self):
         return self.keypair_name
 
-
-    def get_definition_prefix(self):
+    @staticmethod
+    def get_definition_prefix():
         return "resources.ec2KeyPairs."
 
+    def session(self):
+        # type: () -> boto3.Session
 
-    def connect(self):
-        if self._conn: return
-        self._conn = nixops.ec2_utils.connect(self.region, self.access_key_id)
+        if not self._session:
+            self._session = nixops.ec2_utils.session(**{
+                "region_name": self.region,
+                "profile_name": self.profile,
+                "aws_access_key_id": self.access_key_id
+            })
 
+        return self._session
 
     def create(self, defn, check, allow_reboot, allow_recreate):
+        # type: (EC2KeyPairDefinition, bool, bool, bool) -> None
 
+        self.profile = defn.profile
         self.access_key_id = defn.access_key_id or nixops.ec2_utils.get_access_key_id()
-        if not self.access_key_id:
-            raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
 
         # Generate the key pair locally.
         if not self.public_key:
-            (private, public) = nixops.util.create_key_pair(type="rsa") # EC2 only supports RSA keys.
+            private, public = nixops.util.create_key_pair(type="rsa")  # EC2 only supports RSA keys.
             with self.depl._db:
                 self.public_key = public
                 self.private_key = private
 
         # Upload the public key to EC2.
         if check or self.state != self.UP:
-
             self.region = defn.region
-            self.connect()
 
-            # Sometimes EC2 DescribeKeypairs return empty list on invalid
-            # identifiers, which results in a IndexError exception from within boto,
-            # work around that until we figure out what is causing this.
-            try:
-                kp = self._conn.get_key_pair(defn.keypair_name)
-            except IndexError as e:
-                kp = None
+            ec2 = self.session().client('ec2')
+            keys = ec2.describe_key_pairs(Filters=[{'Name': 'key-name', 'Values': [defn.keypair_name]}])
 
             # Don't re-upload the key if it exists and we're just checking.
-            if not kp or self.state != self.UP:
-                if kp: self._conn.delete_key_pair(defn.keypair_name)
+            if not keys['KeyPairs'] or self.state != self.UP:
+                if keys['KeyPairs']:
+                    ec2.delete_key_pair(KeyName=defn.keypair_name)
                 self.log("uploading EC2 key pair ‘{0}’...".format(defn.keypair_name))
-                self._conn.import_key_pair(defn.keypair_name, self.public_key)
+                ec2.import_key_pair(KeyName=defn.keypair_name, PublicKeyMaterial=self.public_key.encode())
 
             with self.depl._db:
                 self.state = self.UP
                 self.keypair_name = defn.keypair_name
 
-
     def destroy(self, wipe=False):
-        def keypair_used():
-            for m in self.depl.active_resources.itervalues():
-                if isinstance(m, nixops.backends.ec2.EC2State) and m.key_pair == self.keypair_name:
-                    return m
-            return None
-
-        m = keypair_used()
-        if m:
-            raise Exception("keypair ‘{0}’ is still in use by ‘{1}’ ({2})".format(self.keypair_name, m.name, m.vm_id))
+        for m in self.depl.active_resources.values():
+            if isinstance(m, nixops.backends.ec2.EC2State) and m.key_pair == self.keypair_name:
+                raise Exception("keypair ‘{0}’ is still in use by ‘{1}’ ({2})".format(self.keypair_name, m.name, m.vm_id))
 
         if not self.depl.logger.confirm("are you sure you want to destroy keypair ‘{0}’?".format(self.keypair_name)):
             return False
 
         if self.state == self.UP:
             self.log("deleting EC2 key pair ‘{0}’...".format(self.keypair_name))
-            self.connect()
-            self._conn.delete_key_pair(self.keypair_name)
+            ec2 = self.session().client('ec2')
+            ec2.delete_key_pair(KeyName=self.keypair_name)
 
         return True
 
     def check(self):
-        self.connect()
-        try:
-            kp = self._conn.get_key_pair(self.keypair_name)
-        except IndexError as e:
-            kp = None
-        if kp is None:
+        ec2 = self.session().client('ec2')
+
+        keys = ec2.describe_key_pairs(Filters=[{'Name': 'key-name', 'Values': [self.keypair_name]}])
+        if not keys['KeyPairs']:
             self.state = self.MISSING

--- a/nixops/resources/ec2_keypair.py
+++ b/nixops/resources/ec2_keypair.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import
 
 import boto3
-import botocore.client
 
 import nixops.ec2_utils
 import nixops.resources

--- a/nixops/resources/elastic_file_system.py
+++ b/nixops/resources/elastic_file_system.py
@@ -26,9 +26,8 @@ class ElasticFileSystemDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0} [{1}]".format(self.get_type(), self.region)
 
-class ElasticFileSystemState(nixops.resources.ResourceState, \
-                             nixops.resources.ec2_common.EC2CommonState, \
-                             nixops.resources.efs_common.EFSCommonState):
+class ElasticFileSystemState(nixops.resources.ec2_common.EC2CommonState, nixops.resources.efs_common.EFSCommonState,
+                             nixops.resources.ResourceState):
     """State of an AWS Elastic File System."""
 
     state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)

--- a/nixops/resources/elastic_file_system.py
+++ b/nixops/resources/elastic_file_system.py
@@ -2,15 +2,19 @@
 
 # AWS Elastic File Systems.
 
+from __future__ import absolute_import
+
+import time
 import uuid
-import boto3
+
 import botocore
-import nixops.util
+
 import nixops.ec2_utils
 import nixops.resources
 import nixops.resources.ec2_common
 import nixops.resources.efs_common
-import time
+import nixops.util
+
 
 class ElasticFileSystemDefinition(nixops.resources.ResourceDefinition):
     """Definition of an AWS Elastic File System."""

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 import os
 import sys
 import time
@@ -18,18 +20,22 @@ import atexit
 import re
 from StringIO import StringIO
 
+from typing import Callable
+
 devnull = open(os.devnull, 'rw')
 
 
 def check_wait(test, initial=10, factor=1, max_tries=60, exception=True):
+    # type: (Callable[[], bool], int, int, int, bool) -> bool
     """Call function ‘test’ periodically until it returns True or a timeout occurs."""
     wait = initial
     tries = 0
     while tries < max_tries and not test():
-        wait = wait * factor
-        tries = tries + 1
+        wait *= factor
+        tries += 1
         if tries == max_tries:
-            if exception: raise Exception("operation timed out")
+            if exception:
+                raise Exception("operation timed out")
             return False
         time.sleep(wait)
     return True
@@ -389,9 +395,10 @@ def parse_nixos_version(s):
 # xvd -> sd
 # nvme -> sd
 def device_name_to_boto_expected(string):
+    # type: (str) -> str
     """Transfoms device name to name, that boto expects."""
     m = re.search('(.*)\/nvme(\d+)n1p?(\d+)?', string)
-    if m != None:
+    if m is not None:
         device = m.group(2)
         device_ = int(device) - 1
         device_transformed = chr(ord('f') + device_)
@@ -412,4 +419,5 @@ def device_name_user_entered_to_stored(string):
 # xvd -> xvd
 # nvme -> nvme
 def device_name_stored_to_real(string):
+    # type: (str) -> str
     return string.replace("/dev/sd", "/dev/xvd")

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -2,24 +2,24 @@
 
 from __future__ import absolute_import
 
-import os
-import sys
-import time
-import json
+import atexit
+import base64
 import copy
 import fcntl
-import base64
+import json
+import logging
+import os
+import re
 import select
+import shutil
 import socket
 import struct
-import shutil
-import tempfile
 import subprocess
-import logging
-import atexit
-import re
-from StringIO import StringIO
+import sys
+import tempfile
+import time
 
+from six import StringIO
 from typing import Callable
 
 devnull = open(os.devnull, 'rw')

--- a/release.nix
+++ b/release.nix
@@ -96,6 +96,7 @@ rec {
           datadog
           digital-ocean
           typing
+          six
         ] ++
         #FIXME add back once https://github.com/NixOS/nixops/pull/1131
         # is reverted.


### PR DESCRIPTION
The way how my AWS accounts are setup (assumeRole + MFA) makes it impossible to use old version of nixops. I initially tried to add an option to specify a profile, but turns out that old boto doesn't seem to support this kind of setup (since it was introduced later on) and it mandated porting to boto3.

So this version works fine with assumeRole + MFA and I also added an option to use the same cache that `aws` command uses. That way you don't have to enter MFA every for every single command.

Currently all of the commands that I used appear to be working, these are:
- list
- create
- modify
- delete
- info
- check
- deploy
- send-keys
- destroy
- stop
- start
- reboot
- show-arguments
- show-physical
- ssh
- ssh-for-each
- scp
- mount
- rename
- backup
- backup-status
- clean-backups
- restore (you need to provide backup id, but it looks like that was unrelated to my change?).
- show-option
- list-generations
- show-console-output
- dump-nix-paths
- export
- edit

If you can, please test it (clone my branch and run `nix-env -f release.nix -iA build.<your platform>`) if there are still broken commands let me know otherwise perhaps this can be merged.