### PR TITLE
Drop `dev-shell` and remove `--exclude tarball`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,4 @@ jobs:
         uses: cachix/install-nix-action@v8
       - name: Coverage
         run: |
-          nix-shell --exclude tarball --run "./coverage-tests.py -a '!libvirtd,!gce,!ec2,!azure' -v"
+          nix-shell --run "./coverage-tests.py -a '!libvirtd,!gce,!ec2,!azure' -v"

--- a/dev-shell
+++ b/dev-shell
@@ -1,2 +1,0 @@
-#! /bin/sh -e
-exec nix-shell shell.nix --exclude tarball "$@"


### PR DESCRIPTION
The `--exclude tarball` doesn't seem to do anything since there is no
tarball attribute anywhere and without it there is no reason to have a
`dev-shell` script when it does the same thing as just invoking
`nix-shell`.