### PR TITLE
Add a withPlugins function to the NixOps derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ let
 
     # The complete buildEnv drv
     buildEnvDrv = interpreter.buildEnv.override {
-      extraLibs = plugins;
+      extraLibs = builtins.map (p: interpreter.pkgs.toPythonModule p) plugins;
     };
 
     # Create a separate environment aggregating the share directory
@@ -111,4 +111,4 @@ let
 
   };
 
-in nixops.python.pkgs.nixops
+in nixops.python.pkgs.nixops.withPlugins(_: [])

--- a/default.nix
+++ b/default.nix
@@ -1,39 +1,114 @@
 { nixpkgs ? <nixpkgs>
 , pkgs ? import nixpkgs {}
+, poetry2nix ? pkgs.poetry2nix
+, symlinkJoin ? pkgs.symlinkJoin
+, lib ? pkgs.lib
+, runCommandNoCC ? pkgs.runCommandNoCC
+, overrides ? (self: super: {})
 }:
 
 let
+  # Wrap the buildEnv derivation in an outer derivation that omits interpreters & other binaries
+  mkPluginDrv = {
+    finalDrv
+    , interpreter
+    , plugins
+  }: let
 
-  overrides = import ./overrides.nix { inherit pkgs; };
+    # The complete buildEnv drv
+    buildEnvDrv = interpreter.buildEnv.override {
+      extraLibs = plugins;
+    };
 
-in pkgs.poetry2nix.mkPoetryApplication {
-  # Once the latest poetry2nix release has reached 20.03 use projectDir instead of:
-  # - src
-  # - pyproject
-  # - poetrylock
+    # Create a separate environment aggregating the share directory
+    # This is done because we only want /share for the actual plugins
+    # and not for e.g. the python interpreter and other dependencies.
+    manEnv = symlinkJoin {
+      name = "${finalDrv.pname}-with-plugins-share-${finalDrv.version}";
+      preferLocalBuild = true;
+      allowSubstitutes = false;
+      paths = plugins;
+      postBuild = ''
+        if test -e $out/share; then
+          mv $out out
+          mv out/share $out
+        else
+          rm -r $out
+          mkdir $out
+        fi
+      '';
+    };
 
-  src = pkgs.lib.cleanSource ./.;
-  pyproject = ./pyproject.toml;
-  poetrylock = ./poetry.lock;
+  in runCommandNoCC "${finalDrv.pname}-with-plugins-${finalDrv.version}" {
+    inherit (finalDrv) passthru meta;
+  } ''
+    mkdir -p $out/bin
 
-  propagatedBuildInputs = [
-    pkgs.openssh
-  ];
+    for bindir in ${lib.concatStringsSep " " (map (d: "${lib.getBin d}/bin") plugins)}; do
+      for bin in $bindir/*; do
+        ln -s ${buildEnvDrv}/bin/$(basename $bin) $out/bin/
+      done
+    done
 
-  nativeBuildInputs = [
-    pkgs.docbook5_xsl
-    pkgs.libxslt
-  ];
-
-  overrides = [
-    pkgs.poetry2nix.defaultPoetryOverrides
-    overrides
-  ];
-
-  # TODO: Manual build should be included via pyproject.toml
-  postInstall = ''
-    cp ${(import ./doc/manual { revision = "1.8"; inherit nixpkgs; }).optionsDocBook} doc/manual/machine-options.xml
-    make -C doc/manual install docdir=$out/share/doc/nixops mandir=$out/share/man
+    ln -s ${manEnv} $out/share
   '';
 
-}
+  # Make a python derivation pluginable
+  #
+  # This adds a `withPlugins` function that works much like `withPackages`
+  # except it only links binaries from the explicit derivation /share
+  # from any plugins
+  toPluginAble = {
+    drv
+    , interpreter
+    , finalDrv
+    , self
+    , super
+  }: drv.overridePythonAttrs(old: {
+    passthru = old.passthru // {
+      withPlugins = pluginFn: mkPluginDrv {
+        plugins = [ finalDrv ] ++ pluginFn self;
+        inherit finalDrv;
+        inherit interpreter;
+      };
+    };
+  });
+
+  nixops = poetry2nix.mkPoetryApplication {
+
+    projectDir = ./.;
+
+    propagatedBuildInputs = [
+      pkgs.openssh
+    ];
+
+    nativeBuildInputs = [
+      pkgs.docbook5_xsl
+      pkgs.libxslt
+    ];
+
+    overrides = [
+      pkgs.poetry2nix.defaultPoetryOverrides
+      overrides
+      (self: super: {
+        nixops = nixops;
+      })
+      (self: super: {
+        nixops = toPluginAble {
+          drv = super.nixops;
+          finalDrv = self.nixops;
+          interpreter = self.python;
+          inherit self super;
+        };
+      })
+    ];
+
+    # TODO: Manual build should be included via pyproject.toml
+    postInstall = ''
+      cp ${(import ./doc/manual { revision = "1.8"; inherit nixpkgs; }).optionsDocBook} doc/manual/machine-options.xml
+      make -C doc/manual install docdir=$out/share/doc/nixops mandir=$out/share/man
+    '';
+
+  };
+
+in nixops.python.pkgs.nixops


### PR DESCRIPTION
It's a variation of the expression from https://github.com/NixOS/nixpkgs/pull/83548.

With this change you can use the following snippet to build NixOps
with a local plugin:
``` nix
{ pkgs ? import <nixpkgs> {} }:

let
  nixops = import ./default.nix { inherit pkgs; };
in nixops.withPlugins(ps: [
  (ps.callPackage ./path/to/plugin {})
])
```

Plugins can have their own dependencies/requirements which may or may not be fulfilled by the package set `ps`.