### PR TITLE
Move from xml intermediate Nix representation to JSON

### DIFF
--- a/doc/plugins/authoring.rst
+++ b/doc/plugins/authoring.rst
@@ -113,6 +113,34 @@ Important Notes
              os.path.dirname(os.path.abspath(__file__)) + "/nix"
          ]
 
+5. Resource subclasses must now work with Python objects instead of XML
+
+   This old-style ResourceDefinition subclass:
+
+   .. code-block:: python
+
+     class MachineDefinition(nixops.resources.ResourceDefinition):
+
+         def __init__(self, xml):
+             super().__init__(xml)
+             self.store_keys_on_machine = (
+                 xml.find("attrs/attr[@name='storeKeysOnMachine']/bool").get("value")
+                 == "true"
+             )
+
+   Should now look like:
+
+   .. code-block:: python
+
+     class MachineDefinition(nixops.resources.ResourceDefinition):
+
+         store_keys_on_machine: bool
+
+         def __init__(self, name: str, config: nixops.resources.ResourceOptions):
+             super().__init__(name, config)
+             self.store_keys_on_machine = config["storeKeysOnMachine"]
+
+
 On with Poetry
 ----
 

--- a/doc/plugins/authoring.rst
+++ b/doc/plugins/authoring.rst
@@ -136,7 +136,7 @@ Important Notes
 
          store_keys_on_machine: bool
 
-         def __init__(self, name: str, config: nixops.resources.ResourceOptions):
+         def __init__(self, name: str, config: nixops.resources.ResourceEval):
              super().__init__(name, config)
              self.store_keys_on_machine = config["storeKeysOnMachine"]
 

--- a/doc/plugins/authoring.rst
+++ b/doc/plugins/authoring.rst
@@ -132,13 +132,25 @@ Important Notes
 
    .. code-block:: python
 
+     class MachineOptions(nixops.resources.ResourceOptions):
+         storeKeysOnMachine: bool
+
      class MachineDefinition(nixops.resources.ResourceDefinition):
+
+         config: MachineOptions
 
          store_keys_on_machine: bool
 
          def __init__(self, name: str, config: nixops.resources.ResourceEval):
              super().__init__(name, config)
-             self.store_keys_on_machine = config["storeKeysOnMachine"]
+             self.store_keys_on_machine = config.storeKeysOnMachine
+
+   ``ResourceEval`` is an immutable ``typing.Mapping`` implementation.
+   Also note that ``ResourceEval`` has turned Nix lists into Python tuples, dictionaries into ResourceEval objects and so on.
+   ``typing.Tuple`` cannot be used as it's fixed-size, use ``typing.Sequence`` instead.
+
+   ``ResourceOptions`` is an immutable object that provides type validation both with ``mypy`` _and_ at runtime.
+   Any attributes which are not explicitly typed are passed through as-is.
 
 
 On with Poetry

--- a/doc/plugins/authoring.rst
+++ b/doc/plugins/authoring.rst
@@ -119,7 +119,7 @@ Important Notes
 
    .. code-block:: python
 
-     class MachineDefinition(nixops.resources.ResourceDefinition):
+     class NeatCloudMachineDefinition(nixops.resources.ResourceDefinition):
 
          def __init__(self, xml):
              super().__init__(xml)
@@ -132,10 +132,10 @@ Important Notes
 
    .. code-block:: python
 
-     class MachineOptions(nixops.resources.ResourceOptions):
+     class NeatCloudMachineOptions(nixops.resources.ResourceOptions):
          storeKeysOnMachine: bool
 
-     class MachineDefinition(nixops.resources.ResourceDefinition):
+     class NeatCloudMachineDefinition(nixops.resources.ResourceDefinition):
 
          config: MachineOptions
 

--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -156,8 +156,8 @@ in
   config = {
 
     assertions = flip mapAttrsToList config.deployment.keys (key: opts: {
-      assertion = (opts.text == null && opts.keyFile != null) ||
-                  (opts.text != null && opts.keyFile == null);
+      assertion = (opts.text == null && opts.keyFile != "") ||
+                  (opts.text != null && opts.keyFile == "");
       message = "Deployment key '${key}' must have either a 'text' or a 'keyFile' specified.";
     });
 

--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -23,6 +23,7 @@ let
     options.keyFile = mkOption {
       default = null;
       type = types.nullOr types.path;
+      apply = toString;
       description = ''
         When non-null, contents of the specified file will be deployed to the
         specified key on the target machine.  If the key name is

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -1,27 +1,28 @@
 # -*- coding: utf-8 -*-
+from typing import Dict, Optional
 import os
 import sys
 import nixops.util
 
 from nixops.backends import MachineDefinition, MachineState
 from nixops.util import attr_property, create_key_pair
+import nixops.resources
 
 
 class NoneDefinition(MachineDefinition):
     """Definition of a trivial machine."""
 
+    _target_host: str
+    _public_ipv4: Optional[str]
+
     @classmethod
     def get_type(cls):
         return "none"
 
-    def __init__(self, xml, config):
-        MachineDefinition.__init__(self, xml, config)
-        self._target_host = xml.find("attrs/attr[@name='targetHost']/string").get(
-            "value"
-        )
-
-        public_ipv4 = xml.find("attrs/attr[@name='publicIPv4']/string")
-        self._public_ipv4 = None if public_ipv4 is None else public_ipv4.get("value")
+    def __init__(self, name: str, config: nixops.resources.ResourceOptions):
+        super().__init__(name, config)
+        self._target_host = config["targetHost"]
+        self._public_ipv4 = config.get("publicIPv4", None)
 
 
 class NoneState(MachineState):

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -4,7 +4,7 @@ import os
 import sys
 import nixops.util
 
-from nixops.backends import MachineDefinition, MachineState
+from nixops.backends import MachineDefinition, MachineState, MachineOptions
 from nixops.util import attr_property, create_key_pair
 import nixops.resources
 
@@ -15,11 +15,13 @@ class NoneDefinition(MachineDefinition):
     _target_host: str
     _public_ipv4: Optional[str]
 
+    config: MachineOptions
+
     @classmethod
     def get_type(cls):
         return "none"
 
-    def __init__(self, name: str, config: nixops.resources.ResourceOptions):
+    def __init__(self, name: str, config: nixops.resources.ResourceEval):
         super().__init__(name, config)
         self._target_host = config["targetHost"]
         self._public_ipv4 = config.get("publicIPv4", None)

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -594,13 +594,13 @@ class Deployment:
             attrs_list = attrs_per_resource[m.name]
 
             # Set system.stateVersion if the Nixpkgs version supports it.
-            nixos_version = nixops.util.parse_nixos_version(defn.config["nixosRelease"])
+            nixos_version = nixops.util.parse_nixos_version(defn.config.nixosRelease)
             if nixos_version >= ["15", "09"]:
                 attrs_list.append(
                     {
                         ("system", "stateVersion"): Call(
                             RawValue("lib.mkDefault"),
-                            m.state_version or defn.config["nixosRelease"],
+                            m.state_version or defn.config.nixosRelease,
                         )
                     }
                 )
@@ -1671,7 +1671,7 @@ def _create_definition(
 
     for cls in _subclasses(nixops.resources.ResourceDefinition):
         if type_name == cls.get_resource_type():
-            return cls(name, nixops.resources.ResourceOptions(config))
+            return cls(name, nixops.resources.ResourceEval(config))
 
     raise nixops.deployment.UnknownBackend(
         "unknown resource type ‘{0}’".format(type_name)

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -9,7 +9,6 @@ import tempfile
 import sqlite3
 import threading
 from collections import defaultdict
-from xml.etree import ElementTree
 import re
 from datetime import datetime, timedelta
 import getpass
@@ -440,16 +439,15 @@ class Deployment:
         except subprocess.CalledProcessError:
             raise NixEvalError
 
-    def evaluate_config(self, attr):
+    def evaluate_config(self, attr) -> Dict:
         try:
-            # FIXME: use --json
-            xml = subprocess.check_output(
+            _json = subprocess.check_output(
                 ["nix-instantiate"]
                 + self.extra_nix_eval_flags
                 + self._eval_flags(self.nix_exprs)
                 + [
                     "--eval-only",
-                    "--xml",
+                    "--json",
                     "--strict",
                     "--arg",
                     "checkConfigurationOptions",
@@ -461,25 +459,19 @@ class Deployment:
                 text=True,
             )
             if DEBUG:
-                print("XML output of nix-instantiate:\n" + xml, file=sys.stderr)
+                print("JSON output of nix-instantiate:\n" + _json, file=sys.stderr)
         except OSError as e:
             raise Exception("unable to run ‘nix-instantiate’: {0}".format(e))
         except subprocess.CalledProcessError:
             raise NixEvalError
 
-        tree = ElementTree.fromstring(xml)
-
-        # Convert the XML to a more Pythonic representation. This is
-        # in fact the same as what json.loads() on the output of
-        # "nix-instantiate --json" would yield.
-        config = nixops.util.xml_expr_to_python(tree.find("*"))
-        return (tree, config)
+        return json.loads(_json)
 
     def evaluate_network(self, action: str = "") -> None:
         if not self.network_attr_eval:
             # Extract global deployment attributes.
             try:
-                (_, config) = self.evaluate_config("info.network")
+                config = self.evaluate_config("info.network")
             except Exception as e:
                 if action not in ("destroy", "delete"):
                     raise e
@@ -494,22 +486,20 @@ class Deployment:
         self.definitions = {}
         self.evaluate_network()
 
-        (tree, config) = self.evaluate_config("info")
+        config = self.evaluate_config("info")
+
+        tree = None
 
         # Extract machine information.
-        for x in tree.findall("attrs/attr[@name='machines']/attrs/attr"):
-            name = x.get("name")
-            cfg = config["machines"][name]
-            defn = _create_definition(x, cfg, cfg["targetEnv"])
+        for name, cfg in config["machines"].items():
+            defn = _create_definition(name, cfg, cfg["targetEnv"])
             self.definitions[name] = defn
 
         # Extract info about other kinds of resources.
-        for x in tree.findall("attrs/attr[@name='resources']/attrs/attr"):
-            res_type = x.get("name")
-            for y in x.findall("attrs/attr"):
-                name = y.get("name")
+        for res_type, cfg in config["resources"].items():
+            for name, y in cfg.items():
                 defn = _create_definition(
-                    y, config["resources"][res_type][name], res_type
+                    name, config["resources"][res_type][name], res_type
                 )
                 self.definitions[name] = defn
 
@@ -1674,16 +1664,14 @@ def _subclasses(cls: Any) -> List[Any]:
     return [cls] if not sub else [g for s in sub for g in _subclasses(s)]
 
 
-def _create_definition(xml: Any, config: Dict[str, Any], type_name: str) -> Any:
+def _create_definition(
+    name: str, config: Dict[str, Any], type_name: str
+) -> nixops.resources.ResourceDefinition:
     """Create a resource definition object from the given XML representation of the machine's attributes."""
 
     for cls in _subclasses(nixops.resources.ResourceDefinition):
         if type_name == cls.get_resource_type():
-            # FIXME: backward compatibility hack
-            if len(inspect.getargspec(cls.__init__).args) == 2:
-                return cls(xml)
-            else:
-                return cls(xml, config)
+            return cls(name, nixops.resources.ResourceOptions(config))
 
     raise nixops.deployment.UnknownBackend(
         "unknown resource type ‘{0}’".format(type_name)

--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -3,12 +3,13 @@
 import re
 import nixops.util
 from threading import Event
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Iterator
 from nixops.state import StateDict
 from nixops.diff import Diff, Handler
+from nixops.util import ImmutableMapping
 
 
-class ResourceOptions(dict):
+class ResourceOptions(ImmutableMapping[Any, Any]):
     pass
 
 

--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -8,7 +8,11 @@ from nixops.state import StateDict
 from nixops.diff import Diff, Handler
 
 
-class ResourceDefinition(object):
+class ResourceOptions(dict):
+    pass
+
+
+class ResourceDefinition:
     """Base class for NixOps resource definitions."""
 
     @classmethod
@@ -21,10 +25,10 @@ class ResourceDefinition(object):
         """A resource type identifier corresponding to the resources.<type> attribute in the Nix expression"""
         return cls.get_type()
 
-    def __init__(self, xml, config={}):
+    def __init__(self, name: str, config: ResourceOptions):
         self.config = config
-        self.name = xml.get("name")
-        assert self.name
+        self.name = name
+
         if not re.match("^[a-zA-Z0-9_\-][a-zA-Z0-9_\-\.]*$", self.name):
             raise Exception("invalid resource name ‘{0}’".format(self.name))
 

--- a/nixops/resources/commandOutput.py
+++ b/nixops/resources/commandOutput.py
@@ -14,7 +14,6 @@ import hashlib
 
 # For typing
 from nixops.deployment import Deployment
-from xml.etree.ElementTree import Element
 from nixops.nix_expr import Function
 from typing import Optional, List, Dict, Tuple
 

--- a/nixops/resources/commandOutput.py
+++ b/nixops/resources/commandOutput.py
@@ -15,11 +15,19 @@ import hashlib
 # For typing
 from nixops.deployment import Deployment
 from nixops.nix_expr import Function
+from nixops.resources import ResourceOptions
 from typing import Optional, List, Dict, Tuple
+
+
+class CommandOutputOptions(ResourceOptions):
+    script: str
+    name: str
 
 
 class CommandOutputDefinition(nixops.resources.ResourceDefinition):
     """Definition of a Command Output."""
+
+    config: CommandOutputOptions
 
     @classmethod
     def get_type(cls):
@@ -65,8 +73,8 @@ class CommandOutputState(nixops.resources.ResourceState):
     def create(self, defn, check, allow_reboot, allow_recreate):
         # type: (CommandOutputDefinition,bool,bool,bool) -> None
         if (
-            (defn.config["script"] is not None)
-            and (self.script != defn.config["script"])
+            (defn.config.script is not None)
+            and (self.script != defn.config.script)
             or self.value is None
         ):
             self.commandName = defn.name
@@ -80,12 +88,12 @@ class CommandOutputState(nixops.resources.ResourceState):
                 env.update(os.environ)
                 env.update({"out": output_dir})
                 res = subprocess.check_output(
-                    [defn.config["script"]], env=env, shell=True, text=True
+                    [defn.config.script], env=env, shell=True, text=True
                 )
                 with self.depl._db:
                     self.value = res
                     self.state = self.UP
-                    self.script = defn.config["script"]
+                    self.script = defn.config.script
             except Exception as e:
                 self.log("Creation failed for output ‘{0}’...".format(defn.name))
                 raise

--- a/nixops/resources/ssh_keypair.py
+++ b/nixops/resources/ssh_keypair.py
@@ -18,7 +18,7 @@ class SSHKeyPairDefinition(nixops.resources.ResourceDefinition):
     def get_resource_type(cls):
         return "sshKeyPairs"
 
-    def __init__(self, name: str, config: nixops.resources.ResourceOptions):
+    def __init__(self, name: str, config: nixops.resources.ResourceEval):
         super().__init__(name, config)
 
     def show_type(self):

--- a/nixops/resources/ssh_keypair.py
+++ b/nixops/resources/ssh_keypair.py
@@ -2,6 +2,7 @@
 
 # Automatic provisioning of SSH key pairs.
 
+from typing import Dict
 import nixops.util
 import nixops.resources
 
@@ -17,8 +18,8 @@ class SSHKeyPairDefinition(nixops.resources.ResourceDefinition):
     def get_resource_type(cls):
         return "sshKeyPairs"
 
-    def __init__(self, xml):
-        nixops.resources.ResourceDefinition.__init__(self, xml)
+    def __init__(self, name: str, config: nixops.resources.ResourceOptions):
+        super().__init__(name, config)
 
     def show_type(self):
         return "{0}".format(self.get_type())

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -735,7 +735,7 @@ def op_export(args):
     with one_or_all(args) as depls:
         for depl in depls:
             res[depl.uuid] = depl.export()
-    print(json.dumps(res, indent=2, sort_keys=True))
+    print(json.dumps(res, indent=2, sort_keys=True, cls=nixops.util.NixopsEncoder))
 
 
 def op_import(args):

--- a/nixops/state.py
+++ b/nixops/state.py
@@ -28,7 +28,7 @@ class StateDict(collections.MutableMapping):
             else:
                 v = value
                 if isinstance(value, list):
-                    v = json.dumps(value)
+                    v = json.dumps(value, cls=nixops.util.NixopsEncoder)
                 c.execute(
                     "insert or replace into ResourceAttrs(machine, name, value) values (?, ?, ?)",
                     (self.id, key, v),

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -500,45 +500,6 @@ def write_file(path: str, contents: str) -> None:
         f.write(contents)
 
 
-def xml_expr_to_python(node):
-    res: Any
-    if node.tag == "attrs":
-        res = {}
-        for attr in node.findall("attr"):
-            if attr.get("name") != "_module":
-                res[attr.get("name")] = xml_expr_to_python(attr.find("*"))
-        return res
-
-    elif node.tag == "list":
-        res = []
-        for elem in node.findall("*"):
-            res.append(xml_expr_to_python(elem))
-        return res
-
-    elif node.tag == "string":
-        return node.get("value")
-
-    elif node.tag == "path":
-        return node.get("value")
-
-    elif node.tag == "bool":
-        return node.get("value") == "true"
-
-    elif node.tag == "int":
-        return int(node.get("value"))
-
-    elif node.tag == "null":
-        return None
-
-    elif node.tag == "derivation":
-        return {"drvPath": node.get("drvPath/"), "outPath": node.get("outPath")}
-
-    raise Exception(
-        "cannot convert XML output of nix-instantiate to Python: Unknown tag "
-        + node.tag
-    )
-
-
 def parse_nixos_version(s: str) -> List[str]:
     """Split a NixOS version string into a list of components."""
     return s.split(".")

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -136,7 +136,7 @@ class ImmutableValidatedObject:
                 return value
 
             if inspect.isclass(ann) and issubclass(ann, ImmutableValidatedObject):
-                return ann(**value)
+                value = ann(**value)
 
             typeguard.check_type(key, value, ann)
 

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -172,6 +172,13 @@ class ImmutableValidatedObject:
         return "{}({})".format(self.__class__.__name__, ", ".join(attrs))
 
 
+class NixopsEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, ImmutableMapping):
+            return dict(obj)
+        return json.JSONEncoder.default(self, obj)
+
+
 def logged_exec(
     command: List[str],
     logger: MachineLogger,
@@ -439,7 +446,7 @@ def attr_property(name: str, default: Any, type: Optional[Any] = str) -> Any:
         if x == default:
             self._del_attr(name)
         elif type is "json":
-            self._set_attr(name, json.dumps(x))
+            self._set_attr(name, json.dumps(x, cls=NixopsEncoder))
         else:
             self._set_attr(name, x)
 

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -142,7 +142,8 @@ class ImmutableValidatedObject:
 
             return value
 
-        for key, value in kwargs.items():
+        for key in set(list(anno.keys()) + list(kwargs.keys())):
+            value = kwargs.get(key)
             setattr(self, key, _transform_value(key, value))
 
         self._frozen = True
@@ -151,6 +152,12 @@ class ImmutableValidatedObject:
         if hasattr(self, "_frozen") and self._frozen:
             raise AttributeError(f"{self.__class__.__name__} is immutable")
         super().__setattr__(name, value)
+
+    def __iter__(self):
+        for attr, value in self.__dict__.items():
+            if attr == "_frozen":
+                continue
+            yield attr, value
 
     def __repr__(self) -> str:
         anno: Dict = self.__annotations__
@@ -174,7 +181,7 @@ class ImmutableValidatedObject:
 
 class NixopsEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, ImmutableMapping):
+        if isinstance(obj, (ImmutableMapping, ImmutableValidatedObject)):
             return dict(obj)
         return json.JSONEncoder.default(self, obj)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -167,6 +167,18 @@ python-versions = "*"
 version = "1.4.1"
 
 [[package]]
+category = "main"
+description = "Run-time type checker for Python"
+name = "typeguard"
+optional = false
+python-versions = ">=3.5.2"
+version = "2.7.1"
+
+[package.extras]
+doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["pytest", "pytest-cov", "typing-extensions"]
+
+[[package]]
 category = "dev"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 name = "typing-extensions"
@@ -188,7 +200,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "283758300f3fc395ecd3ad0e43ebc401768dd4ccec7575b9f6eed71dc6c7e5c9"
+content-hash = "55664a747de02fb0e60b8096bca1a7f7e562cbf3de2178d5d15124db98c799c5"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -329,6 +341,10 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
+typeguard = [
+    {file = "typeguard-2.7.1-py3-none-any.whl", hash = "sha256:1d3710251d3d3d6c64e0c49f45edec2e88ddc386a51e89c3ec0703efeb8b3b81"},
+    {file = "typeguard-2.7.1.tar.gz", hash = "sha256:2d545c71e9439c21bcd7c28f5f55b3606e6106f7031ab58375656a1aed483ef2"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.1-py2-none-any.whl", hash = "sha256:910f4656f54de5993ad9304959ce9bb903f90aadc7c67a0bef07e678014e892d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ include = ["nix/*.nix", "nixops/py.typed" ]
 python = "^3.7"
 PrettyTable = "^0.7.2"
 pluggy = "^0.13.1"
+typeguard = "^2.7.1"
 
 [tool.poetry.dev-dependencies]
 nose = "^1.3.7"

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -60,3 +60,22 @@ class TestUtilTest(unittest.TestCase):
             i["z"] = 1
 
         self.assertRaises(TypeError, _assign)
+
+    def test_immutable_object(self):
+        class SubResource(util.ImmutableValidatedObject):
+            x: int
+
+        class HasSubResource(util.ImmutableValidatedObject):
+            sub: SubResource
+
+        r = HasSubResource(sub={"x": 1})
+        self.assertTrue(isinstance(r.sub.x, int))
+        self.assertEqual(r.sub.x, 1)
+
+        self.assertRaises(TypeError, lambda: SubResource(x="a string"))
+
+        def _assign():
+            r = SubResource(x=1)
+            r.x = 2
+
+        self.assertRaises(AttributeError, _assign)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -28,3 +28,35 @@ class TestUtilTest(unittest.TestCase):
         )
 
         self.assertEqual(ret.strip(), msg)
+
+    def test_immutable_dict(self):
+        d = {
+            "foo": "bar",
+            "list": [1, 2, 3],
+            "nested": {"x": "y",},
+            "nested_in_list": [{"x": "y",}],
+        }
+
+        # Assert that the shape of the immutable dict is the same as the input dict
+
+        i = util.ImmutableMapping(d)
+        self.assertEqual(d["foo"], i["foo"])
+
+        tup = i["list"]
+        self.assertTrue(isinstance(tup, tuple))
+        self.assertEqual(list(tup), d["list"])
+
+        dic = i["nested"]
+        self.assertTrue(isinstance(dic, util.ImmutableMapping))
+        self.assertEqual(
+            dic["x"], d["nested"]["x"],
+        )
+
+        dic_l = i["nested_in_list"][0]
+        self.assertTrue(isinstance(dic_l, util.ImmutableMapping))
+
+        # Assert immutability
+        def _assign():
+            i["z"] = 1
+
+        self.assertRaises(TypeError, _assign)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,3 +1,4 @@
+import json
 from nixops.logger import Logger
 from io import StringIO
 import unittest
@@ -45,6 +46,9 @@ class TestUtilTest(unittest.TestCase):
         tup = i["list"]
         self.assertTrue(isinstance(tup, tuple))
         self.assertEqual(list(tup), d["list"])
+
+        # Ensure our encoder round-trips okay
+        self.assertEqual(json.dumps(i, cls=util.NixopsEncoder), json.dumps(d))
 
         dic = i["nested"]
         self.assertTrue(isinstance(dic, util.ImmutableMapping))

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -83,3 +83,9 @@ class TestUtilTest(unittest.TestCase):
             r.x = 2
 
         self.assertRaises(AttributeError, _assign)
+
+        # Fuzz not passed, should raise TypeError
+        class MustRaise(util.ImmutableValidatedObject):
+            fuzz: str
+
+        self.assertRaises(TypeError, lambda: MustRaise())


### PR DESCRIPTION
This change is intended to make life easier for plugin authors.
We have removed the XML parameter to ResourceDefinition and you are
now only provided with a name & a dict containing the evaluated
values.

Note that this **_will_** break all current plugins.

An example of this in use in a plugin can be found here: https://github.com/adisbladis/nixops-terraform.