### PR TITLE
util: Don't check if process.stdin is None unless stdin_string is passed

### DIFF
--- a/nixops/util.py
+++ b/nixops/util.py
@@ -119,10 +119,6 @@ def logged_exec(
             fds = [process.stdout]
         log_fd_opt = process.stdout
 
-    if process.stdin is None:
-        raise ValueError("process.stdin was None")
-    process_stdin: IO[str] = process.stdin
-
     if process.stdout is None:
         raise ValueError("process.stdout was None")
     process_stdout: IO[str] = process.stdout
@@ -134,6 +130,10 @@ def logged_exec(
     # FIXME: this can deadlock if stdin_string doesn't fit in the
     # kernel pipe buffer.
     if stdin_string is not None:
+        if process.stdin is None:
+            raise ValueError("process.stdin was None")
+        process_stdin: IO[str] = process.stdin
+
         # PIPE_BUF is not the size of the kernel pipe buffer (see
         # https://unix.stackexchange.com/questions/11946/how-big-is-the-pipe-buffer)
         # but if something fits in PIPE_BUF, it'll fit in the kernel pipe
@@ -151,8 +151,8 @@ def logged_exec(
                 ).format(select.PIPE_BUF, len(stdin_string))
             )
 
-        process.stdin.write(stdin_string)
-        process.stdin.close()
+        process_stdin.write(stdin_string)
+        process_stdin.close()
 
     for fd in fds:
         make_non_blocking(fd)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,30 @@
+from nixops.logger import Logger
+from io import StringIO
+import unittest
+
+from nixops import util
+
+
+class TestUtilTest(unittest.TestCase):
+    def setUp(self):
+        self.logfile = StringIO()
+        self.root_logger = Logger(self.logfile)
+        self.logger = self.root_logger.get_logger_for("dummymachine")
+
+    def test_assert_logged_exec(self):
+        msg = "hello"
+
+        ret = util.logged_exec(
+            command=["cat"], logger=self.logger, stdin_string=msg, capture_stdout=True,
+        )
+
+        self.assertEqual(ret, msg)
+
+    def test_assert_logged_exec_stdin_none(self):
+        msg = "hello"
+
+        ret = util.logged_exec(
+            command=["echo", msg], logger=self.logger, capture_stdout=True,
+        )
+
+        self.assertEqual(ret.strip(), msg)


### PR DESCRIPTION
When calling subprocess.Popen passing anything except subprocess.PIPE as stdin the results stdin attribute is None.

If a file descriptor was passed as stdin we don't want to run this check.