### PR TITLE
Adding Nixops clear-state Command:

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -1161,6 +1161,13 @@ class Deployment(object):
                  "--arg", "machines", py2nix(attrs, inline=True)]) != 0:
                 raise Exception("cannot update profile ‘{0}’".format(profile))
 
+    def clear_state(self, include=[], exclude=[]):
+        """clear all resources state."""
+        def worker(m):
+            if not should_do(m, include, exclude): return
+            if m.clear_state(): self.delete_resource(m)
+
+        nixops.parallel.run_tasks(nr_workers=-1, tasks=self.resources.values(), worker_fun=worker)
 
     def reboot_machines(self, include=[], exclude=[], wait=False,
                         rescue=False, hard=False):

--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -189,6 +189,17 @@ class ResourceState(object):
         )
         return False
 
+    def clear_state(self):
+        """clear this resource state, if possible."""
+        if not self.depl.logger.confirm("are you sure you want to clear resources state `{0}`".format(self.name)):
+            self.depl.logger.get_logger_for(self.name).warn("Not clearing state...")
+            return False
+
+        self.logger.warn(
+            "resource ‘{0}’ will be removed from NixOps state file but not actually".format(self.name)
+        )
+        return True
+
     def next_charge_time(self):
         """Return the time (in Unix epoch) when this resource will next incur
         a financial charge (or None if unknown)."""

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -431,6 +431,11 @@ def op_destroy():
                                exclude=args.exclude or [],
                                wipe=args.wipe)
 
+def op_clear_state():
+    depl = open_deployment()
+    if args.confirm:
+        depl.logger.set_autoresponse("y")
+    depl.clear_state(include=args.include or [], exclude=args.exclude or [])
 
 def op_reboot():
     depl = open_deployment()
@@ -845,6 +850,12 @@ subparser.add_argument('--include', nargs='+', metavar='MACHINE-NAME', help='des
 subparser.add_argument('--exclude', nargs='+', metavar='MACHINE-NAME', help='destroy all except the specified machines')
 subparser.add_argument('--wipe', action='store_true', help='securely wipe data on the machines')
 subparser.add_argument('--all', action='store_true', help='destroy all deployments')
+
+subparser = add_subparser('clear-state', help='clear resources from state file')
+subparser.set_defaults(op=op_clear_state)
+subparser.add_argument('--include', nargs='+', metavar='MACHINE-NAME', help='clear only the specified machines')
+subparser.add_argument('--exclude', nargs='+', metavar='MACHINE-NAME', help='clear all resources except the specified machines')
+
 
 subparser = add_subparser('stop', help='stop all virtual machines in the network')
 subparser.set_defaults(op=op_stop)


### PR DESCRIPTION
This command will allow users to painlessly remove resources from nixops database while preserving the actual resource. This can be helpful in various disater recovery scenarios when we need to attach an EBS volume to prod form shadow or vice versa. then can safely reeuse that deployment since the shadow won't clain the volume transfered to prod as it's own and tires to destory it