### PR TITLE
Extract ci actions to ./ci/ scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Parsing
-        run: 'find . -name "*.nix" -exec nix-instantiate --parse --quiet {} >/dev/null +'
+        run: './ci/check-nix-files.sh'
   build:
     runs-on: ubuntu-latest
     steps:
@@ -31,7 +31,7 @@ jobs:
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Black
-        run: 'nix-shell --run "black . --check --diff"'
+        run: './ci/check-formatting.sh'
   mypy:
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +40,7 @@ jobs:
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Mypy
-        run: 'nix-shell --run "mypy nixops"'
+        run: './ci/check-mypy.sh'
   mypy-ratchet:
     runs-on: ubuntu-latest
     steps:
@@ -58,5 +58,4 @@ jobs:
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Coverage
-        run: |
-          nix-shell --run "./coverage-tests.py -a '!libvirtd,!gce,!ec2,!azure' -v"
+        run: './ci/check-tests.sh'

--- a/ci/check-formatting.sh
+++ b/ci/check-formatting.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env nix-shell
+#!nix-shell ../shell.nix -i bash
+
+black . --check --diff

--- a/ci/check-mypy.sh
+++ b/ci/check-mypy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env nix-shell
+#!nix-shell ../shell.nix -i bash
+
+mypy nixops

--- a/ci/check-nix-files.sh
+++ b/ci/check-nix-files.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+find . -name "*.nix" -exec nix-instantiate --parse --quiet {} >/dev/null +

--- a/ci/check-tests.sh
+++ b/ci/check-tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env nix-shell
+#!nix-shell ../shell.nix -i bash
+
+./coverage-tests.py -a '!libvirtd,!gce,!ec2,!azure' -v


### PR DESCRIPTION
**what?**
This extracts the actions performed by the GitHub CI into scripts in ./ci/check-*.sh to allow for easier local execution.

**why?**
While it's possible to find out what the github actions do by looking at .github/workflows/ci.yml I think it is nice and convenient when checks are easy to execute locally.

