### PR TITLE
Fix Hydra build on darwin

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,5 @@
-{ nixopsSrc ? { outPath = ./.; revCount = 0; shortRev = "abcdef"; rev = "HEAD"; }
+{ src ? nixopsSrc
+, nixopsSrc ? { outPath = ./.; revCount = 0; shortRev = "abcdef"; rev = "HEAD"; }
 , officialRelease ? false
 , nixpkgs ? <nixpkgs>
 , p ? (p: [ ])
@@ -6,7 +7,7 @@
 
 let
   pkgs = import nixpkgs { config = {}; overlays = []; };
-  version = "1.8" + (if officialRelease then "" else "pre${toString nixopsSrc.revCount}_${nixopsSrc.shortRev}");
+  version = "1.8" + (if officialRelease then "" else "pre${toString src.revCount}_${src.shortRev}");
 
   allPlugins = let
     plugins = let
@@ -27,9 +28,7 @@ in rec {
   tarball = pkgs.releaseTools.sourceTarball {
     name = "nixops-tarball";
 
-    src = nixopsSrc;
-
-    inherit version;
+    inherit version src;
 
     officialRelease = true; # hack
 
@@ -45,7 +44,7 @@ in rec {
     distPhase =
       ''
         # Generate the manual and the man page.
-        cp ${(import ./doc/manual { revision = nixopsSrc.rev; inherit nixpkgs; }).optionsDocBook} doc/manual/machine-options.xml
+        cp ${(import ./doc/manual { revision = src.rev; inherit nixpkgs; }).optionsDocBook} doc/manual/machine-options.xml
 
         for i in scripts/nixops setup.py doc/manual/manual.xml; do
           substituteInPlace $i --subst-var-by version ${version}


### PR DESCRIPTION
This was caused by a `pkgs` instance using ambient `system`
"leaking" into the darwin build via the `allPlugins` attribute. This
caused darwin builds to fail, but only on Hydra (... or on a Linux
machine with a remote darwin build slave, to be precise).

I fixed it by scoping `allPlugins` to the build via a `let` block, thereby
allowing it to use an instance of `pkgs` with `system` set by Hydra.

I tested it on my Hydra which was failing the same way as hydra.nixos.org does
currently. it can also be tested from a linux box with a darwin remote
builder by running:

``` sh
$ nix-build release.nix -A build.x86_64-darwin
```

Cheers

PS: I renamed the `nixopsSrc` argument in `release.nix` to `src` but kept `nixopsSrc` with `src` defaulting to it. That way it shouldn't break existing code (I think Eelco tried making that change in `nixops-aws` and it ended up being reverted for that reason)