### PR TITLE
Use context manager for file opens

### DIFF
--- a/nixops/known_hosts.py
+++ b/nixops/known_hosts.py
@@ -23,9 +23,8 @@ def _rewrite(ip_address: str, add_ip: bool, public_host_key: str) -> None:
             fcntl.flock(
                 lockfile, fcntl.LOCK_EX
             )  # unlock is implicit at the end of the with
-            f = open(path, "r")
-            contents = f.read()
-            f.close()
+            with open(path, "r") as f:
+                contents = f.read()
 
             def rewrite(lst: str) -> Optional[str]:
                 if " " not in lst:

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -329,12 +329,10 @@ def create_key_pair(
     )
     if res != 0:
         raise Exception("unable to generate an SSH key")
-    f = open(key_dir + "/key")
-    private = f.read()
-    f.close()
-    f = open(key_dir + "/key.pub")
-    public = f.read().rstrip()
-    f.close()
+    with open(key_dir + "/key") as f:
+        private = f.read()
+    with open(key_dir + "/key.pub") as f:
+        public = f.read().rstrip()
     shutil.rmtree(key_dir)
     return (private, public)
 
@@ -430,9 +428,8 @@ def enum(**enums):
 
 
 def write_file(path: str, contents: str) -> None:
-    f = open(path, "w")
-    f.write(contents)
-    f.close()
+    with open(path, "w") as f:
+        f.write(contents)
 
 
 def xml_expr_to_python(node):


### PR DESCRIPTION
Aside from being safer and more idiomatic, it's also fewer lines of code.

No functional change, just cleanup.