### PR TITLE
Python 2to3, too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ result
 *.sw[a-z]
 tags
 tests/test.nixops*
+.mypy_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: nix
 before_script:
   - sudo echo 'sandbox = true' | sudo tee /etc/nix/nix.conf
 script:
+  - nix-shell -p python3Packages.mypy --run "mypy nixops"
   - nix-shell -p python3Packages.black --run "black . --check --diff"
   - ./dev-shell --run "./coverage-tests.py -a '!libvirtd,!gce,!ec2,!azure' -v"
   - nix-build --quiet release.nix -A build.x86_64-linux -I nixpkgs=channel:nixos-19.03

--- a/coverage-tests.py
+++ b/coverage-tests.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#!/usr/bin/env python3
 import nose
 import sys
 import os

--- a/doc/manual/hacking.xml
+++ b/doc/manual/hacking.xml
@@ -25,7 +25,7 @@ so that those dependencies can be found:
 <screen>
 $ nix-shell release.nix -A build.x86_64-linux --exclude tarball
 $ echo $PYTHONPATH
-/nix/store/yzj6p5f7iyh247pwxrg97y3klm6d0cni-python-2.7.3/lib/python2.7/site-packages:<replaceable>...</replaceable>
+/nix/store/5dbidajmgrvskv7kj6bwrkza8szxkgar-python3-3.7.5/lib/python3.7/site-packages:<replaceable>...</replaceable>
 </screen>
 You can then run NixOps in your source tree as follows:
 <screen>
@@ -36,7 +36,7 @@ $ nixops
 <para>To run the tests, do
 
 <screen>
-$ python2 tests.py
+$ python3 tests.py
 </screen>
 
 Note that some of the tests involve the creation of EC2 resources and
@@ -46,7 +46,7 @@ thus cost money.  You must set the environment variable
 looked up in <filename>~/.ec2-keys</filename> or in
 <filename>~/.aws/credentials</filename>, as described in <xref
 linkend="sec-deploying-to-ec2"/>.)  To run a specific test, run
-<literal>python2 tests.py
+<literal>python3 tests.py
 <replaceable>test-name</replaceable></literal>, e.g.
 
 To filter on which backends you want to run functional tests against, you can

--- a/maintainers/dump-route53-hosted-zone.py
+++ b/maintainers/dump-route53-hosted-zone.py
@@ -24,7 +24,7 @@ for record in records:
     by_hostname[name].append(record)
 
 count = {
-    k: len(filter(lambda x: x["Type"] == "A", v)) for (k, v) in by_hostname.items()
+    k: len([x for x in v if x["Type"] == "A"]) for (k, v) in list(by_hostname.items())
 }
 
 
@@ -40,41 +40,46 @@ def print_record(record):
     if res == "":
         res = record["Type"] + "-record"
 
-    print('    "{0}" = {{ resources, ... }}: {{'.format(res))
+    print(('    "{0}" = {{ resources, ... }}: {{'.format(res)))
     print("      zoneId = resources.route53HostedZones.hs;")
     print("      inherit accessKeyId;")
-    print('      routingPolicy = "{}";'.format("multivalue" if mv else "simple"))
-    print('      domainName = "{}";'.format(record["Name"]))
+    print(('      routingPolicy = "{}";'.format("multivalue" if mv else "simple")))
+    print(('      domainName = "{}";'.format(record["Name"])))
     if "SetIdentifier" in record:
-        print('      setIdentifier = "{}";'.format(record["SetIdentifier"]))
+        print(('      setIdentifier = "{}";'.format(record["SetIdentifier"])))
     if "TTL" in record:
-        print("      ttl = {};".format(record["TTL"]))
+        print(("      ttl = {};".format(record["TTL"])))
 
     if "ResourceRecords" in record:
         print("      recordValues = [")
         for v in record["ResourceRecords"]:
-            print('        "{}"'.format(v["Value"]))
+            print(('        "{}"'.format(v["Value"])))
         print("      ];")
 
     if "AliasTarget" in record:
-        print('      aliasDNSName = "{}";'.format(record["AliasTarget"]["DNSName"]))
+        print(('      aliasDNSName = "{}";'.format(record["AliasTarget"]["DNSName"])))
         print(
-            "      aliasEvaluateTargetHealth = {};".format(
-                record["AliasTarget"]["EvaluateTargetHealth"]
+            (
+                "      aliasEvaluateTargetHealth = {};".format(
+                    record["AliasTarget"]["EvaluateTargetHealth"]
+                )
             )
         )
         print(
-            '      aliasHostedZoneId = "{}";'.format(
-                record["AliasTarget"]["HostedZoneId"]
+            (
+                '      aliasHostedZoneId = "{}";'.format(
+                    record["AliasTarget"]["HostedZoneId"]
+                )
             )
         )
 
-    print('      recordType = "{}";'.format(record["Type"]))
+    print(('      recordType = "{}";'.format(record["Type"])))
     print("    };")
 
 
 print(
-    """
+    (
+        """
 {{ accessKeyId ? "nixos-tests" }}:
 {{
   resources.route53HostedZones.hs =
@@ -83,10 +88,11 @@ print(
       inherit accessKeyId;
     }};
 """.format(
-        domain
+            domain
+        )
     )
 )
 print("  resources.route53RecordSets = {")
-map(print_record, records)
+list(map(print_record, records))
 print("  };")
 print("}")

--- a/maintainers/dump-route53-hosted-zone.py
+++ b/maintainers/dump-route53-hosted-zone.py
@@ -19,13 +19,11 @@ records = client.list_resource_record_sets(HostedZoneId=zone_id)["ResourceRecord
 by_hostname = {}
 for record in records:
     name = record["Name"]
-    if not name in by_hostname:
+    if name not in by_hostname:
         by_hostname[name] = []
     by_hostname[name].append(record)
 
-count = {
-    k: len([x for x in v if x["Type"] == "A"]) for (k, v) in list(by_hostname.items())
-}
+count = {k: sum(1 for x in v if x["Type"] == "A") for (k, v) in by_hostname.items()}
 
 
 def print_record(record):
@@ -93,6 +91,7 @@ print(
     )
 )
 print("  resources.route53RecordSets = {")
-list(map(print_record, records))
+for record in records:
+    print_record(record)
 print("  };")
 print("}")

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -263,7 +263,7 @@ class MachineState(nixops.resources.ResourceState):
             return
         if self.store_keys_on_machine:
             return
-        for k, opts in self.get_keys().items():
+        for k, opts in list(self.get_keys().items()):
             self.log("uploading key ‘{0}’...".format(k))
             tmp = self.depl.tempdir + "/key-" + self.name
             if "destDir" not in opts:

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -371,7 +371,7 @@ class MachineState(nixops.resources.ResourceState):
 
     def write_ssh_private_key(self, private_key):
         key_file = "{0}/id_nixops-{1}".format(self.depl.tempdir, self.name)
-        with os.fdopen(os.open(key_file, os.O_CREAT | os.O_WRONLY, 0600), "w") as f:
+        with os.fdopen(os.open(key_file, os.O_CREAT | os.O_WRONLY, 0o600), "w") as f:
             f.write(private_key)
         self._ssh_private_key_file = key_file
         return key_file

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -263,7 +263,7 @@ class MachineState(nixops.resources.ResourceState):
             return
         if self.store_keys_on_machine:
             return
-        for k, opts in list(self.get_keys().items()):
+        for k, opts in self.get_keys().items():
             self.log("uploading key ‘{0}’...".format(k))
             tmp = self.depl.tempdir + "/key-" + self.name
             if "destDir" not in opts:

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -8,7 +8,6 @@ import string
 import tempfile
 import shutil
 import threading
-import exceptions
 import errno
 from collections import defaultdict
 from xml.etree import ElementTree
@@ -234,7 +233,7 @@ class Deployment(object):
         if self._lock_file_path is None:
             lock_dir = os.environ.get("HOME", "") + "/.nixops/locks"
             if not os.path.exists(lock_dir):
-                os.makedirs(lock_dir, 0700)
+                os.makedirs(lock_dir, 0o700)
             self._lock_file_path = lock_dir + "/" + self.uuid
 
         class DeploymentLock(object):
@@ -364,7 +363,7 @@ class Deployment(object):
                 stderr=self.logger.log_file,
             )
             if debug:
-                print >> sys.stderr, "JSON output of nix-instantiate:\n" + xml
+                print("JSON output of nix-instantiate:\n" + xml, file=sys.stderr)
             return json.loads(out)
         except OSError as e:
             raise Exception("unable to run ‘nix-instantiate’: {0}".format(e))
@@ -391,7 +390,7 @@ class Deployment(object):
                 stderr=self.logger.log_file,
             )
             if debug:
-                print >> sys.stderr, "XML output of nix-instantiate:\n" + xml
+                print("XML output of nix-instantiate:\n" + xml, file=sys.stderr)
         except OSError as e:
             raise Exception("unable to run ‘nix-instantiate’: {0}".format(e))
         except subprocess.CalledProcessError:
@@ -721,7 +720,7 @@ class Deployment(object):
         profile = self.get_profile()
         dir = os.path.dirname(profile)
         if not os.path.exists(dir):
-            os.makedirs(dir, 0755)
+            os.makedirs(dir, 0o755)
         return profile
 
     def build_configs(self, include, exclude, dry_run=False, repair=False):
@@ -745,7 +744,7 @@ class Deployment(object):
         p = self.get_physical_spec()
         nixops.util.write_file(phys_expr, p)
         if debug:
-            print >> sys.stderr, "generated physical spec:\n" + p
+            print("generated physical spec:\n" + p, file=sys.stderr)
 
         selected = [
             m for m in self.active.itervalues() if should_do(m, include, exclude)
@@ -795,7 +794,7 @@ class Deployment(object):
 
             load_dir = "{0}/current-load".format(self.tempdir)
             if not os.path.exists(load_dir):
-                os.makedirs(load_dir, 0700)
+                os.makedirs(load_dir, 0o700)
             os.environ["NIX_CURRENT_LOAD"] = load_dir
 
         try:
@@ -1015,11 +1014,11 @@ class Deployment(object):
             cutoff = (datetime.now() - timedelta(days=keep_days)).strftime(
                 "%Y%m%d%H%M%S"
             )
-            print cutoff
+            print(cutoff)
             tbr = [bid for bid in backup_ids if bid < cutoff]
 
         for backup_id in tbr:
-            print "Removing backup {0}".format(backup_id)
+            print("Removing backup {0}".format(backup_id))
             self.remove_backup(backup_id, keep_physical)
 
     def remove_backup(self, backup_id, keep_physical=False):

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -109,19 +109,17 @@ class Deployment(object):
 
     @property
     def machines(self):
-        return {n: r for n, r in list(self.resources.items()) if is_machine(r)}
+        return {n: r for n, r in self.resources.items() if is_machine(r)}
 
     @property
     def active(self):  # FIXME: rename to "active_machines"
         return {
-            n: r
-            for n, r in list(self.resources.items())
-            if is_machine(r) and not r.obsolete
+            n: r for n, r in self.resources.items() if is_machine(r) and not r.obsolete
         }
 
     @property
     def active_resources(self):
-        return {n: r for n, r in list(self.resources.items()) if not r.obsolete}
+        return {n: r for n, r in self.resources.items() if not r.obsolete}
 
     def get_typed_resource(self, name, type):
         res = self.active_resources.get(name, None)
@@ -637,7 +635,7 @@ class Deployment(object):
             if is_machine(r):
                 # Sort the hosts by its canonical host names.
                 sorted_hosts = sorted(
-                    iter(hosts[r.name].items()), key=lambda item: item[1][0]
+                    hosts[r.name].items(), key=lambda item: item[1][0]
                 )
                 # Just to remember the format:
                 #   ip_address canonical_hostname [aliases...]
@@ -990,9 +988,7 @@ class Deployment(object):
                 machine_backups[m.name] = m.get_backups()
 
         # merging machine backups into network backups
-        backup_ids = [
-            b for bs in list(machine_backups.values()) for b in list(bs.keys())
-        ]
+        backup_ids = [b for bs in machine_backups.values() for b in bs.keys()]
         backups = {}
         for backup_id in backup_ids:
             backups[backup_id] = {}
@@ -1002,7 +998,7 @@ class Deployment(object):
             backup = backups[backup_id]
             for m in self.active.values():
                 if should_do(m, include, exclude):
-                    if backup_id in list(machine_backups[m.name].keys()):
+                    if backup_id in machine_backups[m.name].keys():
                         backup["machines"][m.name] = machine_backups[m.name][backup_id]
                         backup["info"].extend(backup["machines"][m.name]["info"])
                         # status is always running when one of the backups is still running
@@ -1021,8 +1017,7 @@ class Deployment(object):
 
     def clean_backups(self, keep, keep_days, keep_physical=False):
         _backups = self.get_backups()
-        backup_ids = [b for b in list(_backups.keys())]
-        backup_ids.sort()
+        backup_ids = sorted(_backups.keys())
 
         if keep:
             index = len(backup_ids) - keep
@@ -1107,7 +1102,7 @@ class Deployment(object):
         # Determine the set of active resources.  (We can't just
         # delete obsolete resources from ‘self.resources’ because they
         # contain important state that we don't want to forget about.)
-        for m in list(self.resources.values()):
+        for m in self.resources.values():
             if m.name in self.definitions:
                 if m.obsolete:
                     self.logger.log(
@@ -1395,7 +1390,7 @@ class Deployment(object):
             names.add(filename)
 
         # Update the set of active machines.
-        for m in list(self.machines.values()):
+        for m in self.machines.values():
             if m.name in names:
                 if m.obsolete:
                     self.logger.log(
@@ -1404,8 +1399,7 @@ class Deployment(object):
                     m.obsolete = False
             else:
                 self.logger.log("machine ‘{0}’ is obsolete".format(m.name))
-                if not m.obsolete:
-                    m.obsolete = True
+                m.obsolete = True
 
         self.copy_closures(
             self.configs_path,

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -11,7 +11,6 @@ import threading
 import errno
 from collections import defaultdict
 from xml.etree import ElementTree
-import nixops.statefile
 import nixops.backends
 import nixops.logger
 import nixops.parallel

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -29,6 +29,7 @@ import time
 import importlib
 from nixops.plugins import get_plugin_manager
 from functools import reduce
+import typing
 
 
 class NixEvalError(Exception):

--- a/nixops/diff.py
+++ b/nixops/diff.py
@@ -57,7 +57,7 @@ class Diff(object):
 
     def get_keys(self):
         # type: () -> List[str]
-        diff = [k for k in list(self._diff.keys()) if k not in self._reserved]
+        diff = [k for k in self._diff.keys() if k not in self._reserved]
         return diff
 
     def plan(self, show=False):

--- a/nixops/diff.py
+++ b/nixops/diff.py
@@ -57,7 +57,7 @@ class Diff(object):
 
     def get_keys(self):
         # type: () -> List[str]
-        diff = [k for k in self._diff.keys() if k not in self._reserved]
+        diff = [k for k in list(self._diff.keys()) if k not in self._reserved]
         return diff
 
     def plan(self, show=False):
@@ -67,7 +67,7 @@ class Diff(object):
         the diff between definition and state then return a sorted list
         of the handlers to be called to realize the diff.
         """
-        keys = self._state.keys() + self._definition.keys()
+        keys = list(self._state.keys()) + list(self._definition.keys())
         for k in keys:
             self.eval_resource_attr_diff(k)
         for k in self.get_keys():

--- a/nixops/logger.py
+++ b/nixops/logger.py
@@ -29,6 +29,7 @@ class Logger(object):
                 self._log_file.write("\n")
                 self._last_log_prefix = None
             self._log_file.write(msg + "\n")
+            self._log_file.flush()
 
     def log_start(self, prefix, msg):
         with self._log_lock:
@@ -38,6 +39,7 @@ class Logger(object):
                 self._log_file.write(prefix)
             self._log_file.write(msg)
             self._last_log_prefix = prefix
+            self._log_file.flush()
 
     def log_end(self, prefix, msg):
         with self._log_lock:
@@ -50,6 +52,7 @@ class Logger(object):
                     return
                 self._log_file.write(prefix)
             self._log_file.write(msg + "\n")
+            self._log_file.flush()
 
     def get_logger_for(self, machine_name):
         """
@@ -89,8 +92,10 @@ class Logger(object):
                     "warning: {0} (y/N) ".format(question), outfile=self._log_file
                 )
             )
+            self._log_file.flush()
             if self._auto_response is not None:
                 self._log_file.write("{0}\n".format(self._auto_response))
+                self._log_file.flush()
                 return self._auto_response == "y"
             response = sys.stdin.readline()
             if response == "":
@@ -131,8 +136,7 @@ class MachineLogger(object):
 
     def log(self, msg):
         self.main_logger.log(
-            self._log_prefix
-            + (msg if isinstance(msg, str) else msg.decode('utf-8'))
+            self._log_prefix + (msg if isinstance(msg, str) else msg.decode("utf-8"))
         )
 
     def log_start(self, msg):

--- a/nixops/logger.py
+++ b/nixops/logger.py
@@ -130,7 +130,10 @@ class MachineLogger(object):
             )
 
     def log(self, msg):
-        self.main_logger.log(self._log_prefix + msg)
+        self.main_logger.log(
+            self._log_prefix
+            + (msg if isinstance(msg, str) else msg.decode('utf-8'))
+        )
 
     def log_start(self, msg):
         self.main_logger.log_start(self._log_prefix, msg)

--- a/nixops/logger.py
+++ b/nixops/logger.py
@@ -24,6 +24,7 @@ class Logger(object):
         return self._log_file.isatty()
 
     def log(self, msg):
+        msg = msg if isinstance(msg, str) else msg.decode("utf-8")
         with self._log_lock:
             if self._last_log_prefix is not None:
                 self._log_file.write("\n")
@@ -32,6 +33,7 @@ class Logger(object):
             self._log_file.flush()
 
     def log_start(self, prefix, msg):
+        msg = msg if isinstance(msg, str) else msg.decode("utf-8")
         with self._log_lock:
             if self._last_log_prefix != prefix:
                 if self._last_log_prefix is not None:
@@ -42,6 +44,7 @@ class Logger(object):
             self._log_file.flush()
 
     def log_end(self, prefix, msg):
+        msg = msg if isinstance(msg, str) else msg.decode("utf-8")
         with self._log_lock:
             last = self._last_log_prefix
             self._last_log_prefix = None
@@ -76,9 +79,11 @@ class Logger(object):
             ml.update_log_prefix(max_len)
 
     def warn(self, msg):
+        msg = msg if isinstance(msg, str) else msg.decode("utf-8")
         self.log(ansi_warn("warning: " + msg, outfile=self._log_file))
 
     def error(self, msg):
+        msg = msg if isinstance(msg, str) else msg.decode("utf-8")
         self.log(ansi_error("error: " + msg, outfile=self._log_file))
 
     def confirm_once(self, question):

--- a/nixops/nix_expr.py
+++ b/nixops/nix_expr.py
@@ -195,7 +195,7 @@ def py2nix(value, initial_indentation=0, maxwidth=80, inline=False):
         while len(nodes) == 1 and isinstance(nodes[0], list):
             nodes = nodes[0]
             pre, post = pre + " [", post + " ]"
-        return Container(pre, list([_enc(n, inlist=True) for n in nodes]), post)
+        return Container(pre, [_enc(n, inlist=True) for n in nodes], post)
 
     def _enc_key(key):
         if not isinstance(key, str):
@@ -222,7 +222,7 @@ def py2nix(value, initial_indentation=0, maxwidth=80, inline=False):
             # attribute, recursively merge them with a dot, like "a.b.c".
             child_key, child_value = key, value
             while isinstance(child_value, dict) and len(child_value) == 1:
-                child_key, child_value = list(child_value.items())[0]
+                child_key, child_value = next(iter(child_value.items()))
                 encoded_key += "." + _enc_key(child_key)
 
             contents = _enc(child_value)
@@ -291,7 +291,7 @@ def expand_dict(unexpanded):
     {'a': {'b': 'c', 'd': {'e': 'f'}}}
     """
     paths, strings = [], {}
-    for key, val in list(unexpanded.items()):
+    for key, val in unexpanded.items():
         if isinstance(key, tuple):
             if len(key) == 0:
                 raise KeyError("invalid key {0}".format(repr(key)))
@@ -307,7 +307,7 @@ def expand_dict(unexpanded):
 
     return {
         key: (expand_dict(val) if isinstance(val, dict) else val)
-        for key, val in list(functools.reduce(nixmerge, paths + [strings]).items())
+        for key, val in functools.reduce(nixmerge, paths + [strings]).items()
     }
 
 
@@ -319,7 +319,7 @@ def nixmerge(expr1, expr2):
 
     def _merge_dicts(d1, d2):
         out = {}
-        for key in set(d1.keys()).union(list(d2.keys())):
+        for key in set(d1.keys()).union(d2.keys()):
             if key in d1 and key in d2:
                 out[key] = _merge(d1[key], d2[key])
             elif key in d1:

--- a/nixops/nix_expr.py
+++ b/nixops/nix_expr.py
@@ -173,7 +173,7 @@ def py2nix(value, initial_indentation=0, maxwidth=80, inline=False):
             ],
         )
 
-        inline_variant = RawValue(u'"{0}"'.format(encoded))
+        inline_variant = RawValue('"{0}"'.format(encoded))
 
         if for_attribute:
             return inline_variant.value
@@ -195,7 +195,7 @@ def py2nix(value, initial_indentation=0, maxwidth=80, inline=False):
         while len(nodes) == 1 and isinstance(nodes[0], list):
             nodes = nodes[0]
             pre, post = pre + " [", post + " ]"
-        return Container(pre, list(map(lambda n: _enc(n, inlist=True), nodes)), post)
+        return Container(pre, list([_enc(n, inlist=True) for n in nodes]), post)
 
     def _enc_key(key):
         if not isinstance(key, str):
@@ -291,7 +291,7 @@ def expand_dict(unexpanded):
     {'a': {'b': 'c', 'd': {'e': 'f'}}}
     """
     paths, strings = [], {}
-    for key, val in unexpanded.items():
+    for key, val in list(unexpanded.items()):
         if isinstance(key, tuple):
             if len(key) == 0:
                 raise KeyError("invalid key {0}".format(repr(key)))
@@ -307,7 +307,7 @@ def expand_dict(unexpanded):
 
     return {
         key: (expand_dict(val) if isinstance(val, dict) else val)
-        for key, val in functools.reduce(nixmerge, paths + [strings]).items()
+        for key, val in list(functools.reduce(nixmerge, paths + [strings]).items())
     }
 
 
@@ -319,7 +319,7 @@ def nixmerge(expr1, expr2):
 
     def _merge_dicts(d1, d2):
         out = {}
-        for key in set(d1.keys()).union(d2.keys()):
+        for key in set(d1.keys()).union(list(d2.keys())):
             if key in d1 and key in d2:
                 out[key] = _merge(d1[key], d2[key])
             elif key in d1:

--- a/nixops/parallel.py
+++ b/nixops/parallel.py
@@ -22,8 +22,8 @@ class MultipleExceptions(Exception):
 
 
 def run_tasks(nr_workers, tasks, worker_fun):
-    task_queue = Queue.Queue()
-    result_queue = Queue.Queue()
+    task_queue = queue.Queue()
+    result_queue = queue.Queue()
 
     nr_tasks = 0
     for t in tasks:
@@ -43,7 +43,7 @@ def run_tasks(nr_workers, tasks, worker_fun):
         while True:
             try:
                 t = task_queue.get(False)
-            except Queue.Empty:
+            except queue.Empty:
                 break
             n = n + 1
             try:
@@ -66,7 +66,7 @@ def run_tasks(nr_workers, tasks, worker_fun):
             # Use a timeout to allow keyboard interrupts to be
             # processed.  The actual timeout value doesn't matter.
             (res, excinfo, name) = result_queue.get(True, 1000)
-        except Queue.Empty:
+        except queue.Empty:
             continue
         if excinfo:
             exceptions[name] = excinfo

--- a/nixops/parallel.py
+++ b/nixops/parallel.py
@@ -1,6 +1,6 @@
 import threading
 import sys
-import Queue
+import queue
 import random
 import traceback
 
@@ -77,7 +77,7 @@ def run_tasks(nr_workers, tasks, worker_fun):
 
     if len(exceptions.keys()) == 1:
         excinfo = exceptions[exceptions.keys()[0]]
-        raise excinfo[0], excinfo[1], excinfo[2]
+        raise excinfo[0](excinfo[1]).with_traceback(excinfo[2])
 
     if len(exceptions.keys()) > 1:
         raise MultipleExceptions(exceptions)

--- a/nixops/parallel.py
+++ b/nixops/parallel.py
@@ -10,13 +10,13 @@ class MultipleExceptions(Exception):
         self.exceptions = exceptions
 
     def __str__(self):
-        err = "Multiple exceptions (" + str(len(list(self.exceptions.keys()))) + "): \n"
+        err = "Multiple exceptions (" + str(len(self.exceptions)) + "): \n"
         for r in sorted(self.exceptions.keys()):
             err += "  * {}: {}\n".format(r, self.exceptions[r][1])
         return err
 
     def print_all_backtraces(self):
-        for k, e in list(self.exceptions.items()):
+        for k, e in self.exceptions.items():
             sys.stderr.write("-" * 30 + "\n")
             traceback.print_exception(e[0], e[1], e[2])
 
@@ -75,11 +75,11 @@ def run_tasks(nr_workers, tasks, worker_fun):
     for thr in threads:
         thr.join()
 
-    if len(list(exceptions.keys())) == 1:
-        excinfo = exceptions[list(exceptions.keys())[0]]
+    if len(exceptions) == 1:
+        excinfo = exceptions[next(iter(exceptions.keys()))]
         raise excinfo[0](excinfo[1]).with_traceback(excinfo[2])
 
-    if len(list(exceptions.keys())) > 1:
+    if len(exceptions) > 1:
         raise MultipleExceptions(exceptions)
 
     return results

--- a/nixops/parallel.py
+++ b/nixops/parallel.py
@@ -10,13 +10,13 @@ class MultipleExceptions(Exception):
         self.exceptions = exceptions
 
     def __str__(self):
-        err = "Multiple exceptions (" + str(len(self.exceptions.keys())) + "): \n"
+        err = "Multiple exceptions (" + str(len(list(self.exceptions.keys()))) + "): \n"
         for r in sorted(self.exceptions.keys()):
             err += "  * {}: {}\n".format(r, self.exceptions[r][1])
         return err
 
     def print_all_backtraces(self):
-        for k, e in self.exceptions.iteritems():
+        for k, e in list(self.exceptions.items()):
             sys.stderr.write("-" * 30 + "\n")
             traceback.print_exception(e[0], e[1], e[2])
 
@@ -75,11 +75,11 @@ def run_tasks(nr_workers, tasks, worker_fun):
     for thr in threads:
         thr.join()
 
-    if len(exceptions.keys()) == 1:
-        excinfo = exceptions[exceptions.keys()[0]]
+    if len(list(exceptions.keys())) == 1:
+        excinfo = exceptions[list(exceptions.keys())[0]]
         raise excinfo[0](excinfo[1]).with_traceback(excinfo[2])
 
-    if len(exceptions.keys()) > 1:
+    if len(list(exceptions.keys())) > 1:
         raise MultipleExceptions(exceptions)
 
     return results

--- a/nixops/plugins/__init__.py
+++ b/nixops/plugins/__init__.py
@@ -1,5 +1,5 @@
 import pluggy
-import hookspecs
+from . import hookspecs
 
 hookimpl = pluggy.HookimplMarker("nixops")
 """Marker to be imported and used in plugins (and for own implementations)"""

--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -69,7 +69,7 @@ class ResourceState(object):
         """Update machine attributes in the state file."""
         with self.depl._db:
             c = self.depl._db.cursor()
-            for n, v in attrs.iteritems():
+            for n, v in list(attrs.items()):
                 if v == None:
                     c.execute(
                         "delete from ResourceAttrs where machine = ? and name = ?",
@@ -121,7 +121,7 @@ class ResourceState(object):
     def import_(self, attrs):
         """Import the resource from another database"""
         with self.depl._db:
-            for k, v in attrs.iteritems():
+            for k, v in list(attrs.items()):
                 if k == "type":
                     continue
                 self._set_attr(k, v)

--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -69,7 +69,7 @@ class ResourceState(object):
         """Update machine attributes in the state file."""
         with self.depl._db:
             c = self.depl._db.cursor()
-            for n, v in list(attrs.items()):
+            for n, v in attrs.items():
                 if v == None:
                     c.execute(
                         "delete from ResourceAttrs where machine = ? and name = ?",
@@ -121,7 +121,7 @@ class ResourceState(object):
     def import_(self, attrs):
         """Import the resource from another database"""
         with self.depl._db:
-            for k, v in list(attrs.items()):
+            for k, v in attrs.items():
                 if k == "type":
                     continue
                 self._set_attr(k, v)

--- a/nixops/resources/commandOutput.py
+++ b/nixops/resources/commandOutput.py
@@ -82,7 +82,7 @@ class CommandOutputState(nixops.resources.ResourceState):
                 env.update({"out": output_dir})
                 res = subprocess.check_output(
                     [defn.config["script"]], env=env, shell=True
-                )
+                ).decode()
                 with self.depl._db:
                     self.value = res
                     self.state = self.UP

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -47,7 +47,7 @@ def op_list_plugins(args):
             tbl.add_row([plugin[0], plugin[1].__str__()])
         else:
             tbl.add_row([plugin[0]])
-    print tbl
+    print(tbl)
 
 
 def create_table(headers):
@@ -93,7 +93,7 @@ def op_list_deployments(args):
                 ", ".join(set([m.get_type() for m in depl.machines.itervalues()])),
             ]
         )
-    print tbl
+    print(tbl)
 
 
 def open_deployment(args):
@@ -239,16 +239,22 @@ def op_info(args):
                 resource_state = r.show_state() if r else "Missing"
 
             if args.plain:
-                print "\t".join(
-                    ([depl.uuid, depl.name or "(none)"] if args.all else [])
-                    + [
-                        name,
-                        resource_state.lower(),
-                        r.show_type() if r else d.show_type(),
-                        r.resource_id or "" if r else "",
-                        r.public_ipv4 or "" if r and hasattr(r, "public_ipv4") else "",
-                        r.private_ipv4 or "" if r and deployment.is_machine(r) else "",
-                    ]
+                print(
+                    "\t".join(
+                        ([depl.uuid, depl.name or "(none)"] if args.all else [])
+                        + [
+                            name,
+                            resource_state.lower(),
+                            r.show_type() if r else d.show_type(),
+                            r.resource_id or "" if r else "",
+                            r.public_ipv4 or ""
+                            if r and hasattr(r, "public_ipv4")
+                            else "",
+                            r.private_ipv4 or ""
+                            if r and deployment.is_machine(r)
+                            else "",
+                        ]
+                    )
                 )
             else:
                 tbl.add_row(
@@ -272,33 +278,34 @@ def op_info(args):
             tbl = create_table([("Deployment", "l")] + table_headers)
         for depl in sort_deployments(sf.get_all_deployments()):
             do_eval(depl)
-            print_deployment(depl)
+            print(deployment(depl))
         if not args.plain:
-            print tbl
+            print(tbl)
 
     else:
         depl = open_deployment(args)
         do_eval(depl)
 
         if args.plain:
-            print_deployment(depl)
+            print(deployment(depl))
         else:
-            print "Network name:", depl.name or "(none)"
-            print "Network UUID:", depl.uuid
-            print "Network description:", depl.description
-            print "Nix expressions:", " ".join(depl.nix_exprs)
+            print("Network name:", depl.name or "(none)")
+            print("Network UUID:", depl.uuid)
+            print("Network description:", depl.description)
+            print("Nix expressions:", " ".join(depl.nix_exprs))
             if depl.nix_path != []:
-                print "Nix path:", " ".join(map(lambda x: "-I " + x, depl.nix_path))
+                print("Nix path:", " ".join(map(lambda x: "-I " + x, depl.nix_path)))
             if depl.rollback_enabled:
-                print "Nix profile:", depl.get_profile()
+                print("Nix profile:", depl.get_profile())
             if depl.args != {}:
-                print "Nix arguments:", ", ".join(
-                    [n + " = " + v for n, v in depl.args.iteritems()]
+                print(
+                    "Nix arguments:",
+                    ", ".join([n + " = " + v for n, v in depl.args.iteritems()]),
                 )
-            print
+            print()
             tbl = create_table(table_headers)
-            print_deployment(depl)
-            print tbl
+            print(deployment(depl))
+            print(tbl)
 
 
 def op_check(args):
@@ -417,8 +424,8 @@ def op_check(args):
     ):
         tbl.add_row(res[2])
         status |= res[3]
-    print nixops.util.ansi_success("Machines state:")
-    print tbl
+    print(nixops.util.ansi_success("Machines state:"))
+    print(tbl)
 
     for res in sorted(
         resources_results,
@@ -426,8 +433,8 @@ def op_check(args):
     ):
         resources_tbl.add_row(res[2])
         status |= res[3]
-    print nixops.util.ansi_success("Non machines resources state:")
-    print resources_tbl
+    print(nixops.util.ansi_success("Non machines resources state:"))
+    print(resources_tbl)
 
     sys.exit(status)
 
@@ -436,7 +443,7 @@ def print_backups(depl, backups):
     tbl = prettytable.PrettyTable(["Backup ID", "Status", "Info"])
     for k, v in sorted(backups.items(), reverse=True):
         tbl.add_row([k, v["status"], "\n".join(v["info"])])
-    print tbl
+    print(tbl)
 
 
 def op_clean_backups(args):
@@ -464,7 +471,7 @@ def op_backup(args):
             exclude=args.exclude or [],
             devices=args.devices or [],
         )
-        print backup_id
+        print(backup_id)
 
     if args.force:
         do_backup()
@@ -507,7 +514,7 @@ def op_backup_status(args):
         backups_status = [b["status"] for _, b in _backups.items()]
         if "running" in backups_status:
             if args.wait:
-                print "waiting for 30 seconds..."
+                print("waiting for 30 seconds...")
                 time.sleep(30)
             else:
                 raise Exception("backup has not yet finished")
@@ -627,7 +634,7 @@ def op_show_arguments(args):
     for arg in sorted(args.keys()):
         files = sorted(args[arg])
         tbl.add_row([arg, "\n".join(files)])
-    print tbl
+    print(tbl)
 
 
 def op_show_physical(args):
@@ -672,14 +679,14 @@ def op_dump_nix_paths(args):
         paths.extend(nix_paths(depl))
 
     for p in paths:
-        print p
+        print(p)
 
 
 def op_export(args):
     res = {}
     for depl in one_or_all(args):
         res[depl.uuid] = depl.export()
-    print json.dumps(res, indent=2, sort_keys=True)
+    print(json.dumps(res, indent=2, sort_keys=True))
 
 
 def op_import(args):
@@ -761,7 +768,7 @@ def op_scp(args):
     ssh_name = m.get_ssh_name()
     from_loc = scp_loc(username, ssh_name, args.scp_from, args.source)
     to_loc = scp_loc(username, ssh_name, args.scp_to, args.destination)
-    print >> sys.stderr, "{0} -> {1}".format(from_loc, to_loc)
+    print("{0} -> {1}".format(from_loc, to_loc), file=sys.stderr)
     flags = ["scp", "-r"] + m.get_ssh_flags() + [from_loc, to_loc]
     # Map ssh's ‘-p’ to scp's ‘-P’.
     flags = ["-P" if f == "-p" else f for f in flags]

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -931,7 +931,11 @@ def setup_logging(args):
     ]:
         # determine user
         try:
-            user = subprocess.check_output(["logname"], stderr=subprocess.PIPE).strip()
+            user = (
+                subprocess.check_output(["logname"], stderr=subprocess.PIPE)
+                .strip()
+                .decode()
+            )
         except:
             user = pwd.getpwuid(os.getuid())[0]
 

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -90,7 +90,7 @@ def op_list_deployments(args):
                 depl.name or "(none)",
                 depl.description,
                 len(depl.machines),
-                ", ".join(set([m.get_type() for m in depl.machines.values()])),
+                ", ".join(set(m.get_type() for m in depl.machines.values())),
             ]
         )
     print(tbl)
@@ -441,7 +441,7 @@ def op_check(args):
 
 def print_backups(depl, backups):
     tbl = prettytable.PrettyTable(["Backup ID", "Status", "Info"])
-    for k, v in sorted(list(backups.items()), reverse=True):
+    for k, v in sorted(backups.items(), reverse=True):
         tbl.add_row([k, v["status"], "\n".join(v["info"])])
     print(tbl)
 
@@ -479,7 +479,7 @@ def op_backup(args):
         backups = depl.get_backups(
             include=args.include or [], exclude=args.exclude or []
         )
-        backups_status = [b["status"] for _, b in list(backups.items())]
+        backups_status = [b["status"] for _, b in backups.items()]
         if "running" in backups_status:
             raise Exception(
                 "There are still backups running, use --force to run a new backup concurrently (not advised!)"
@@ -497,7 +497,7 @@ def op_backup_status(args):
         )
 
         if backupid or args.latest:
-            sorted_backups = sorted(list(backups.keys()), reverse=True)
+            sorted_backups = sorted(backups.keys(), reverse=True)
             if args.latest:
                 if len(backups) == 0:
                     raise Exception("no backups found")
@@ -511,7 +511,7 @@ def op_backup_status(args):
 
         print_backups(depl, _backups)
 
-        backups_status = [b["status"] for _, b in list(_backups.items())]
+        backups_status = [b["status"] for _, b in _backups.items()]
         if "running" in backups_status:
             if args.wait:
                 print("waiting for 30 seconds...")

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -749,7 +749,7 @@ def op_ssh_for_each(args):
             tasks=iter(depl.active.values()),
             worker_fun=worker,
         )
-
+    results = [result for result in results if result is not None]
     sys.exit(max(results) if results != [] else 0)
 
 

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -218,11 +218,13 @@ def op_info(args):
         def name_to_key(name):
             d = definitions.get(name)
             r = depl.resources.get(name)
-            return (
-                machine_to_key(depl.uuid, name, r.get_type())
-                if r
-                else machine_to_key(depl.uuid, name, d.get_type)
-            )
+            if r:
+                key = machine_to_key(depl.uuid, name, d.get_type())
+            elif r is None:
+                key = machine_to_key(depl.uuid, name, "")
+            else:
+                key = machine_to_key(depl.uuid, name, r.get_type)
+            return key
 
         names = sorted(
             set(definitions.keys()) | set(depl.resources.keys()), key=name_to_key

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -63,7 +63,7 @@ class SSHMaster(object):
             + ssh_flags
         )
 
-        res = nixops.util.logged_exec(cmd, logger, check=False, **kwargs)
+        res = nixops.util.logged_exec(cmd, logger, **kwargs)
         if res != 0:
             raise SSHConnectionFailed(
                 "unable to start SSH master connection to " "‘{0}’".format(target)
@@ -103,7 +103,7 @@ class SSHMaster(object):
         the environment variable NIXOPS_SSH_PASSWORD.
         """
         path = os.path.join(self._tempdir, "nixops-askpass-helper")
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0700)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o700)
         os.write(
             fd,
             """#!{0}

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -268,7 +268,7 @@ class SSH(object):
         Helper method for run_command, which essentially prepares and properly
         escape the command. See run_command() for further description.
         """
-        if isinstance(command, basestring):
+        if isinstance(command, str):
             if allow_ssh_args:
                 return shlex.split(command)
             else:

--- a/nixops/state.py
+++ b/nixops/state.py
@@ -68,7 +68,7 @@ class StateDict(collections.MutableMapping):
             return _keys
 
     def __iter__(self):
-        return iter(self.keys())
+        return iter(list(self.keys()))
 
     def __len__(self):
-        return len(self.keys())
+        return len(list(self.keys()))

--- a/nixops/state.py
+++ b/nixops/state.py
@@ -68,7 +68,7 @@ class StateDict(collections.MutableMapping):
             return _keys
 
     def __iter__(self):
-        return iter(list(self.keys()))
+        return iter(self.keys())
 
     def __len__(self):
-        return len(list(self.keys()))
+        return len(self.keys())

--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -3,7 +3,7 @@
 import nixops.deployment
 import os
 import os.path
-from pysqlite2 import dbapi2 as sqlite3
+import sqlite3
 import sys
 import threading
 
@@ -57,7 +57,7 @@ def get_default_state_file():
             if os.path.exists(home + "/deployments.charon"):
                 os.rename(home + "/deployments.charon", home + "/deployments.nixops")
         else:
-            os.makedirs(home, 0700)
+            os.makedirs(home, 0o700)
     return os.environ.get(
         "NIXOPS_STATE", os.environ.get("CHARON_STATE", home + "/deployments.nixops")
     )

--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -7,7 +7,7 @@ import sqlite3
 import sys
 import threading
 import typing
-from typing import Optional
+from typing import Optional, List
 
 
 class Connection(sqlite3.Connection):
@@ -133,7 +133,7 @@ class StateFile(object):
         res = c.fetchall()
         return [x[0] for x in res]
 
-    def get_all_deployments(self):
+    def get_all_deployments(self) -> List[nixops.deployment.Deployment]:
         """Return Deployment objects for every deployment in the database."""
         uuids = self.query_deployments()
         res = []
@@ -189,17 +189,17 @@ class StateFile(object):
             )
         )
 
-    def create_deployment(self, uuid=None):
+    def create_deployment(self, uuid=None) -> nixops.deployment.Deployment:
         """Create a new deployment."""
         if not uuid:
-            import uuid
+            import uuid as uuidlib
 
-            uuid = str(uuid.uuid1())
+            uuid = str(uuidlib.uuid1())
         with self._db:
             self._db.execute("insert into Deployments(uuid) values (?)", (uuid,))
         return nixops.deployment.Deployment(self, uuid, sys.stderr)
 
-    def _table_exists(self, c, table):
+    def _table_exists(self, c, table) -> bool:
         c.execute(
             "select 1 from sqlite_master where name = ? and type='table'", (table,)
         )

--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -6,6 +6,8 @@ import os.path
 import sqlite3
 import sys
 import threading
+import typing
+from typing import Optional
 
 
 class Connection(sqlite3.Connection):
@@ -144,7 +146,7 @@ class StateFile(object):
                 )
         return res
 
-    def _find_deployment(self, uuid=None):
+    def _find_deployment(self, uuid=None) -> Optional[nixops.deployment.Deployment]:
         c = self._db.cursor()
         if not uuid:
             c.execute("select uuid from Deployments")
@@ -176,7 +178,7 @@ class StateFile(object):
                 )
         return nixops.deployment.Deployment(self, res[0][0], sys.stderr)
 
-    def open_deployment(self, uuid=None):
+    def open_deployment(self, uuid=None) -> nixops.deployment.Deployment:
         """Open an existing deployment."""
         deployment = self._find_deployment(uuid=uuid)
         if deployment:

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -124,7 +124,7 @@ def logged_exec(
         make_non_blocking(fd)
 
     at_new_line = True
-    stdout = ""
+    stdout = b""
 
     while len(fds) > 0:
         # The timeout/poll is to deal with processes (like
@@ -137,20 +137,20 @@ def logged_exec(
             break
         if capture_stdout and process.stdout in r:
             data = process.stdout.read()
-            if data == "":
+            if data == b"":
                 fds.remove(process.stdout)
             else:
                 stdout += data
         if log_fd in r:
             data = log_fd.read()
-            if data == "":
+            if data == b"":
                 if not at_new_line:
                     logger.log_end("")
                 fds.remove(log_fd)
             else:
                 start = 0
                 while start < len(data):
-                    end = data.find("\n", start)
+                    end = data.find(b"\n", start)
                     if end == -1:
                         logger.log_start(data[start:])
                         at_new_line = False
@@ -172,7 +172,7 @@ def logged_exec(
         err = msg.format(command, logger.machine_name)
         raise CommandFailed(err, res)
 
-    return stdout if capture_stdout else res
+    return stdout.decode() if capture_stdout else res
 
 
 def generate_random_string(length=256):

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -357,6 +357,9 @@ class TeeStderr(StringIO):
     def isatty(self):
         return self.stderr.isatty()
 
+    def flush(self):
+        return self.stderr.flush()
+
 
 class TeeStdout(StringIO):
     stdout = None
@@ -381,6 +384,9 @@ class TeeStdout(StringIO):
 
     def isatty(self):
         return self.stdout.isatty()
+
+    def flush(self):
+        return self.stdout.flush()
 
 
 # Borrowed from http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python.

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -372,7 +372,8 @@ class TeeStdout(StringIO):
 
     def write(self, data):
         self.stdout.write(data)
-        for l in data.split("\n"):
+        bytesified = data if isinstance(data, bytes) else data.encode("utf-8")
+        for l in bytesified.split(b"\n"):
             self.logger.info(l)
 
     def fileno(self):

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -16,9 +16,9 @@ import subprocess
 import logging
 import atexit
 import re
-from StringIO import StringIO
+from io import StringIO
 
-devnull = open(os.devnull, "rw")
+devnull = open(os.devnull, "r+")
 
 
 def check_wait(test, initial=10, factor=1, max_tries=60, exception=True):

--- a/release.nix
+++ b/release.nix
@@ -92,9 +92,6 @@ in rec {
       doCheck = true;
 
       postCheck = ''
-        # We have to unset PYTHONPATH here since it will pick enum34 which collides
-        # with python3 own module. This can be removed when nixops is ported to python3.
-        PYTHONPATH= mypy --cache-dir=/dev/null nixops
         # smoke test
         HOME=$TMPDIR $out/bin/nixops --version
       '';

--- a/release.nix
+++ b/release.nix
@@ -68,20 +68,17 @@ in rec {
     with import nixpkgs { inherit system; };
 
 
-    python2Packages.buildPythonApplication rec {
+    python3Packages.buildPythonApplication rec {
       name = "nixops-${version}";
 
       src = "${tarball}/tarballs/*.tar.bz2";
 
-      buildInputs = [ python2Packages.nose python2Packages.coverage ];
+      buildInputs = [ python3Packages.nose python3Packages.coverage ];
 
       nativeBuildInputs = [ pkgs.mypy ];
 
-      propagatedBuildInputs = with python2Packages;
+      propagatedBuildInputs = with python3Packages;
         [ prettytable
-          # Go back to sqlite once Python 2.7.13 is released
-          pysqlite
-          typing
           pluggy
         ] ++ pkgs.lib.traceValFn (x: "Using plugins: " + builtins.toJSON x) (map (d: d.build.${system}) (p allPlugins));
 

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from nixops import deployment

--- a/scripts/nixops
+++ b/scripts/nixops
@@ -10,7 +10,7 @@ from nixops.script_defs import *
 parser = argparse.ArgumentParser(description='NixOS cloud deployment tool', prog='nixops')
 parser.add_argument('--version', action='version', version='NixOps @version@')
 
-subparsers = parser.add_subparsers(help='sub-command help')
+subparsers = parser.add_subparsers(help='sub-command help', metavar="operation", required=True)
 
 subparser = add_subparser(subparsers, 'list', help='list all known deployments')
 subparser.set_defaults(op=op_list_deployments)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [mypy]
-python_version = 2.7
 no_implicit_optional = True
 strict_optional = True
 

--- a/tests/functional/single_machine_test.py
+++ b/tests/functional/single_machine_test.py
@@ -47,5 +47,5 @@ class SingleMachineTest(generic_deployment_test.GenericDeploymentTest):
 
     def check_command(self, command):
         self.depl.evaluate()
-        machine = self.depl.machines.values()[0]
+        machine = list(self.depl.machines.values())[0]
         return machine.run_command(command)

--- a/tests/functional/single_machine_test.py
+++ b/tests/functional/single_machine_test.py
@@ -47,5 +47,5 @@ class SingleMachineTest(generic_deployment_test.GenericDeploymentTest):
 
     def check_command(self, command):
         self.depl.evaluate()
-        machine = list(self.depl.machines.values())[0]
+        machine = next(iter(self.depl.machines.values()))
         return machine.run_command(command)

--- a/tests/functional/test_rebooting_reboots.py
+++ b/tests/functional/test_rebooting_reboots.py
@@ -10,7 +10,7 @@ class TestRebootingReboots(single_machine_test.SingleMachineTest):
         self.depl.deploy()
         self.check_command("touch /run/not-rebooted")
         self.depl.reboot_machines(wait=True)
-        m = self.depl.active.values()[0]
+        m = list(self.depl.active.values())[0]
         m.check()
         tools.assert_equal(m.state, m.UP)
         with tools.assert_raises(SSHCommandFailed):

--- a/tests/functional/test_starting_starts.py
+++ b/tests/functional/test_starting_starts.py
@@ -8,6 +8,6 @@ class TestStartingStarts(single_machine_test.SingleMachineTest):
         self.depl.deploy()
         self.depl.stop_machines()
         self.depl.start_machines()
-        m = self.depl.active.values()[0]
+        m = list(self.depl.active.values())[0]
         m.check()
         tools.assert_equal(m.state, m.UP)

--- a/tests/functional/test_stopping_stops.py
+++ b/tests/functional/test_stopping_stops.py
@@ -7,5 +7,5 @@ class TestStoppingStops(single_machine_test.SingleMachineTest):
     def run_check(self):
         self.depl.deploy()
         self.depl.stop_machines()
-        m = self.depl.active.values()[0]
+        m = list(self.depl.active.values())[0]
         tools.assert_equal(m.state, m.STOPPED)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -11,7 +11,7 @@ class RootLoggerTest(unittest.TestCase):
         self.root_logger = Logger(self.logfile)
 
     def assert_log(self, value):
-        self.assertEquals(self.logfile.getvalue(), value)
+        self.assertEqual(self.logfile.getvalue(), value)
 
     def test_simple(self):
         self.root_logger.log("line1")

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,6 +1,6 @@
 import unittest
 
-from StringIO import StringIO
+from io import StringIO
 
 from nixops.logger import Logger
 

--- a/tests/unit/test_nix_expr.py
+++ b/tests/unit/test_nix_expr.py
@@ -326,7 +326,7 @@ class NixMergeTest(unittest.TestCase):
     def test_merge_list(self):
         self.assert_merge(
             [[1, 2, 3], [4, 5, 6], [7, 6, 5], ["abc", "def"], ["ghi", "abc"],],
-            [1, 2, 3, 4, 5, 6, 7, "abc", "ghi", "def"],
+            [1, 2, 3, 4, 5, 6, 7, "ghi", "def", "abc"],
         )
 
     def test_merge_dict(self):

--- a/tests/unit/test_nix_expr.py
+++ b/tests/unit/test_nix_expr.py
@@ -1,3 +1,4 @@
+import functools
 import unittest
 
 from textwrap import dedent
@@ -320,7 +321,7 @@ class Nix2PyTest(unittest.TestCase):
 
 class NixMergeTest(unittest.TestCase):
     def assert_merge(self, sources, expect):
-        self.assertEqual(reduce(nixmerge, sources), expect)
+        self.assertEqual(functools.reduce(nixmerge, sources), expect)
 
     def test_merge_list(self):
         self.assert_merge(

--- a/tests/unit/test_nix_expr.py
+++ b/tests/unit/test_nix_expr.py
@@ -303,16 +303,14 @@ class Py2NixTestBase(unittest.TestCase):
 
 class Nix2PyTest(unittest.TestCase):
     def test_simple(self):
-        self.assertEquals(py2nix(nix2py("{\na = b;\n}"), maxwidth=0), "{\na = b;\n}")
-        self.assertEquals(
-            py2nix(nix2py("\n{\na = b;\n}\n"), maxwidth=0), "{\na = b;\n}"
-        )
+        self.assertEqual(py2nix(nix2py("{\na = b;\n}"), maxwidth=0), "{\na = b;\n}")
+        self.assertEqual(py2nix(nix2py("\n{\na = b;\n}\n"), maxwidth=0), "{\na = b;\n}")
 
     def test_nested(self):
-        self.assertEquals(
+        self.assertEqual(
             py2nix([nix2py("a\nb\nc")], maxwidth=0), "[\n  (a\n  b\n  c)\n]"
         )
-        self.assertEquals(
+        self.assertEqual(
             py2nix({"foo": nix2py("a\nb\nc"), "bar": nix2py("d\ne\nf")}, maxwidth=0),
             # ugly, but probably won't happen in practice
             "{\n  bar = d\n  e\n  f;\n  foo = a\n  b\n  c;\n}",


### PR DESCRIPTION
Continues #1214 by @taneb. The result of running 2to3 on the codebase, plus manual fixes when we're dealing with bytes and strings... plus a few minor 2-to-3 incompatibilities like Queue.Queue and output flushing.

I have tested this deploying to machines which are deployed without any plugin, as well as machines deployed with the nixops-packet plugin, using:

* this branch of nixops-packet https://github.com/input-output-hk/nixops-packet/compare/master...grahamc:py3 (only the last 3 commits are relevant)
*  a recent nixpkgs-unstable at b94c1c89f69563a9fc2ceee487b9bc19e5234d6a
* and this Nixpkgs overlay:

```nix
    (final: super: {
      nixopsBootstrap = (import "${../../../github.com/NixOS/nixops}/release.nix" {
        nixpkgs = final.path;
        p = (nixopsPlugins: [
        ]);
      }).build."${system}";

      nixops-packet = (import "${../../../github.com/input-output-hk/nixops-packet}/release.nix" {
        nixopsSrc = {
          outPath = ../../../github.com/NixOS/nixops;
          revCount = 0;
          shortRev = "abcdef";
          rev = "HEAD";
        };
        nixpkgs = final.path;
        nixops = final.nixopsBootstrap;
      });

      nixops = (import "${../../../github.com/NixOS/nixops}/release.nix" {
        nixpkgs = final.path;
        p = (nixopsPlugins: [
          final.nixops-packet
        ]);
      }).build."${system}";
    })
```

I have tested these things:

* Creating a new system
* Destroying an unneeded system
* `nixops ssh-for-each`
* `nixops deploy`
* `nixops deploy --force-reboot --exclude foo bar`
* `nixops deploy -k`
* `nixops deploy --include foo bar`
* `nixops info`
* `nixops list`
* `nixops check`
* `nixops send-keys`
* `nixops show-arguments` (but I had none)
* `nixops show-physical`
* `nixops ssh` (both to and from)
* `nixops dump-nix-paths`
* `nixops export`

I fixed many problems with combining bytes and strings in the logger, and bytes and strings when running remote commands. I fixed the stdout handler which had trouble with `b"" != ""` especially when detecting a remote SSH command was completed writing. I fixed the logger not flushing after each `.` write, and not flushing when asking if destroying things is okay. 

IMO this is ready to go, and the upgrades to other plugins will need to be done after this merges.