### PR TITLE
log more commands

### DIFF
--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -711,7 +711,7 @@ def op_copy_closure(args):
         raise Exception("unknown machine ‘{0}’".format(machine))
     env = dict(os.environ)
     env['NIX_SSHOPTS'] = ' '.join(m.get_ssh_flags())
-    res = subprocess.call(
+    res = nixops.util.logged_exec(
         ["nix", "copy", "--to",
             "ssh://{}".format(m.get_ssh_name()), args.storepath],
         env=env)

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -48,9 +48,10 @@ class SSHMaster(object):
                '-oNumberOfPasswordPrompts={0}'.format(pass_prompts),
                '-oServerAliveInterval=60',
                '-oControlPersist=600'] \
-              + (["-C"] if compress else [])
+              + (["-C"] if compress else []) \
+              + ssh_flags
 
-        res = subprocess.call(cmd + ssh_flags, **kwargs)
+        res = nixops.util.logged_exec(cmd, logger, **kwargs)
         if res != 0:
             raise SSHConnectionFailed(
                 "unable to start SSH master connection to "


### PR DESCRIPTION
while developing on nixops, I regularly have issues and logging the run command helps a lot in debugging.
I wonder if nixops should have different levels but it would be cool to better log commands. 
(I can remove the NIX_SSHOPTS)