### PR TITLE
Add support for non-root deployments

### DIFF
--- a/doc/guides/deploy-without-root.rst
+++ b/doc/guides/deploy-without-root.rst
@@ -1,0 +1,95 @@
+Deploying without Root
+====
+
+Requirements
+----
+
+NixOps 2.0 allows for deploying as users other than root, as long
+as the deploying user meets two requirements:
+
+1. The user can become root without needing to type a password.
+2. Nix considers the user to be a `"trusted user" <https://nixos.org/nix/manual/#conf-trusted-users>`_.
+
+In this guide, we will use passwordless sudo.
+
+We assume:
+
+1. The deploying user's name is "deployer".
+2. The target machine's name is "hermes".
+3. The target machine is already managed by NixOps.
+
+Steps
+----
+
+1. Configure the target machine according to the listed requirements.
+2. Update the NixOps network to use our alternative user.
+3. Deploy as the new user.
+
+
+Configuring the Target Machine
+****
+
+First, mark the deploying user as trusted:
+
+.. code-block:: nix
+
+  {
+    nix.trustedUsers = [ "deployer" ];
+  }
+
+This will let the user copy Nix store paths to the target.
+
+Let the deploying user use sudo:
+
+.. code-block:: nix
+
+  {
+    users.users.deployer.extraGroups = [ "wheel" ];
+  }
+
+Then, we configure the machine to have passwordless sudo:
+
+.. code-block:: nix
+
+  {
+    security.sudo.wheelNeedsPassword = false;
+  }
+
+Now use NixOps to deploy these changes to the server before taking
+the next step.
+
+Configuring the NixOps Network
+****
+
+Edit your network.nix to specify the machine's
+``deployment.targetUser``:
+
+.. code-block:: nix
+
+  {
+    network.description = "Non-root deployment";
+
+    hermes =
+      { resources, ... }:
+      {
+        deployment.targetUser = "deployer";
+      };
+  }
+
+
+Testing our Changes
+****
+
+Then, run ``nixops deploy`` to update the NixOps database. This deploy
+will use your "deployer" user instead of root.
+
+Try running ``nixops ssh``, and see that you are logged in as
+"deployer".
+
+Notes
+----
+
+* NixOps caches the target user and related variables in its state
+  file, and commands like ``nixops send-keys`` and ``ssh`` use the
+  cached data. After changing these values, run ``nixops deploy`` to
+  update the cache.

--- a/doc/manual/nixops.xml
+++ b/doc/manual/nixops.xml
@@ -1197,7 +1197,8 @@ machine> instance state is ‘stopped’</screen>
 
 <para>This command opens an SSH connection to the specified machine
 and executes the specified command.  If no command is specified, an
-interactive shell is started.</para>
+interactive shell is started. If no user is specified, the machines
+<literal>deployment.targetUser</literal> is used.</para>
 
 </refsection>
 
@@ -1344,8 +1345,8 @@ local file system. If
 <literal>:<replaceable>remote</replaceable></literal> is omitted, the
 entire remote file system is mounted. If you specify an empty path
 (i.e. <literal>:</literal>), then the home directory of the specified
-user is mounted. If no user is specified, <literal>root</literal> is
-assumed.</para>
+user is mounted. If no user is specified, the machines
+<literal>deployment.targetUser</literal> is used.</para>
 
 <para>This command is implemented using <command>sshfs</command>, so
 you must have <command>sshfs</command> installed and the

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -118,7 +118,7 @@ rec {
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
       foldr (a: b: a // b)
-        { inherit (v.config.deployment) targetEnv targetPort targetHost targetUser sshOptions alwaysActivate owners keys hasFastConnection;
+        { inherit (v.config.deployment) targetEnv targetPort targetHost targetUser sshOptions privilegeEscalationCommand alwaysActivate owners keys hasFastConnection;
           nixosRelease = v.config.system.nixos.release or v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
           publicIPv4 = v.config.networking.publicIPv4;
         }

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -118,7 +118,7 @@ rec {
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
       foldr (a: b: a // b)
-        { inherit (v.config.deployment) targetEnv targetPort targetHost targetUser alwaysActivate owners keys hasFastConnection;
+        { inherit (v.config.deployment) targetEnv targetPort targetHost targetUser sshOptions alwaysActivate owners keys hasFastConnection;
           nixosRelease = v.config.system.nixos.release or v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
           publicIPv4 = v.config.networking.publicIPv4;
         }

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -118,7 +118,7 @@ rec {
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
       foldr (a: b: a // b)
-        { inherit (v.config.deployment) targetEnv targetPort targetHost alwaysActivate owners keys hasFastConnection;
+        { inherit (v.config.deployment) targetEnv targetPort targetHost targetUser alwaysActivate owners keys hasFastConnection;
           nixosRelease = v.config.system.nixos.release or v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
           publicIPv4 = v.config.networking.publicIPv4;
         }

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -64,6 +64,17 @@ in
       '';
     };
 
+    deployment.privilegeEscalationCommand = mkOption {
+      type = types.listOf types.str;
+      default = [ "sudo" "-H" ];
+      description = ''
+        A command to escalate to root privileges when using SSH as a non-root user.
+        This option is ignored if the <literal>targetUser</literal> option is set to <literal>root</literal>.
+
+        The program and its options are executed verbatim without shell.
+      '';
+    };
+
     deployment.alwaysActivate = mkOption {
       type = types.bool;
       default = true;

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -34,9 +34,12 @@ in
       type = types.nullOr types.str;
       default = "root";
       description = ''
-        This option specifies the username to be used by
-        NixOps on the remote system to execute deployment
-        operations.
+        The username to be used by NixOps by SSH when connecting to the
+        remote system.
+
+        If <literal>targetUser<literal> is set to <literal>null<literal>
+        the username is set to the username of the user invoking
+        <literal>nixops<literal>.
       '';
     };
 

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -69,12 +69,15 @@ in
 
     deployment.privilegeEscalationCommand = mkOption {
       type = types.listOf types.str;
-      default = [ "sudo" "-H" ];
+      default = [ "sudo" "-H" "--" ];
       description = ''
         A command to escalate to root privileges when using SSH as a non-root user.
         This option is ignored if the <literal>targetUser</literal> option is set to <literal>root</literal>.
 
         The program and its options are executed verbatim without shell.
+
+        It's good practice to end with "--" to indicate that the privilege escalation command
+        should stop processing command line arguments.
       '';
     };
 

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -30,6 +30,16 @@ in
       '';
     };
 
+    deployment.targetUser = mkOption {
+      type = types.nullOr types.str;
+      default = "root";
+      description = ''
+        This option specifies the username to be used by
+        NixOps on the remote system to execute deployment
+        operations.
+      '';
+    };
+
     deployment.targetHost = mkOption {
       type = types.str;
       description = ''

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -31,16 +31,16 @@ in
     };
 
     deployment.targetUser = mkOption {
-      type = types.nullOr types.str;
+      # type = types.nullOr types.str;
+      type = types.str;
       default = "root";
       description = ''
         The username to be used by NixOps by SSH when connecting to the
         remote system.
-
-        If <literal>targetUser<literal> is set to <literal>null<literal>
-        the username is set to the username of the user invoking
-        <literal>nixops<literal>.
       '';
+      # If <literal>targetUser</literal> is set to <literal>null</literal>
+      # the username is set to the username of the user invoking
+      # </literal>nixops</literal>.
     };
 
     deployment.targetHost = mkOption {

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -56,6 +56,14 @@ in
       '';
     };
 
+    deployment.sshOptions = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = ''
+        Extra options passed to the OpenSSH client verbatim, and are not executed by a shell.
+      '';
+    };
+
     deployment.alwaysActivate = mkOption {
       type = types.bool;
       default = true;

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -54,10 +54,7 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
         self.keys = {k: KeyOptions(**v) for k, v in config["keys"].items()}
         self.ssh_options = config["sshOptions"]
 
-        self.ssh_user = getpass.getuser()
-        ssh_user = config["targetUser"]
-        if ssh_user is not None:
-            self.ssh_user = ssh_user
+        self.ssh_user = config["targetUser"]
 
         self.privilege_escalation_command = config["privilegeEscalationCommand"]
 

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -43,6 +43,7 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
     keys: Mapping[str, KeyOptions]
     ssh_user: str
     ssh_options: List[str]
+    privilege_escalation_command: List[str]
 
     def __init__(self, name: str, config: nixops.resources.ResourceEval):
         super().__init__(name, config)
@@ -57,6 +58,8 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
         ssh_user = config["targetUser"]
         if ssh_user is not None and ssh_user:
             self.ssh_user = ssh_user
+
+        self.privilege_escalation_command = config["privilegeEscalationCommand"]
 
 
 class MachineState(nixops.resources.ResourceState):
@@ -116,6 +119,8 @@ class MachineState(nixops.resources.ResourceState):
         self.has_fast_connection = defn.has_fast_connection
         if not self.has_fast_connection:
             self.ssh.enable_compression()
+
+        self.ssh.privilege_escalation_command = list(defn.privilege_escalation_command)
 
     def stop(self) -> None:
         """Stop this machine, if possible."""

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -56,7 +56,7 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
 
         self.ssh_user = getpass.getuser()
         ssh_user = config["targetUser"]
-        if ssh_user is not None and ssh_user:
+        if ssh_user is not None:
             self.ssh_user = ssh_user
 
         self.privilege_escalation_command = config["privilegeEscalationCommand"]

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -70,6 +70,9 @@ class MachineState(nixops.resources.ResourceState):
     ssh_port: int = nixops.util.attr_property("targetPort", 22, int)
     ssh_user: str = nixops.util.attr_property("targetUser", "root", str)
     ssh_options: List[str] = nixops.util.attr_property("sshOptions", [], "json")
+    privilege_escalation_command: List[str] = nixops.util.attr_property(
+        "privilegeEscalationCommand", [], "json"
+    )
     public_vpn_key: Optional[str] = nixops.util.attr_property("publicVpnKey", None)
     keys: Mapping[str, str] = nixops.util.attr_property("keys", {}, "json")
     owners: List[str] = nixops.util.attr_property("owners", [], "json")
@@ -99,6 +102,7 @@ class MachineState(nixops.resources.ResourceState):
         self.ssh.register_passwd_fun(self.get_ssh_password)
         self._ssh_private_key_file: Optional[str] = None
         self.new_toplevel: Optional[str] = None
+        self.ssh.privilege_escalation_command = self.privilege_escalation_command
 
     def prefix_definition(self, attr):
         return attr
@@ -118,6 +122,7 @@ class MachineState(nixops.resources.ResourceState):
             self.ssh.enable_compression()
 
         self.ssh.privilege_escalation_command = list(defn.privilege_escalation_command)
+        self.privilege_escalation_command = list(defn.privilege_escalation_command)
 
     def stop(self) -> None:
         """Stop this machine, if possible."""

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -771,8 +771,20 @@ def op_import(args):
                             nixops.known_hosts.add(m.private_ipv4, m.public_host_key)
 
 
-def parse_machine(name):
-    return ("root", name) if name.find("@") == -1 else name.split("@", 1)
+def parse_machine(name, depl):
+    username, machine_name = (None, name) if name.find("@") == -1 else name.split("@", 1)
+    m = depl.machines.get(machine_name)
+
+    if not m:
+        raise Exception("unknown machine ‘{0}’".format(machine_name))
+
+    if not username and m.ssh_user:
+        username = m.ssh_user
+
+    if username is None:
+        username = "root"
+
+    return username, machine_name
 
 
 def op_ssh(args):

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -785,7 +785,7 @@ def op_ssh(args):
         sys.exit(
             m.ssh.run_command(
                 command,
-                flags,
+                flags=flags,
                 check=False,
                 logged=False,
                 allow_ssh_args=True,
@@ -804,8 +804,9 @@ def op_ssh_for_each(args):
                     m, args.include or [], args.exclude or []
                 ):
                     return None
+
                 return m.ssh.run_command_get_status(
-                    args.args, allow_ssh_args=True, check=False
+                    args.args, allow_ssh_args=True, check=False, user=m.ssh_user
                 )
 
             results = results + nixops.parallel.run_tasks(

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -782,7 +782,6 @@ def op_ssh(args):
         if not m:
             raise Exception("unknown machine ‘{0}’".format(machine))
         flags, command = m.ssh.split_openssh_args(args.args)
-        user = None if username == "root" else username
         sys.exit(
             m.ssh.run_command(
                 command,
@@ -790,7 +789,7 @@ def op_ssh(args):
                 check=False,
                 logged=False,
                 allow_ssh_args=True,
-                user=user,
+                user=username,
             )
         )
 

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -172,7 +172,7 @@ class SSH(object):
     def _get_target(self, user: str) -> str:
         if self._host_fun is None:
             raise AssertionError("don't know which SSH host to connect to")
-        return "{0}@{1}".format("root" if user is None else user, self._host_fun())
+        return "{0}@{1}".format(user, self._host_fun())
 
     def register_flag_fun(self, flag_fun: Callable[[], List[str]]) -> None:
         """

--- a/nixops/ssh_util.py
+++ b/nixops/ssh_util.py
@@ -160,6 +160,7 @@ class SSH(object):
         self._logger = logger
         self._ssh_master: Optional[SSHMaster] = None
         self._compress = False
+        self.privilege_escalation_command: List[str] = []
 
     def register_host_fun(self, host_fun: Callable[[], str]) -> None:
         """
@@ -307,7 +308,7 @@ class SSH(object):
             )
 
         if user and user != "root":
-            cmd.insert(0, "sudo")
+            cmd = self.privilege_escalation_command + cmd
 
         return ["--", nixops.util.shlex_join(cmd)]
 


### PR DESCRIPTION
This adds a new `deployment` configuration attribute (`targetUser`).
To inherit the username from the local user issuing the deployment
set:
``` nix
deployment.targetUser = null;
```
Setting this to a string will deploy as that user. This option
defaults to "root".

 ### We assume the following for non-root deploys:

- Passwordless sudo (no TTY allocation possible)

I'm using the following NixOS configuration
``` nix
security.pam.services.sudo.sshAgentAuth = true;
security.pam.enableSSHAgentAuth = true;
```

For this use-case I've introduced:
``` nix
deployment.sshOptions = [ "-A" ];
```

- The deployment user is trusted by the Nix daemon
``` nix
nix.trustedUsers = [ "adisbladis" ];
```
This is required because of nix-copy-closure.

Closes https://github.com/NixOS/nixops/issues/730