### PR TITLE
script_defs: Remove None assertion

### DIFF
--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -28,7 +28,7 @@ class ResourceDefinition(object):
         if not re.match("^[a-zA-Z0-9_\-][a-zA-Z0-9_\-\.]*$", self.name):
             raise Exception("invalid resource name ‘{0}’".format(self.name))
 
-    def show_type(self):
+    def show_type(self) -> str:
         """A short description of the type of resource this is"""
         return self.get_type()
 
@@ -142,11 +142,11 @@ class ResourceState(object):
     warn = lambda s, m: s.logger.warn(m)
     success = lambda s, m: s.logger.success(m)
 
-    def show_type(self):
+    def show_type(self) -> str:
         """A short description of the type of resource this is"""
         return self.get_type()
 
-    def show_state(self):
+    def show_state(self) -> str:
         """A description of the resource's current state"""
         state = self.state
         if state == self.UNKNOWN:

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -241,9 +241,7 @@ def op_info(args):
 
             resource_state: str = "Missing"
             if isinstance(r, nixops.backends.MachineState):
-                resource_state = "{0} / {1}".format(
-                    r.show_state() if r else "Missing", state(depl, d, r)
-                )
+                resource_state = "{0} / {1}".format(r.show_state(), state(depl, d, r))
             elif r:
                 resource_state = r.show_state()
 

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -188,7 +188,7 @@ def op_info(args):
         ("IP address", "l"),
     ]
 
-    def state(depl, d, m):
+    def state(depl, d, m) -> str:
         if not d and (depl.definitions != None or m.obsolete):
             return "Obsolete"
         if d and m and m.obsolete:
@@ -199,6 +199,8 @@ def op_info(args):
             return "Outdated"
         if deployment.is_machine(m):
             return "Up-to-date"
+
+        raise ValueError("Unknown state")
 
     def do_eval(depl):
         if not args.no_eval:
@@ -236,20 +238,20 @@ def op_info(args):
         for name in names:
             d = definitions.get(name)
             r = depl.resources.get(name)
-            assert r is not None
-            if deployment.is_machine(r):
+
+            resource_state: str = "Missing"
+            if r is not None and deployment.is_machine(r):
                 resource_state = "{0} / {1}".format(
                     r.show_state() if r else "Missing", state(depl, d, r)
                 )
-            else:
-                resource_state = r.show_state() if r else "Missing"
+            elif r:
+                resource_state = r.show_state()
 
+            user_type: str = "unknown-type"
             if r:
                 user_type = r.show_type()
             elif d:
                 user_type = d.show_type()
-            else:
-                user_type = "unknown-type"
 
             public_ipv4: str = ""
             private_ipv4: str = ""

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -240,7 +240,7 @@ def op_info(args):
             r = depl.resources.get(name)
 
             resource_state: str = "Missing"
-            if r is not None and deployment.is_machine(r):
+            if isinstance(r, nixops.backends.MachineState):
                 resource_state = "{0} / {1}".format(
                     r.show_state() if r else "Missing", state(depl, d, r)
                 )

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -193,18 +193,14 @@ def op_info(args):
         d: Optional[nixops.resources.ResourceDefinition],
         m: nixops.backends.MachineState,
     ) -> str:
-        if not d and (depl.definitions != None or m.obsolete):
-            return "Obsolete"
-        if d and m and m.obsolete:
+        if d and m.obsolete:
             return "Revived"
-        if not m:
-            return "New"
-        if deployment.is_machine(m) and depl.configs_path != m.cur_configs_path:
+        if d is None and m.obsolete:
+            return "Obsolete"
+        if depl.configs_path != m.cur_configs_path:
             return "Outdated"
-        if deployment.is_machine(m):
-            return "Up-to-date"
 
-        raise ValueError("Unknown state")
+        return "Up-to-date"
 
     def do_eval(depl):
         if not args.no_eval:

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -188,7 +188,11 @@ def op_info(args):
         ("IP address", "l"),
     ]
 
-    def state(depl, d, m) -> str:
+    def state(
+        depl: nixops.deployment.Deployment,
+        d: Optional[nixops.resources.ResourceDefinition],
+        m: nixops.backends.MachineState,
+    ) -> str:
         if not d and (depl.definitions != None or m.obsolete):
             return "Obsolete"
         if d and m and m.obsolete:


### PR DESCRIPTION
`r` being `None` is peferctly valid when the resource does not yet exist.

Without this fix a resource not yet deployed fails with AssertionError.