### PR TITLE
Remove deployment.storeKeysOnMachine

### DIFF
--- a/nix/auto-luks.nix
+++ b/nix/auto-luks.nix
@@ -48,12 +48,7 @@ with utils;
               the volume.  If left empty, a passphrase is generated
               automatically; this passphrase is lost when you destroy the
               machine or underlying device, unless you copy it from
-              NixOps's state file.  Note that unless
-              <option>deployment.storeKeysOnMachine</option> is set to
-              <literal>false</literal>, the passphrase is stored in the
-              Nix store of the instance, so an attacker who gains access
-              to the disk containing the store can subsequently decrypt
-              the encrypted volume.
+              NixOps's state file.
             '';
           };
 

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -118,7 +118,7 @@ rec {
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
       foldr (a: b: a // b)
-        { inherit (v.config.deployment) targetEnv targetPort targetHost storeKeysOnMachine alwaysActivate owners keys hasFastConnection;
+        { inherit (v.config.deployment) targetEnv targetPort targetHost alwaysActivate owners keys hasFastConnection;
           nixosRelease = v.config.system.nixos.release or v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
           publicIPv4 = v.config.networking.publicIPv4;
         }

--- a/tests/functional/single_machine_elsewhere_key.nix
+++ b/tests/functional/single_machine_elsewhere_key.nix
@@ -1,7 +1,5 @@
 {
   machine.deployment = {
-    storeKeysOnMachine = false;
-
     keys."elsewhere.key".text = "12345";
     keys."elsewhere.key".destDir = "/new/directory";
   };

--- a/tests/functional/single_machine_secret_key.nix
+++ b/tests/functional/single_machine_secret_key.nix
@@ -1,7 +1,5 @@
 {
   machine.deployment = {
-    storeKeysOnMachine = false;
-
     keys."secret.key".text = "12345";
   };
 }


### PR DESCRIPTION
This is a dangerous options and persistent secrets can already be
achieved by setting a destDir to a persistent mutable location.