### PR TITLE
add env var 'NIXOPS_SSH_OPTS'

### DIFF
--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -145,6 +145,7 @@ class SSH(object):
         self._logger = logger
         self._ssh_master = None
         self._compress = False
+        self._env_flags = shlex.split(os.getenv("NIXOPS_SSH_OPTS", ""))
 
     def register_host_fun(self, host_fun):
         """
@@ -313,6 +314,7 @@ class SSH(object):
 
         'timeout' specifies the SSH connection timeout.
         """
+        flags = flags + self._env_flags
         master = self.get_master(flags, timeout, user)
         flags = flags + self._get_flags()
         if logged:


### PR DESCRIPTION
I'd like to use nixops for unattended local deployments that don't
write to the local `$HOME/.ssh` config.

There are two ways to achieve this:
- Running nixops in a mount namespace and bind-mounting `$HOME/.ssh`, which
  is cumbersome and requires root permissions on most systems.
  Bind-mounting is needed because `openssh` doesn't respect the `HOME`
  env var.
- Adding options to the `ssh` command used by nixops. This is enabled by this PR.