### PR TITLE
Even more mypy type checking

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import os
 import re

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import os
 import sys
 from typing import Any, Optional, List, Dict, Tuple, Union

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-import nixops.util
+from typing import Any, Optional, List, Dict, Tuple, Union
+import xml.etree.ElementTree as ET
 
 from nixops.backends import MachineDefinition, MachineState
+import nixops.deployment
+import nixops.resources
+import nixops.util
 from nixops.util import attr_property, create_key_pair
 
 
@@ -11,40 +15,42 @@ class NoneDefinition(MachineDefinition):
     """Definition of a trivial machine."""
 
     @classmethod
-    def get_type(cls):
+    def get_type(cls) -> str:
         return "none"
 
-    def __init__(self, xml, config):
+    def __init__(self, xml: ET.Element, config: Dict[str, Any]) -> None:
         MachineDefinition.__init__(self, xml, config)
-        self._target_host = xml.find("attrs/attr[@name='targetHost']/string").get(
-            "value"
+        self._target_host = nixops.util.xml_find_get(
+            xml, "attrs/attr[@name='targetHost']/string"
         )
-
-        public_ipv4 = xml.find("attrs/attr[@name='publicIPv4']/string")
-        self._public_ipv4 = None if public_ipv4 is None else public_ipv4.get("value")
+        self._public_ipv4 = nixops.util.xml_find_get(
+            xml, "attrs/attr[@name='publicIPv4']/string"
+        )
 
 
 class NoneState(MachineState):
     """State of a trivial machine."""
 
     @classmethod
-    def get_type(cls):
+    def get_type(cls) -> str:
         return "none"
 
-    target_host = nixops.util.attr_property("targetHost", None)
-    public_ipv4 = nixops.util.attr_property("publicIpv4", None)
-    _ssh_private_key = attr_property("none.sshPrivateKey", None)
-    _ssh_public_key = attr_property("none.sshPublicKey", None)
-    _ssh_public_key_deployed = attr_property("none.sshPublicKeyDeployed", False, bool)
+    target_host: Optional[str] = attr_property("targetHost", None)
+    public_ipv4: Optional[str] = attr_property("publicIpv4", None)
+    _ssh_private_key: Optional[str] = attr_property("none.sshPrivateKey", None)
+    _ssh_public_key: Optional[str] = attr_property("none.sshPublicKey", None)
+    _ssh_public_key_deployed: bool = attr_property(
+        "none.sshPublicKeyDeployed", False, bool
+    )
 
-    def __init__(self, depl, name, id):
+    def __init__(self, depl: nixops.deployment.Deployment, name: str, id: str) -> None:
         MachineState.__init__(self, depl, name, id)
 
     @property
-    def resource_id(self):
+    def resource_id(self) -> Optional[str]:
         return self.vm_id
 
-    def get_physical_spec(self):
+    def get_physical_spec(self) -> Dict[Union[Tuple[str, ...], str], Any]:
         return (
             {
                 (
@@ -61,57 +67,74 @@ class NoneState(MachineState):
             else {}
         )
 
-    def create(self, defn, check, allow_reboot, allow_recreate):
+    def create(
+        self,
+        defn: nixops.resources.ResourceDefinition,
+        check: bool,
+        allow_reboot: bool,
+        allow_recreate: bool,
+    ) -> None:
         assert isinstance(defn, NoneDefinition)
         self.set_common_state(defn)
         self.target_host = defn._target_host
         self.public_ipv4 = defn._public_ipv4
 
         if not self.vm_id:
-            self.log_start("generating new SSH keypair... ")
+            self.logger.log_start("generating new SSH keypair... ")
             key_name = "NixOps client key for {0}".format(self.name)
             self._ssh_private_key, self._ssh_public_key = create_key_pair(
                 key_name=key_name
             )
-            self.log_end("done")
+            self.logger.log_end("done")
             self.vm_id = "nixops-{0}-{1}".format(self.depl.uuid, self.name)
 
-    def switch_to_configuration(self, method, sync, command=None):
+    def switch_to_configuration(
+        self, method: str, sync: bool, command: Optional[str] = None
+    ) -> int:
         res = super(NoneState, self).switch_to_configuration(method, sync, command)
         if res == 0:
             self._ssh_public_key_deployed = True
         return res
 
-    def get_ssh_name(self):
+    def get_ssh_name(self) -> str:
         assert self.target_host
         return self.target_host
 
-    def get_ssh_private_key_file(self):
+    def get_ssh_private_key_file(self) -> Optional[str]:
         if self._ssh_private_key_file:
             return self._ssh_private_key_file
-        else:
+        elif self._ssh_private_key:
             return self.write_ssh_private_key(self._ssh_private_key)
+        else:
+            # TODO: make better message
+            raise Exception("No SSH key available")
 
-    def get_ssh_flags(self, *args, **kwargs):
-        super_state_flags = super(NoneState, self).get_ssh_flags(*args, **kwargs)
+    def get_ssh_flags(self, scp: bool = False) -> List[str]:
+        super_state_flags = super(NoneState, self).get_ssh_flags(scp=scp)
+
+        ssh_private_key_file = self.get_ssh_private_key_file()
+        assert ssh_private_key_file is not None
+
         if self.vm_id and self.cur_toplevel and self._ssh_public_key_deployed:
             return super_state_flags + [
                 "-o",
                 "StrictHostKeyChecking=accept-new",
                 "-i",
-                self.get_ssh_private_key_file(),
+                ssh_private_key_file,
             ]
         return super_state_flags
 
-    def _check(self, res):
+    # FIXME: see _check in MachineState for fixing type
+    def _check(self, res: nixops.backends.CheckResult) -> None:  # type: ignore
         if not self.vm_id:
             res.exists = False
             return
         res.exists = True
+        assert self.target_host
         res.is_up = nixops.util.ping_tcp_port(self.target_host, self.ssh_port)
         if res.is_up:
             MachineState._check(self, res)
 
-    def destroy(self, wipe=False):
+    def destroy(self, wipe: bool = False) -> bool:
         # No-op; just forget about the machine.
         return True

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -1818,5 +1818,5 @@ def _load_modules_from(dir: str) -> None:
         importlib.import_module("nixops." + dir + "." + module[:-3])
 
 
-_load_modules_from("backends")
-_load_modules_from("resources")
+# _load_modules_from("backends")
+# _load_modules_from("resources")

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -44,6 +44,7 @@ import nixops.logger
 from nixops.nix_expr import RawValue, Function, Call, nixmerge, py2nix
 import nixops.parallel
 from nixops.plugins import get_plugin_manager
+import nixops.resources
 import nixops.statefile
 
 Definitions = Dict[str, nixops.resources.ResourceDefinition]

--- a/nixops/diff.py
+++ b/nixops/diff.py
@@ -6,24 +6,27 @@ from typing import Any, AnyStr, Callable, Dict, List, Optional, Tuple
 from nixops.logger import MachineLogger
 from nixops.state import StateDict
 
+# (allow_recreate: bool) -> None
+HandlerFn = Callable[[bool], None]
+
 
 class Handler:
     def __init__(
         self,
         keys: List[str],
-        after: Optional[List] = None,
-        handle: Optional[Callable] = None,
+        after: Optional[List[Any]] = None,
+        handle: Optional[HandlerFn] = None,
     ) -> None:
         if after is None:
             after = []
-        if handle is None:
-            self.handle = self._default_handle
-        else:
+        if handle is not None:
             self.handle = handle
+        else:
+            self.handle = self._default_handle
         self._keys = keys
         self._dependencies = after
 
-    def _default_handle(self):
+    def _default_handle(self, allow_recreate: bool) -> None:
         """
         Method that should be implemented to handle the changes
         of keys returned by get_keys()

--- a/nixops/logger.py
+++ b/nixops/logger.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import sys
 import threading
 from typing import List, Optional, TextIO
@@ -55,7 +57,7 @@ class Logger(object):
             self._log_file.write(msg + "\n")
             self._log_file.flush()
 
-    def get_logger_for(self, machine_name: str) -> "MachineLogger":
+    def get_logger_for(self, machine_name: str) -> MachineLogger:
         """
         Returns a logger instance for a specific machine name.
         """

--- a/nixops/nix_expr.py
+++ b/nixops/nix_expr.py
@@ -13,7 +13,7 @@ else:
 
 __all__ = ["py2nix", "nix2py", "nixmerge", "expand_dict", "RawValue", "Function"]
 
-Node = Union[MultiLineRawValue, RawValue, Container]
+Node = Union["MultiLineRawValue", "RawValue", "Container"]
 
 
 class RawValue(object):
@@ -51,7 +51,7 @@ class MultiLineRawValue(RawValue):
 
 
 class Function(object):
-    def __init__(self, head: str, body: str) -> None:
+    def __init__(self, head: str, body: Union[str, Dict[Any, Any]]) -> None:
         self.head = head
         self.body = body
 
@@ -136,11 +136,7 @@ class Container(object):
         return ind + self.prefix + sep + lines + sep + suffix_ind + self.suffix
 
 
-def enclose_node(
-    node: Union[MultiLineRawValue, RawValue, Container],
-    prefix: str = "",
-    suffix: str = "",
-) -> Union[MultiLineRawValue, RawValue, Container]:
+def enclose_node(node: Node, prefix: str = "", suffix: str = "",) -> Node:
     if isinstance(node, MultiLineRawValue):
         new_values = list(node.values)
         new_values[0] = prefix + new_values[0]

--- a/nixops/nix_expr.py
+++ b/nixops/nix_expr.py
@@ -36,8 +36,9 @@ class RawValue(object):
         return isinstance(other, RawValue) and other.value == self.value
 
 
+# TODO: why does MultiLineRawValue inherit RawValue but not use self.value?
 class MultiLineRawValue(RawValue):
-    def __init__(self, values: Any) -> None:
+    def __init__(self, values: List[Any]) -> None:
         self.values = values
 
     def get_min_length(self) -> int:
@@ -48,6 +49,13 @@ class MultiLineRawValue(RawValue):
 
     def indent(self, level: int = 0, inline: bool = False, maxwidth: int = 80) -> str:
         return "\n".join(["  " * level + value for value in self.values])
+
+    # TODO: is this correct?
+    def __repr__(self) -> str:
+        return str(self.values)
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, MultiLineRawValue) and other.values == self.values
 
 
 class Function(object):

--- a/nixops/plugins/__init__.py
+++ b/nixops/plugins/__init__.py
@@ -5,7 +5,7 @@ hookimpl = pluggy.HookimplMarker("nixops")
 """Marker to be imported and used in plugins (and for own implementations)"""
 
 
-def get_plugin_manager():
+def get_plugin_manager() -> pluggy.PluginManager:
     pm = pluggy.PluginManager("nixops")
     pm.add_hookspecs(hookspecs)
     pm.load_setuptools_entrypoints("nixops")

--- a/nixops/plugins/hookspecs.py
+++ b/nixops/plugins/hookspecs.py
@@ -1,5 +1,6 @@
-import pluggy
+# type: ignore
 
+import pluggy
 
 hookspec = pluggy.HookspecMarker("nixops")
 

--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import re
 from threading import Event

--- a/nixops/resources/commandOutput.py
+++ b/nixops/resources/commandOutput.py
@@ -16,24 +16,21 @@ import hashlib
 from nixops.deployment import Deployment
 from xml.etree.ElementTree import Element
 from nixops.nix_expr import Function
-from typing import Optional, List, Dict, Tuple
+from typing import Any, Optional, List, Dict, Tuple, Union
 
 
 class CommandOutputDefinition(nixops.resources.ResourceDefinition):
     """Definition of a Command Output."""
 
     @classmethod
-    def get_type(cls):
-        # type: () -> (str)
+    def get_type(cls) -> str:
         return "command-output"
 
     @classmethod
-    def get_resource_type(cls):
-        # type: () -> (str)
+    def get_resource_type(cls) -> str:
         return "commandOutput"
 
-    def show_type(self):
-        # type: () -> (str)
+    def show_type(self) -> str:
         return "{0}".format(self.get_type())
 
 
@@ -48,13 +45,11 @@ class CommandOutputState(nixops.resources.ResourceState):
     commandName = nixops.util.attr_property("name", None)
 
     @classmethod
-    def get_type(cls):
-        # type: () -> (str)
+    def get_type(cls) -> str:
         return "command-output"
 
     @property
-    def resource_id(self):
-        # type: () -> Optional[str]
+    def resource_id(self) -> Optional[str]:
         if self.value is not None:
             # Avoid printing any potential secret information
             return "{0}-{1}".format(
@@ -63,8 +58,13 @@ class CommandOutputState(nixops.resources.ResourceState):
         else:
             return None
 
-    def create(self, defn, check, allow_reboot, allow_recreate):
-        # type: (CommandOutputDefinition,bool,bool,bool) -> None
+    def create(
+        self,
+        defn: nixops.resources.ResourceDefinition,
+        check: bool,
+        allow_reboot: bool,
+        allow_recreate: bool,
+    ) -> None:
         if (
             (defn.config["script"] is not None)
             and (self.script != defn.config["script"])
@@ -76,7 +76,9 @@ class CommandOutputState(nixops.resources.ResourceState):
                     tempfile.mkdtemp(prefix="nixops-output-tmp")
                 )
 
-                self.log("Running shell function for output ‘{0}’...".format(defn.name))
+                self.logger.log(
+                    "Running shell function for output ‘{0}’...".format(defn.name)
+                )
                 env = {}  # type: Dict[str,str]
                 env.update(os.environ)
                 env.update({"out": output_dir})
@@ -88,26 +90,24 @@ class CommandOutputState(nixops.resources.ResourceState):
                     self.state = self.UP
                     self.script = defn.config["script"]
             except Exception as e:
-                self.log("Creation failed for output ‘{0}’...".format(defn.name))
+                self.logger.log("Creation failed for output ‘{0}’...".format(defn.name))
                 raise
 
-    def prefix_definition(self, attr):
-        # type: (Dict[str,Function]) -> Dict[Tuple[str,str],Dict[str,Function]]
+    def prefix_definition(self, attr: Dict[Any, Any]) -> Dict[Any, Any]:
+        # (Dict[str,Function]) -> Dict[Tuple[str,str],Dict[str,Function]]
         return {("resources", "commandOutput"): attr}
 
-    def get_physical_spec(self):
-        # type: () -> Dict[str,str]
+    def get_physical_spec(self) -> Dict[Union[Tuple[str, ...], str], Any]:
         return {"value": self.value}
 
-    def destroy(self, wipe=False):
-        # type: (bool) -> bool
+    def destroy(self, wipe: bool = False) -> bool:
         if self.depl.logger.confirm(
             "are you sure you want to destroy {0}?".format(self.name)
         ):
-            self.log("destroying...")
+            self.logger.log("destroying...")
         else:
             raise Exception("can't proceed further")
-            return False
+
         self.value = None
         self.state = self.MISSING
         return True

--- a/nixops/resources/ssh_keypair.py
+++ b/nixops/resources/ssh_keypair.py
@@ -2,25 +2,29 @@
 
 # Automatic provisioning of SSH key pairs.
 
-import nixops.util
+from typing import Any, Dict, Union, Tuple
+import xml.etree.ElementTree as ET
+
+import nixops.deployment
 import nixops.resources
+import nixops.util
 
 
 class SSHKeyPairDefinition(nixops.resources.ResourceDefinition):
     """Definition of an SSH key pair."""
 
     @classmethod
-    def get_type(cls):
+    def get_type(cls) -> str:
         return "ssh-keypair"
 
     @classmethod
-    def get_resource_type(cls):
+    def get_resource_type(cls) -> str:
         return "sshKeyPairs"
 
-    def __init__(self, xml):
+    def __init__(self, xml: ET.Element) -> None:
         nixops.resources.ResourceDefinition.__init__(self, xml)
 
-    def show_type(self):
+    def show_type(self) -> str:
         return "{0}".format(self.get_type())
 
 
@@ -34,14 +38,20 @@ class SSHKeyPairState(nixops.resources.ResourceState):
     private_key = nixops.util.attr_property("privateKey", None)
 
     @classmethod
-    def get_type(cls):
+    def get_type(cls) -> str:
         return "ssh-keypair"
 
-    def __init__(self, depl, name, id):
+    def __init__(self, depl: nixops.deployment.Deployment, name: str, id: str) -> None:
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._conn = None
 
-    def create(self, defn, check, allow_reboot, allow_recreate):
+    def create(
+        self,
+        defn: nixops.resources.ResourceDefinition,
+        check: bool,
+        allow_reboot: bool,
+        allow_recreate: bool,
+    ) -> None:
         # Generate the key pair locally.
         if not self.public_key:
             (private, public) = nixops.util.create_key_pair(type="ed25519")
@@ -50,11 +60,11 @@ class SSHKeyPairState(nixops.resources.ResourceState):
                 self.private_key = private
                 self.state = state = nixops.resources.ResourceState.UP
 
-    def prefix_definition(self, attr):
+    def prefix_definition(self, attr: Dict[Any, Any]) -> Dict[Any, Any]:
         return {("resources", "sshKeyPairs"): attr}
 
-    def get_physical_spec(self):
+    def get_physical_spec(self) -> Dict[Union[Tuple[str, ...], str], Any]:
         return {"privateKey": self.private_key, "publicKey": self.public_key}
 
-    def destroy(self, wipe=False):
+    def destroy(self, wipe: bool = False) -> bool:
         return True

--- a/nixops/resources/ssh_keypair.py
+++ b/nixops/resources/ssh_keypair.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 # Automatic provisioning of SSH key pairs.
 

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# type: ignore
 
 from nixops import deployment
 from nixops.nix_expr import py2nix
@@ -1119,7 +1120,7 @@ def add_common_deployment_options(subparser):
     )
 
 
-def error(msg):
+def error(msg: str) -> None:
     sys.stderr.write(nixops.util.ansi_warn("error: ") + msg + "\n")
 
 

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -7,8 +7,10 @@ import sys
 import time
 import weakref
 from tempfile import mkdtemp
+from typing import Dict, Any, Optional, Callable, List, Union, Iterable, Tuple
+
 import nixops.util
-from typing import Dict, Any, Optional, Callable, List
+from nixops.logger import MachineLogger
 
 __all__ = ["SSHConnectionFailed", "SSHCommandFailed", "SSH"]
 
@@ -22,7 +24,15 @@ class SSHCommandFailed(nixops.util.CommandFailed):
 
 
 class SSHMaster(object):
-    def __init__(self, target, logger, ssh_flags, passwd, user, compress=False):
+    def __init__(
+        self,
+        target: str,
+        logger: MachineLogger,
+        ssh_flags: List[str] = [],
+        passwd: Optional[str] = None,
+        user: Optional[str] = None,
+        compress: bool = False,
+    ) -> None:
         self._running = False
         self._tempdir = nixops.util.SelfDeletingDir(mkdtemp(prefix="nixops-ssh-tmp"))
         self._askpass_helper = None
@@ -85,20 +95,20 @@ class SSHMaster(object):
 
         weakself = weakref.ref(self)
 
-        def maybe_shutdown():
+        def maybe_shutdown() -> None:
             realself = weakself()
             if realself is not None:
                 realself.shutdown()
 
         atexit.register(maybe_shutdown)
 
-    def is_alive(self):
+    def is_alive(self) -> bool:
         """
         Check whether the control socket is still existing.
         """
         return os.path.exists(self._control_socket)
 
-    def _make_askpass_helper(self):
+    def _make_askpass_helper(self) -> str:
         """
         Create a SSH_ASKPASS helper script, which just outputs the contents of
         the environment variable NIXOPS_SSH_PASSWORD.
@@ -117,7 +127,7 @@ sys.stdout.write(os.environ['NIXOPS_SSH_PASSWORD'])""".format(
         os.close(fd)
         return path
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """
         Shutdown master process and clean up temporary files.
         """
@@ -129,12 +139,15 @@ sys.stdout.write(os.environ['NIXOPS_SSH_PASSWORD'])""".format(
             stderr=nixops.util.devnull,
         )
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.shutdown()
 
 
+Command = Union[str, Iterable[str]]
+
+
 class SSH(object):
-    def __init__(self, logger):
+    def __init__(self, logger: MachineLogger):
         """
         Initialize a SSH object with the specified Logger instance, which will
         be used to write SSH output to.
@@ -146,19 +159,19 @@ class SSH(object):
         self._ssh_master: Optional[SSHMaster] = None
         self._compress = False
 
-    def register_host_fun(self, host_fun: Callable[[], str]):
+    def register_host_fun(self, host_fun: Callable[[], str]) -> None:
         """
         Register a function which returns the hostname or IP to connect to. The
         function has to require no arguments.
         """
         self._host_fun = host_fun
 
-    def _get_target(self, user=None):
+    def _get_target(self, user: Optional[str] = None) -> str:
         if self._host_fun is None:
             raise AssertionError("don't know which SSH host to connect to")
         return "{0}@{1}".format("root" if user is None else user, self._host_fun())
 
-    def register_flag_fun(self, flag_fun: Callable[[], List[str]]):
+    def register_flag_fun(self, flag_fun: Callable[[], List[str]]) -> None:
         """
         Register a function that is used for obtaining additional SSH flags.
         The function has to require no arguments and should return a list of
@@ -166,10 +179,10 @@ class SSH(object):
         """
         self._flag_fun = flag_fun
 
-    def _get_flags(self):
+    def _get_flags(self) -> List[str]:
         return self._flag_fun()
 
-    def register_passwd_fun(self, passwd_fun: Callable[[], Optional[str]]):
+    def register_passwd_fun(self, passwd_fun: Callable[[], Optional[str]]) -> None:
         """
         Register a function that returns either a string or None and requires
         no arguments. If the return value is a string, the returned string is
@@ -178,10 +191,10 @@ class SSH(object):
         """
         self._passwd_fun = passwd_fun
 
-    def _get_passwd(self):
+    def _get_passwd(self) -> Optional[str]:
         return self._passwd_fun()
 
-    def reset(self):
+    def reset(self) -> None:
         """
         Reset SSH master connection.
         """
@@ -189,7 +202,12 @@ class SSH(object):
             self._ssh_master.shutdown()
             self._ssh_master = None
 
-    def get_master(self, flags=[], timeout=None, user=None):
+    def get_master(
+        self,
+        flags: List[str] = [],
+        timeout: Optional[int] = None,
+        user: Optional[str] = None,
+    ) -> SSHMaster:
         """
         Start (if necessary) an SSH master connection to speed up subsequent
         SSH sessions. Returns the SSHMaster instance on success.
@@ -238,7 +256,7 @@ class SSH(object):
         return weakref.proxy(self._ssh_master)
 
     @classmethod
-    def split_openssh_args(self, args):
+    def split_openssh_args(self, args: Iterable[str]) -> Tuple[List[str], Command]:
         """
         Splits the specified list of arguments into a tuple consisting of the
         list of flags and a list of strings for the actual command.
@@ -265,8 +283,10 @@ class SSH(object):
                 break
         return (flags, command)
 
-    def _sanitize_command(self, command, allow_ssh_args):
-        """
+    def _sanitize_command(
+        self, command: Command, allow_ssh_args: bool
+    ) -> Iterable[str]:
+        """ 
         Helper method for run_command, which essentially prepares and properly
         escape the command. See run_command() for further description.
         """
@@ -288,14 +308,14 @@ class SSH(object):
 
     def run_command(
         self,
-        command,
-        flags=[],
-        timeout=None,
-        logged=True,
-        allow_ssh_args=False,
-        user=None,
-        **kwargs
-    ):
+        command: Command,
+        flags: List[str] = [],
+        timeout: Optional[int] = None,
+        logged: bool = True,
+        allow_ssh_args: bool = False,
+        user: Optional[str] = None,
+        **kwargs: Any
+    ) -> Union[str, int]:
         """
         Execute a 'command' on the current target host using SSH, passing
         'flags' as additional arguments to SSH. The command can be either a
@@ -337,5 +357,5 @@ class SSH(object):
             else:
                 return res
 
-    def enable_compression(self):
+    def enable_compression(self) -> None:
         self._compress = True

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -7,7 +7,12 @@ import sys
 import time
 import weakref
 from tempfile import mkdtemp
-from typing import Dict, Any, Optional, Callable, List, Union, Iterable, Tuple
+from typing import Dict, Any, Optional, Callable, List, Union, Iterable, Tuple, overload
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 import nixops.util
 from nixops.logger import MachineLogger
@@ -305,6 +310,49 @@ class SSH(object):
                     ["'{0}'".format(arg.replace("'", r"'\''")) for arg in command]
                 ),
             ]
+
+    @overload
+    def run_command(
+        self,
+        command: Command,
+        flags: List[str] = ...,
+        timeout: Optional[int] = ...,
+        logged: bool = ...,
+        allow_ssh_args: bool = ...,
+        user: Optional[str] = ...,
+        *,
+        capture_stdout: Literal[False],
+        **kwargs: Any
+    ) -> int:
+        ...
+
+    @overload
+    def run_command(
+        self,
+        command: Command,
+        flags: List[str] = ...,
+        timeout: Optional[int] = ...,
+        logged: bool = ...,
+        allow_ssh_args: bool = ...,
+        user: Optional[str] = ...,
+        *,
+        capture_stdout: Literal[True],
+        **kwargs: Any
+    ) -> str:
+        ...
+
+    @overload
+    def run_command(
+        self,
+        command: Command,
+        flags: List[str] = [],
+        timeout: Optional[int] = None,
+        logged: bool = True,
+        allow_ssh_args: bool = False,
+        user: Optional[str] = None,
+        **kwargs: Any
+    ) -> Union[str, int]:
+        ...
 
     def run_command(
         self,

--- a/nixops/state.py
+++ b/nixops/state.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import collections
 import sqlite3

--- a/nixops/state.py
+++ b/nixops/state.py
@@ -2,17 +2,24 @@ import json
 import collections
 import sqlite3
 import nixops.util
-from typing import Any, List, Iterator, AbstractSet, Tuple
+from typing import Any, List, Iterator, AbstractSet, Tuple, TYPE_CHECKING
+
+import nixops.deployment
+
+if TYPE_CHECKING:
+    StateBase = collections.MutableMapping[str, Any]
+else:
+    StateBase = collections.MutableMapping
 
 
-class StateDict(collections.MutableMapping):
+class StateDict(StateBase):
     """
        An implementation of a MutableMapping container providing
        a python dict like behavior for the NixOps state file.
     """
 
     # TODO implement __repr__ for convenience e.g debuging the structure
-    def __init__(self, depl, id: str):
+    def __init__(self, depl: nixops.deployment.Deployment, id: str) -> None:
         super(StateDict, self).__init__()
         self._db: sqlite3.Connection = depl._db
         self.id = id

--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import os
 import os.path

--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -1,21 +1,22 @@
 # -*- coding: utf-8 -*-
 
-import nixops.deployment
 import os
 import os.path
 import sqlite3
 import sys
 import threading
 import typing
-from typing import Optional, List
+from typing import Any, Optional, List
+
+import nixops.deployment
 
 
 class Connection(sqlite3.Connection):
-    def __init__(self, db_file, **kwargs):
+    def __init__(self, db_file: str, **kwargs: Any) -> None:
         db_exists = os.path.exists(db_file)
         if not db_exists:
             os.fdopen(os.open(db_file, os.O_WRONLY | os.O_CREAT, 0o600), "w").close()
-        sqlite3.Connection.__init__(self, db_file, **kwargs)
+        sqlite3.Connection.__init__(self, db_file, **kwargs)  # type: ignore
         self.db_file = db_file
         self.nesting = 0
         self.lock = threading.RLock()
@@ -24,14 +25,19 @@ class Connection(sqlite3.Connection):
     # automatically commits or rolls back.  The difference with the
     # parent's "with" implementation is that we nest, i.e. a commit or
     # rollback is only done at the outer "with".
-    def __enter__(self):
+    def __enter__(self, *args: Any, **kwargs: Any) -> "Connection":
         self.lock.acquire()
         if self.nesting == 0:
             self.must_rollback = False
         self.nesting = self.nesting + 1
-        sqlite3.Connection.__enter__(self)
+        return sqlite3.Connection.__enter__(self)  # type: ignore
 
-    def __exit__(self, exception_type, exception_value, exception_traceback):
+    # def __exit__(self, exception_type, exception_value, exception_traceback) -> None:
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        exception_type = args[0]
+        exception_value = args[1]
+        exception_traceback = args[2]
+
         if exception_type != None:
             self.must_rollback = True
         self.nesting = self.nesting - 1
@@ -43,13 +49,13 @@ class Connection(sqlite3.Connection):
                 except sqlite3.ProgrammingError:
                     pass
             else:
-                sqlite3.Connection.__exit__(
+                sqlite3.Connection.__exit__(  # type: ignore
                     self, exception_type, exception_value, exception_traceback
                 )
         self.lock.release()
 
 
-def get_default_state_file():
+def get_default_state_file() -> str:
     home = os.environ.get("HOME", "") + "/.nixops"
     if not os.path.exists(home):
         old_home = os.environ.get("HOME", "") + "/.charon"
@@ -70,7 +76,7 @@ class StateFile(object):
 
     current_schema = 3
 
-    def __init__(self, db_file):
+    def __init__(self, db_file: str) -> None:
         self.db_file = db_file
 
         if os.path.splitext(db_file)[1] not in [".nixops", ".charon"]:
@@ -122,10 +128,10 @@ class StateFile(object):
 
         self._db: sqlite3.Connection = db
 
-    def close(self):
+    def close(self) -> None:
         self._db.close()
 
-    def query_deployments(self):
+    def query_deployments(self) -> List[str]:
         """Return the UUIDs of all deployments in the database."""
         c = self._db.cursor()
         c.execute("select uuid from Deployments")
@@ -145,7 +151,9 @@ class StateFile(object):
                 )
         return res
 
-    def _find_deployment(self, uuid=None):
+    def _find_deployment(
+        self, uuid: Optional[str] = None
+    ) -> Optional[nixops.deployment.Deployment]:
         c = self._db.cursor()
         if not uuid:
             c.execute("select uuid from Deployments")
@@ -177,7 +185,9 @@ class StateFile(object):
                 )
         return nixops.deployment.Deployment(self, res[0][0], sys.stderr)
 
-    def open_deployment(self, uuid=None):
+    def open_deployment(
+        self, uuid: Optional[str] = None
+    ) -> nixops.deployment.Deployment:
         """Open an existing deployment."""
         deployment = self._find_deployment(uuid=uuid)
         if deployment:
@@ -188,7 +198,9 @@ class StateFile(object):
             )
         )
 
-    def create_deployment(self, uuid=None) -> nixops.deployment.Deployment:
+    def create_deployment(
+        self, uuid: Optional[str] = None
+    ) -> nixops.deployment.Deployment:
         """Create a new deployment."""
         if not uuid:
             import uuid as uuidlib
@@ -198,13 +210,13 @@ class StateFile(object):
             self._db.execute("insert into Deployments(uuid) values (?)", (uuid,))
         return nixops.deployment.Deployment(self, uuid, sys.stderr)
 
-    def _table_exists(self, c, table) -> bool:
+    def _table_exists(self, c: sqlite3.Cursor, table: str) -> bool:
         c.execute(
             "select 1 from sqlite_master where name = ? and type='table'", (table,)
         )
         return c.fetchone() != None
 
-    def _create_schemaversion(self, c):
+    def _create_schemaversion(self, c: sqlite3.Cursor) -> None:
         c.execute(
             """create table if not exists SchemaVersion(
                  version integer not null
@@ -215,7 +227,7 @@ class StateFile(object):
             "insert into SchemaVersion(version) values (?)", (self.current_schema,)
         )
 
-    def _create_schema(self, c):
+    def _create_schema(self, c: sqlite3.Cursor) -> None:
         self._create_schemaversion(c)
 
         c.execute(
@@ -254,11 +266,11 @@ class StateFile(object):
                );"""
         )
 
-    def _upgrade_1_to_2(self, c):
+    def _upgrade_1_to_2(self, c: sqlite3.Cursor) -> None:
         sys.stderr.write("updating database schema from version 1 to 2...\n")
         self._create_schemaversion(c)
 
-    def _upgrade_2_to_3(self, c):
+    def _upgrade_2_to_3(self, c: sqlite3.Cursor) -> None:
         sys.stderr.write("updating database schema from version 2 to 3...\n")
         c.execute("alter table Machines rename to Resources")
         c.execute("alter table MachineAttrs rename to ResourceAttrs")

--- a/release.nix
+++ b/release.nix
@@ -89,6 +89,7 @@ in rec {
         propagatedBuildInputs = [
           pythonPackages.prettytable
           pythonPackages.pluggy
+          pythonPackages.typing-extensions
         ] ++ pkgs.lib.traceValFn
            (x: "Using plugins: " + builtins.toJSON x)
            (map (d: d.build.${system}) (pluginSet allPlugins));

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,33 @@
 [mypy]
 python_version = 3.7
-no_implicit_optional = True
-strict_optional = True
+
+allow_redefinition = False
+allow_untyped_globals = False
 check_untyped_defs = True
+disallow_any_decorated = True
+# disallow_any_expr = True
+disallow_any_generics = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+error_summary = True
+no_implicit_optional = True
+no_implicit_reexport = True
+show_none_errors = True
+strict_equality = True
+warn_no_return = True
+warn_redundant_casts = True
+# warn_return_any = True
+warn_unreachable = True
+warn_unused_configs = True
+warn_unused_ignores = True
+
+color_output = True
+show_error_context = True
+show_column_numbers = True
+pretty = True
 
 [mypy-azure.*]
 ignore_missing_imports = True

--- a/tests/functional/generic_deployment_test.py
+++ b/tests/functional/generic_deployment_test.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import nixops.deployment
 import nixops.statefile
 
 from nose import SkipTest

--- a/tests/functional/test_starting_starts.py
+++ b/tests/functional/test_starting_starts.py
@@ -1,5 +1,7 @@
 from nose import tools
 
+import nixops.deployment
+
 from tests.functional import single_machine_test
 
 

--- a/tests/functional/test_stopping_stops.py
+++ b/tests/functional/test_stopping_stops.py
@@ -1,5 +1,7 @@
 from nose import tools
 
+import nixops.deployment
+
 from tests.functional import single_machine_test
 
 


### PR DESCRIPTION
It started out a little more disciplined then became a big ball of changes, apologies.

Also some of this might be overkill.

Included the stricter mypy config that this passes for reference, but it's maybe we don't want to require it yet. 

Running mypy (with stricter config):
![image](https://user-images.githubusercontent.com/5341292/75645891-c0fb8880-5c15-11ea-9d17-bc13fcc64660.png)

The mypy report part errors out early, but what it does get to:
```
+--------------------------+-------------------+----------+
| Module                   | Imprecision       | Lines    |
+--------------------------+-------------------+----------+
| nixops                   |   0.00% imprecise |    0 LOC |
| nixops.ansi              |   0.00% imprecise |   18 LOC |
| nixops.diff              |  15.17% imprecise |  211 LOC |
| nixops.known_hosts       |  11.43% imprecise |   70 LOC |
| nixops.logger            |   0.00% imprecise |  158 LOC |
| nixops.nix_expr          |  27.53% imprecise |  385 LOC |
| nixops.parallel          |   9.48% imprecise |  116 LOC |
| nixops.plugins           |  58.33% imprecise |   12 LOC |
| nixops.plugins.hookspecs |  15.38% imprecise |   26 LOC |
| nixops.resources         |  15.31% imprecise |  320 LOC |
| nixops.script_defs       |  28.99% imprecise | 1128 LOC |
| nixops.ssh_util          |   5.62% imprecise |  409 LOC |
| nixops.state             |  18.07% imprecise |   83 LOC |
| nixops.util              |  10.83% imprecise |  600 LOC |
+--------------------------+-------------------+----------+
| Total                    |  18.30% imprecise | 3536 LOC |
+--------------------------+-------------------+----------+
```

Tests:
![image](https://user-images.githubusercontent.com/5341292/75735421-a1716800-5cc8-11ea-97ec-fd0df7c81251.png)



@grahamc saw your tweet about working on this and having some experience hitting python over the head with mypy, figured I'd make a pass (^_^)