### PR TITLE
Fix leaking secret keys: Allow defining keyFiles as strings

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -41,6 +41,7 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
             opts = {}
             for (key, xmlType) in (
                 ("text", "string"),
+                ("keyFile", "string"),
                 ("keyFile", "path"),
                 ("destDir", "string"),
                 ("user", "string"),


### PR DESCRIPTION
Only allowing type 'path' forces keyFiles to be copied to the nix store
when deploying, which is a serious security flaw.