### PR TITLE
Added a keyCmd option for fetching a key from local command

### DIFF
--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -15,11 +15,33 @@ let
         <filename><replaceable>destDir</replaceable>/<replaceable>password</replaceable></filename>
         will be <literal>foobar</literal>.
 
-        NOTE: Either <literal>text</literal> or <literal>keyFile</literal> have
-        to be set.
+        NOTE: Either <literal>text</literal>, <literal>keyCmd</literal> or
+        <literal>keyFile</literal> have to be set.
       '';
     };
 
+    options.keyCmd = mkOption {
+      default = null;
+      example = "pass show secrettoken";
+      type = types.nullOr types.str;
+      description = ''
+        When non-null, output of this command run on local machine will be
+        deployed to the specified key on the target machine.  If the key name
+        is
+        <replaceable>password</replaceable> and <literal>echo secrettoken</literal>
+        is set here, the contents of the file
+        <filename><replaceable>destDir</replaceable>/<replaceable>password</replaceable></filename>
+        deployed will equal the output of the command <literal>echo secrettoken</literal>.
+
+        This option is especially useful when you don't want to store the secrets
+        inside of your NixOps deployment but rather in a well-guarded place such as an
+        encrypted file. Consider using nixpkgs.password-store as storage for
+        such sensitive secrets.
+
+        NOTE: Either <literal>text</literal>, <literal>keyCmd</literal> or
+        <literal>keyFile</literal> have to be set.
+      '';
+    };
     options.keyFile = mkOption {
       default = null;
       type = types.nullOr types.path;
@@ -36,8 +58,8 @@ let
         are no limits on that content: null bytes, invalid Unicode,
         <literal>/dev/random</literal> output -- anything goes.
 
-        NOTE: Either <literal>text</literal> or <literal>keyFile</literal> have
-        to be set.
+        NOTE: Either <literal>text</literal>, <literal>keyCmd</literal> or
+        <literal>keyFile</literal> have to be set.
       '';
     };
 
@@ -155,11 +177,12 @@ in
 
   config = {
 
-    assertions = flip mapAttrsToList config.deployment.keys (key: opts: {
-      assertion = (opts.text == null && opts.keyFile != "") ||
-                  (opts.text != null && opts.keyFile == "");
-      message = "Deployment key '${key}' must have either a 'text' or a 'keyFile' specified.";
-    });
+    assertions = (flip mapAttrsToList config.deployment.keys (key: opts: {
+      assertion = (opts.text == null && opts.keyFile != "" && opts.keyCmd == null) ||
+                  (opts.text != null && opts.keyFile == "" && opts.keyCmd == null) ||
+                  (opts.text == null && opts.keyFile == "" && opts.keyCmd != null);
+      message = "Deployment key '${key}' must have either a 'text', 'keyCmd' or a 'keyFile' specified.";
+    }));
 
     system.activationScripts.nixops-keys =
       let

--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -15,15 +15,15 @@ let
         <filename><replaceable>destDir</replaceable>/<replaceable>password</replaceable></filename>
         will be <literal>foobar</literal>.
 
-        NOTE: Either <literal>text</literal>, <literal>keyCmd</literal> or
+        NOTE: Either <literal>text</literal>, <literal>keyCommand</literal> or
         <literal>keyFile</literal> have to be set.
       '';
     };
 
-    options.keyCmd = mkOption {
+    options.keyCommand = mkOption {
       default = null;
-      example = "pass show secrettoken";
-      type = types.nullOr types.str;
+      example = [ "pass" "show" "secrettoken" ];
+      type = types.nullOr (types.listOf types.str);
       description = ''
         When non-null, output of this command run on local machine will be
         deployed to the specified key on the target machine.  If the key name
@@ -38,14 +38,14 @@ let
         encrypted file. Consider using nixpkgs.password-store as storage for
         such sensitive secrets.
 
-        NOTE: Either <literal>text</literal>, <literal>keyCmd</literal> or
+        NOTE: Either <literal>text</literal>, <literal>keyCommand</literal> or
         <literal>keyFile</literal> have to be set.
       '';
     };
     options.keyFile = mkOption {
       default = null;
       type = types.nullOr types.path;
-      apply = toString;
+      apply = value: if value == null then null else toString value;
       description = ''
         When non-null, contents of the specified file will be deployed to the
         specified key on the target machine.  If the key name is
@@ -58,7 +58,7 @@ let
         are no limits on that content: null bytes, invalid Unicode,
         <literal>/dev/random</literal> output -- anything goes.
 
-        NOTE: Either <literal>text</literal>, <literal>keyCmd</literal> or
+        NOTE: Either <literal>text</literal>, <literal>keyCommand</literal> or
         <literal>keyFile</literal> have to be set.
       '';
     };
@@ -178,10 +178,10 @@ in
   config = {
 
     assertions = (flip mapAttrsToList config.deployment.keys (key: opts: {
-      assertion = (opts.text == null && opts.keyFile != "" && opts.keyCmd == null) ||
-                  (opts.text != null && opts.keyFile == "" && opts.keyCmd == null) ||
-                  (opts.text == null && opts.keyFile == "" && opts.keyCmd != null);
-      message = "Deployment key '${key}' must have either a 'text', 'keyCmd' or a 'keyFile' specified.";
+      assertion = (opts.text == null && opts.keyFile != null && opts.keyCommand == null) ||
+                  (opts.text != null && opts.keyFile == null && opts.keyCommand == null) ||
+                  (opts.text == null && opts.keyFile == null && opts.keyCommand != null);
+      message = "Deployment key '${key}' must have either a 'text', 'keyCommand' or a 'keyFile' specified.";
     }));
 
     system.activationScripts.nixops-keys =

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -6,12 +6,13 @@ from typing import Mapping, Any, List, Optional, Union, Sequence
 import nixops.util
 import nixops.resources
 import nixops.ssh_util
+import subprocess
 
 
 class KeyOptions(nixops.resources.ResourceOptions):
     text: Optional[str]
     keyFile: Optional[str]
-    keyCmd: Optional[str]
+    keyCommand: Optional[Sequence[str]]
     destDir: str
     user: str
     group: str
@@ -296,12 +297,12 @@ class MachineState(nixops.resources.ResourceState):
                     f.write(opts["text"])
             elif opts.get("keyFile") is not None:
                 self._logged_exec(["cp", opts["keyFile"], tmp])
-            elif opts.get("keyCmd") is not None:
+            elif opts.get("keyCommand") is not None:
                 with open(tmp, "w+") as f:
-                    subprocess.Popen(opts["keyCmd"], stdout=f, shell=True)
+                    subprocess.run(opts["keyCommand"], stdout=f, check=True)
             else:
                 raise Exception(
-                    "Neither 'text' or 'keyFile' options were set for key '{0}'.".format(
+                    "Neither 'text', 'keyFile', nor 'keyCommand' options were set for key '{0}'.".format(
                         k
                     )
                 )

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -11,6 +11,7 @@ import nixops.ssh_util
 class KeyOptions(nixops.resources.ResourceOptions):
     text: Optional[str]
     keyFile: Optional[str]
+    keyCmd: Optional[str]
     destDir: str
     user: str
     group: str
@@ -290,11 +291,14 @@ class MachineState(nixops.resources.ResourceState):
                 ).format(destDir)
             )
 
-            if opts["text"] is not None:
+            if opts.get("text") is not None:
                 with open(tmp, "w+") as f:
                     f.write(opts["text"])
-            elif opts["keyFile"] is not None:
+            elif opts.get("keyFile") is not None:
                 self._logged_exec(["cp", opts["keyFile"], tmp])
+            elif opts.get("keyCmd") is not None:
+                with open(tmp, "w+") as f:
+                    subprocess.Popen(opts["keyCmd"], stdout=f, shell=True)
             else:
                 raise Exception(
                     "Neither 'text' or 'keyFile' options were set for key '{0}'.".format(

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -298,8 +298,12 @@ class MachineState(nixops.resources.ResourceState):
             elif opts.get("keyFile") is not None:
                 self._logged_exec(["cp", opts["keyFile"], tmp])
             elif opts.get("keyCommand") is not None:
-                with open(tmp, "w+") as f:
-                    subprocess.run(opts["keyCommand"], stdout=f, check=True)
+                try:
+                    with open(tmp, "w+") as f:
+                        subprocess.run(opts["keyCommand"], stdout=f, check=True)
+                except subprocess.CalledProcessError:
+                    self.warn(f"Running command to generate key '{k}' failed:")
+                    raise
             else:
                 raise Exception(
                     "Neither 'text', 'keyFile', nor 'keyCommand' options were set for key '{0}'.".format(


### PR DESCRIPTION
The option `deployment.keys.*.keyCmd` executes a command on the local machine and sends its output as a key to the remote machine.

The use-case is storing NixOps secrets in encrypted form using, e.g. password-store.

The patch should also apply to the `flake-support` branch - since I developed this feature with flakes in mind, should I file another pull-request to cherry-pick it there?