### PR TITLE
Fix a Python format exception when raising a 'reboot required' Exception

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -748,7 +748,7 @@ class Deployment(object):
                 if res == 100 or force_reboot or m.state == m.RESCUE:
                     if not allow_reboot and not force_reboot:
                         raise Exception("the new configuration requires a "
-                                        "reboot to take effect (hint: use "
+                                        "reboot of '{}' to take effect (hint: use "
                                         "‘--allow-reboot’)".format(m.name))
                     m.reboot_sync()
                     res = 0


### PR DESCRIPTION
I'm unsure whether I'm fixing a symptom here, but this PR fixes an issue I'm having when attempting to `nix-shell` myself into latest NixOps, with patch instructions detailed here https://github.com/NixOS/nixops/issues/1207 applied.

Use case: I'm trying to start an hydra server locally in a VirtualBox VM, following instructions from https://nixos.wiki/wiki/Hydra.

Prior this PR, I was having the following:
```
Executing setuptoolsCheckPhase
/nix/store/3vb5fxvqjahhgm8h8xii464qhvc8hyg4-python2.7-setuptools-41.4.0/lib/python2.7/site-packages/setuptools/dist.py:484: UserWarning: The version specified ('1.8pre0_abcdef') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
  "details." % self.metadata.version
running test
......................................
----------------------------------------------------------------------
Ran 38 tests in 0.011s

OK
nixops/deployment.py:750: error:(B Not all arguments converted during string formatting(B
Found 1 error in 1 file (checked 20 source files)(B
builder for '/nix/store/2hcqzy5kkyx1y3ga7wwrbjwxjx02wh7f-nixops-1.8pre0_abcdef.drv' failed with exit code 1
error: build of '/nix/store/2hcqzy5kkyx1y3ga7wwrbjwxjx02wh7f-nixops-1.8pre0_abcdef.drv' failed
```

I can provide more information if needed.

