### PR TITLE
WIP: Add deploy without creating a state file

### DIFF
--- a/nixops/__main__.py
+++ b/nixops/__main__.py
@@ -164,6 +164,7 @@ subparser.add_argument(
     help="activate unchanged configurations as well",
 )
 add_common_deployment_options(subparser)
+add_common_modify_options(subparser)
 
 subparser = add_subparser(subparsers, "send-keys", help="send encryption keys")
 subparser.set_defaults(op=op_send_keys)

--- a/nixops/evaluation.py
+++ b/nixops/evaluation.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+import subprocess
+import typing
+import json
+
+
+@dataclass
+class NetworkEval:
+
+    description: str = "Unnamed NixOps network"
+    enableRollback: bool = False
+    enableState: bool = True
+
+
+def _eval_attr(
+    attr, nix_exprs: typing.List[str]
+) -> typing.Dict[typing.Any, typing.Any]:
+    p = subprocess.run(
+        [
+            "nix-instantiate",
+            "--eval-only",
+            "--json",
+            "--strict",
+            # Arg
+            "--arg",
+            "checkConfigurationOptions",
+            "false",
+            # Attr
+            "-A",
+            attr,
+        ]
+        + nix_exprs,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if p.returncode != 0:
+        raise RuntimeError(p.stderr.decode())
+
+    return json.loads(p.stdout)
+
+
+def eval_network(nix_exprs: typing.List[str]) -> NetworkEval:
+    result = _eval_attr("network", nix_exprs)
+    return NetworkEval(**result)

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -1089,7 +1089,7 @@ def add_subparser(
     return subparser
 
 
-def add_common_modify_options(subparser: ArgumentParser):
+def add_common_modify_options(subparser: ArgumentParser) -> None:
     subparser.add_argument(
         "nix_exprs",
         nargs="*",
@@ -1106,7 +1106,7 @@ def add_common_modify_options(subparser: ArgumentParser):
     )
 
 
-def add_common_deployment_options(subparser: ArgumentParser):
+def add_common_deployment_options(subparser: ArgumentParser) -> None:
     subparser.add_argument(
         "--include",
         nargs="+",

--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -82,7 +82,10 @@ class StateFile(object):
     def __init__(self, db_file: str) -> None:
         self.db_file: str = db_file
 
-        if os.path.splitext(db_file)[1] not in [".nixops", ".charon"]:
+        if db_file != ":memory:" and os.path.splitext(db_file)[1] not in [
+            ".nixops",
+            ".charon",
+        ]:
             raise Exception(
                 "state file ‘{0}’ should have extension ‘.nixops’".format(db_file)
             )


### PR DESCRIPTION
Create an in-memory SQLite db if `--no-state` is passed to deploy.
This is probably the easiest way possible for us to add support for deployments without using a state file.

If `--no-state` is passed a create is implicitly done in the same process.

While this works perfectly fine with the `none` backend it's marked WIP because it needs docs.

Based on top of https://github.com/NixOS/nixops/pull/1240 since they touch a lot of the same code & meant to be used together with https://github.com/NixOS/nixops/pull/1247.