### PR TITLE
Restore commandOutput resources

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -94,6 +94,7 @@ rec {
     (a: b: a // (b { inherit evalResources zipAttrs resourcesByType;}))
     {
       sshKeyPairs = evalResources ./ssh-keypair.nix (zipAttrs resourcesByType.sshKeyPairs or []);
+      commandOutput = evalResources ./command-output.nix (zipAttrs resourcesByType.commandOutput or []);
       machines = mapAttrs (n: v: v.config) nodes;
     }
     pluginResources;


### PR DESCRIPTION
The customCommand resource is no longer usable since acb2ab15ac85189758aa530a76b7ec3cc7ceb295.

I'm not sure if this is intentional or if it was accidentally removed from eval-machine-info.nix during the plugin restructuring. Assuming it was not intentional, this PR re-enables it.

After applying, tests/functional/single_machine_outputs.nix should be deployable.