### PR TITLE
Deploy Targets: Policy/Behavior-free Deployment Hooks (auto-rollbacks, drain events, etc.)

### DIFF
--- a/nix/options.nix
+++ b/nix/options.nix
@@ -16,6 +16,7 @@ in
       ./auto-raid0.nix
       ./auto-luks.nix
       ./keys.nix
+      ./targets.nix
     ];
 
 

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -1,0 +1,28 @@
+{
+  systemd.targets = {
+    deploy-prepare = {
+      description = "Started immediately before switch-to-configuration.";
+      unitConfig = {
+        Conflicts = [ "deploy-healthy.target" "deploy-complete.target" ];
+        X-StopOnReconfiguration = true;
+      };
+    };
+
+    deploy-healthy = {
+      description = "Started after confirming switch-to-configuration was successful.";
+      unitConfig = {
+        Conflicts = [ "deploy-prepare.target" ];
+        X-StopOnReconfiguration = true;
+      };
+    };
+
+    deploy-complete = {
+      description = "Started after confirming switch-to-configuration was successful on the entire deployment.";
+      unitConfig = {
+        Conflicts = [ "deploy-prepare.target" ];
+        X-StopOnReconfiguration = true;
+      };
+    };
+
+  };
+}

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -3,13 +3,22 @@
     deploy-prepare = {
       description = "Started immediately before switch-to-configuration.";
       unitConfig = {
-        Conflicts = [ "deploy-healthy.target" "deploy-complete.target" ];
+        Conflicts = [ "deploy-healthy.target" "deploy-complete.target" "deploy-failed.target" ];
         X-StopOnReconfiguration = true;
       };
     };
 
     deploy-healthy = {
       description = "Started after confirming switch-to-configuration was successful.";
+      unitConfig = {
+        OnFailure = [ "deploy-failed.target" ];
+        Conflicts = [ "deploy-prepare.target" "deploy-failed.target" ];
+        X-StopOnReconfiguration = true;
+      };
+    };
+
+    deploy-failed = {
+      description = "Started when deploy-healthy fails.";
       unitConfig = {
         Conflicts = [ "deploy-prepare.target" ];
         X-StopOnReconfiguration = true;

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -1,15 +1,7 @@
 {
   systemd.targets = {
-    deploy-prepare = {
-      description = "Started immediately before switch-to-configuration.";
-      unitConfig = {
-        Conflicts = [ "deploy-healthy.target" "deploy-complete.target" "deploy-failed.target" ];
-        X-StopOnReconfiguration = true;
-      };
-    };
-
-    deploy-healthy = {
-      description = "Started after confirming switch-to-configuration was successful.";
+    deploy-machine-commit = {
+      description = "Healthy Deployment";
       unitConfig = {
         OnFailure = [ "deploy-failed.target" ];
         Conflicts = [ "deploy-prepare.target" "deploy-failed.target" ];
@@ -17,21 +9,32 @@
       };
     };
 
-    deploy-failed = {
-      description = "Started when deploy-healthy fails.";
+    deploy-machine-abort = {
+      description = "Failed Deployment";
       unitConfig = {
         Conflicts = [ "deploy-prepare.target" ];
         X-StopOnReconfiguration = true;
       };
     };
 
-    deploy-complete = {
-      description = "Started after confirming switch-to-configuration was successful on the entire deployment.";
+    deploy-network-commit = {
+      description = "Deployment Complete Across All Machines";
       unitConfig = {
         Conflicts = [ "deploy-prepare.target" ];
         X-StopOnReconfiguration = true;
       };
     };
 
+    #                      Why is this last?
+    #
+    # When deploy-machine-request runs, it is at the _end_ of the
+    # lifecycle of the previously deployed system.
+    deploy-machine-request = {
+      description = "Deployment Requested";
+      unitConfig = {
+        Conflicts = [ "deploy-healthy.target" "deploy-complete.target" "deploy-failed.target" ];
+        X-StopOnReconfiguration = true;
+      };
+    };
   };
 }

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -1,7 +1,15 @@
 {
   systemd.targets = {
-    deploy-machine-commit = {
-      description = "Healthy Deployment";
+    deploy-prepare = {
+      description = "Started immediately before switch-to-configuration.";
+      unitConfig = {
+        Conflicts = [ "deploy-healthy.target" "deploy-complete.target" "deploy-failed.target" ];
+        X-StopOnReconfiguration = true;
+      };
+    };
+
+    deploy-healthy = {
+      description = "Started after confirming switch-to-configuration was successful.";
       unitConfig = {
         OnFailure = [ "deploy-failed.target" ];
         Conflicts = [ "deploy-prepare.target" "deploy-failed.target" ];
@@ -9,32 +17,21 @@
       };
     };
 
-    deploy-machine-abort = {
-      description = "Failed Deployment";
+    deploy-failed = {
+      description = "Started when deploy-healthy fails.";
       unitConfig = {
         Conflicts = [ "deploy-prepare.target" ];
         X-StopOnReconfiguration = true;
       };
     };
 
-    deploy-network-commit = {
-      description = "Deployment Complete Across All Machines";
+    deploy-complete = {
+      description = "Started after confirming switch-to-configuration was successful on the entire deployment.";
       unitConfig = {
         Conflicts = [ "deploy-prepare.target" ];
         X-StopOnReconfiguration = true;
       };
     };
 
-    #                      Why is this last?
-    #
-    # When deploy-machine-request runs, it is at the _end_ of the
-    # lifecycle of the previously deployed system.
-    deploy-machine-request = {
-      description = "Deployment Requested";
-      unitConfig = {
-        Conflicts = [ "deploy-healthy.target" "deploy-complete.target" "deploy-failed.target" ];
-        X-StopOnReconfiguration = true;
-      };
-    };
   };
 }

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -440,6 +440,12 @@ class MachineState(nixops.resources.ResourceState):
         cmd += " " + method
         return self.run_command(cmd, check=False)
 
+    def verify_current_system(self, expected: str) -> str:
+        ret = self.run_command(
+            f'test "$(readlink -f /run/current-system)" == "{expected}"', check=False
+        )
+        return ret == 0
+
     def mark_deploy_healthy(self) -> bool:
         """
         Starts the target "deploy-healthy.target".

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -997,6 +997,8 @@ class Deployment:
                     elif ret != 0:
                         raise Exception("unable to set new system profile")
 
+            assert m.new_toplevel is not None
+
             try:
                 if not dry_activate:
                     m.log("starting deploy-prepare.target")

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -1055,6 +1055,12 @@ class Deployment:
                 if res == 0:
                     m.success("activation finished successfully")
 
+                if not m.verify_current_system(m.new_toplevel):
+                    m.warn("did not switch to the new system; possible rollback")
+                    raise Exception(
+                        f"{m.name} did not switch to the new system; possible rollback"
+                    )
+
                 m.log("starting deploy-healthy.target")
                 if not m.mark_deploy_healthy():
                     m.warn("refused to go to deploy-healthy.target")

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -998,6 +998,14 @@ class Deployment:
                         raise Exception("unable to set new system profile")
 
             try:
+                if not dry_activate:
+                    m.log("starting deploy-prepare.target")
+                    if not m.is_okay_to_deploy():
+                        m.warn("refused to go to deploy-prepare.target")
+                        raise Exception(
+                            f"Failed to prepare {m.name} for deployment (deploy-prepare.target failed)"
+                        )
+
                 if not test:
                     set_profile()
 
@@ -1011,14 +1019,6 @@ class Deployment:
                     switch_method = "test"
                 else:
                     switch_method = "switch"
-
-                if not dry_activate:
-                    m.log("starting deploy-prepare.target")
-                    if not m.is_okay_to_deploy():
-                        m.warn("refused to go to deploy-prepare.target")
-                        raise Exception(
-                            f"Failed to prepare {m.name} for deployment (deploy-prepare.target failed)"
-                        )
 
                 # Run the switch script.  This will also update the
                 # GRUB boot loader.


### PR DESCRIPTION
(don't merge yet)

This PR adds trivial targets without any particular behavior or policy
to NixOps. These targets allows the system to react to deployment
events, and for users to customize the policy of how to react to their
use case.

In particular, this PR is authored with the intent of providing safe
and automatic rollbacks for embedded NixOS systems which are hard to
access and repair. Thank you to Yakkertech for sponsoring this work.

The following targets are added, with a note of when they become
active:

* `deploy-prepare.target` - before a new system is activated.
* `deploy-healthy.target` - after NixOps reconnects over SSH.
* `deploy-failed.target` - if `deploy-health.target` fails.
* `deploy-complete.target` - after every system in the given
  deployment (ie: `--include` / `--exclude`) completes successfully.

During a deploy, for each system, each system has the following steps
executed independently:

1. copy the system closure
2. start `deploy-prepare.target`. If this fails, fail this machine's
   deploy.
3. run the new system's activation script
4. close the SSH connection
5. open a new SSH connection. if this fails, the next step is skipped.
6. start `deploy-healthy.target`. If this fails,
   `deploy-failed.target` is started automatically, and NixOps sees an
   error.

Once every server has completed these steps, if they all completed
successfully NixOps will SSH to each machine and start
`deploy-completed.target`.

Importantly, none of these targets actually _do_ anything on their
own. NixOps has expressed no preference or policy or behavior.
@adisbladis and I feel the space is too large and complicated for any
one implementation to get it right.

# Current Problems and To-Do

* During activation, NixOS's `switch-to-configuration.pl` starts
  `deploy-prepare.target` and its dependents, causing preparation
  steps to run too many times, and at innapropriate times. @adisbladis
  will be working on a solution to this Monday.
* The `Before`, `Requires`, and other directives are very sensitive.
  We need to provide very precise and accurate tests and documentation
  on exactly how a user can and should hook in to these targets.
* If `deploy-prepare` gets stuck and will only refuse a deployment,
  NixOps has no way to ignore that and deploy anyway. This is a
  problem, because there is no way to automatically recover without
  manually SSHing in and rolling back to some other system version.

# Future Work

* Potentially move the targets in to NixOS itself, teaching
  `nixos-rebuild` about these targets.
* Publish to some well-known location a set of expressions for ways
  these targets can be used to safely implement various use cases.

# Use Cases

## Draining Phase

Hooking an event in to `deploy-prepare.target` allows the server
itself to delay a deployment. This can be used to, for example:

- remove itself from a load balancer
- wait for an important measurement to complete
- wait for in-progress builds to complete
- wait for the mail queue to empty

Example, a server removing itself from an ELB before the deployment,
and adding itself after the system's deployment is healthy:

```nix
{ pkgs, ... }: {
  systemd.targets.deploy-prepare.unitConfig.Requires = [ "leave-elb.service" ];
  systemd.services.leave-elb = {
    unitConfig.Before = [ "deploy-prepare.target" ];
    serviceConfig.Type = "oneshot";
    serviceConfig.RemainAfterExit = true;
    path = [ pkgs.awscli ];

    script = ''
      aws elb deregister-instances-from-load-balancer \
          --load-balancer-name prod-web-traffic-load-balancer \
          --instance my-instance-id | jq .
    '';
  };

  systemd.targets.deploy-healthy.unitConfig.Requires = [ "join-elb.service" ];
  systemd.services.join-elb = {
    unitConfig.After = [ "deploy-healthy.target" ];
    serviceConfig.Type = "oneshot";
    serviceConfig.RemainAfterExit = true;
    path = [ pkgs.awscli ];

    script = ''
      aws elb register-instances-with-load-balancer \
          --load-balancer-name prod-web-traffic-load-balancer \
          --instance my-instance-id | jq .
    '';
  };
}
```


## Critical Window Protection

Hooking an event in to `deploy-prepare.target` allows the server
itself to _prevent_ a deployment, too. This could be used to protect a
system from deployments during a critical time window. For example, a
system which absolutely must remain undisturbed during a critical
production event could flat out refuse the deployment:


Example, a server which refuses deploys after 12:

```nix
{ pkgs, ... }: {
  systemd.targets.deploy-prepare.unitConfig.Requires = [
    "no-afternoon-deploys.service"
  ];
  systemd.services.no-afternoon-deploys = {
    unitConfig.Before = [ "deploy-prepare.target" ];
    serviceConfig.Type = "oneshot";
    serviceConfig.RemainAfterExit = true;

    script = ''
      hour=$(date +%H)
      if [ $hour -ge 12 ]; then
        echo "Don't deploy during the afternoon!"
        exit 1
      fi
    '';
  };
}
```

## Coordinated Distributed Database Maintenance

Many distributed databases will identify a failed machine and begin
reallocated data, assuming the old machine will not come back. A
graceful, coordinated shutdown can fix this.

For example, with Elasticsearch it is important to disable shard
allocation during a deployment, and forcing a synced flush will
improve recovery time.

Elasticsearch in particular is interesting, because we can use the
`deploy-complete` hook to ensure _every_ machine has finished before
re-enabling allocation: something NixOS and NixOps do not easily
support right now.

```nix
{ config, pkgs, ... }:
let
  esConfig = config.services.elasticsearch;
  esUrl = "http://${esConfig.listenAddress}:${esConfig.port}";
in {
  systemd.targets.deploy-prepare.unitConfig.Requires = [
    "elasticsearch-pre-deploy.service"
  ];
  systemd.services.elasticsearch-pre-deploy = {
    unitConfig.Before = [ "deploy-prepare.target" ];
    serviceConfig.Type = "oneshot";
    serviceConfig.RemainAfterExit = true;
    path = [ pkgs.curl ];

    script = ''
      echo "Disabling shard replication during node shutdown..."

      curl -X PUT "${esUrl}/_cluster/settings?pretty" \
        -H 'Content-Type: application/json' -d'
        {
          "persistent": {
            "cluster.routing.allocation.enable": "primaries"
          }
        }
      '

      echo "Forcing a synced flush to speed up recovery"
      curl -X POST "${esUrl}/_flush/synced?pretty" \
    '';
  };

  systemd.targets.deploy-complete.unitConfig.Requires = [
    "elasticsearch-post-deploy.service"
  ];
  systemd.services.elasticsearch-post-deploy = {
    unitConfig.After = [ "deploy-complete.target" ];
    serviceConfig.Type = "oneshot";
    serviceConfig.RemainAfterExit = true;
    path = [ pkgs.curl ];

    script = ''
      echo "Re-enabling allocation"
      curl -X PUT "${esUrl}" \
        -H 'Content-Type: application/json' -d'
        {
          "persistent": {
            "cluster.routing.allocation.enable": null
          }
        }
      '
    '';
  };
}
```

## Automatic Rollback After a Failed Deployment

With the addition of a timer, we can implement an automatic rollback
in not very much code. In this example, the automatic rollback
is triggered in two cases:

 * `deploy-healthy.target` is activated, but fails
 * `deploy-healthy.target` is not activated within 1 minute of
   `deploy-prepare.target`, indicating the new system configuration
   broke the network or system in a way preventing the deployment host
   from confirming the new system.

```nix
{ pkgs, ... }:
{
  systemd.services.automatic-rollback = {
    description = "Automatic rollback";
    wantedBy = [ "deploy-failed.target" ];
    script = ''
      echo "Rolling back!"
      nix-env --rollback -p /nix/var/nix/profiles/system
      /nix/var/nix/profiles/system/bin/switch-to-configuration switch
    '';
    serviceConfig.Type = "oneshot";
    serviceConfig.RemainAfterExit = false;
  };

  systemd.timers.automatic-rollback = {
    enable = true;
    wantedBy = [ "deploy-prepare.target" ];

    unitConfig = {
      Conflicts = [ "deploy-healthy.target" ];
    };
    timerConfig = {
      OnActiveSec = "1m";
      RemainAfterElapse = false;
    };
  };
}
```

---

_note: the examples are just examples and have not been tested_
