### PR TITLE
Adding nixops delete-resources command

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -1160,6 +1160,13 @@ class Deployment(object):
                  "--arg", "machines", py2nix(attrs, inline=True)]) != 0:
                 raise Exception("cannot update profile ‘{0}’".format(profile))
 
+    def delete_resources(self, include=[], exclude=[]):
+        """delete all resources state."""
+        def worker(m):
+            if not should_do(m, include, exclude): return
+            if m.delete_resources(): self.delete_resource(m)
+
+        nixops.parallel.run_tasks(nr_workers=-1, tasks=self.resources.values(), worker_fun=worker)
 
     def reboot_machines(self, include=[], exclude=[], wait=False,
                         rescue=False, hard=False):

--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -189,6 +189,20 @@ class ResourceState(object):
         )
         return False
 
+    def delete_resources(self):
+        """delete this resource state, if possible."""
+        if not self.depl.logger.confirm(
+                "are you sure you want to clear the state of {}? "
+                "this will only remove the resource from the local "
+                "NixOPS state and the resource may still exist outside "
+                "of the NixOPS database.".format(self.name)):
+            return False
+
+        self.logger.warn(
+            "removing resource {} from the local NixOPS database ...".format(self.name)
+        )
+        return True
+
     def next_charge_time(self):
         """Return the time (in Unix epoch) when this resource will next incur
         a financial charge (or None if unknown)."""

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -456,6 +456,11 @@ def op_reboot(args):
                          rescue=args.rescue,
                          hard=args.hard)
 
+def op_delete_resources(args):
+    depl = open_deployment(args)
+    if args.confirm:
+        depl.logger.set_autoresponse("y")
+    depl.delete_resources(include=args.include or [], exclude=args.exclude or [])
 
 def op_stop(args):
     depl = open_deployment(args)

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -81,6 +81,11 @@ subparser.add_argument('--exclude', nargs='+', metavar='MACHINE-NAME', help='des
 subparser.add_argument('--wipe', action='store_true', help='securely wipe data on the machines')
 subparser.add_argument('--all', action='store_true', help='destroy all deployments')
 
+subparser = add_subparser(subparsers, 'delete-resources', help='deletes the resource from the local NixOPS state file.')
+subparser.set_defaults(op=op_delete_resources)
+subparser.add_argument('--include', nargs='+', metavar='RESOURCE-NAME', help='delete only the specified resources')
+subparser.add_argument('--exclude', nargs='+', metavar='RESOURCE-NAME', help='delete all resources except the specified resources')
+
 subparser = add_subparser(subparsers, 'stop', help='stop all virtual machines in the network')
 subparser.set_defaults(op=op_stop)
 subparser.add_argument('--include', nargs='+', metavar='MACHINE-NAME', help='stop only the specified machines')


### PR DESCRIPTION
This command will allow users to painlessly remove resources from nixops database while preserving the actual resource. This can be helpful in various disater recovery scenarios when we need to attach an EBS volume to prod form shadow or vice versa. then can safely reeuse that deployment since the shadow won't clain the volume transfered to prod as it's own and tires to destory it