### PR TITLE
eval-machine-info.nix: add nixpkgsPath argument.

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -1,4 +1,5 @@
 { system ? builtins.currentSystem
+, nixpkgsPath ? <nixpkgs>
 , networkExprs
 , checkConfigurationOptions ? true
 , uuid
@@ -7,7 +8,7 @@
 , pluginNixExprs
 }:
 
-with import <nixpkgs> { inherit system; };
+with import nixpkgsPath { inherit system; };
 with lib;
 
 
@@ -52,7 +53,7 @@ rec {
           networks;
       in
       { name = machineName;
-        value = import <nixpkgs/nixos/lib/eval-config.nix> {
+        value = import (nixpkgsPath + "/nixos/lib/eval-config.nix") {
           modules =
             modules ++
             defaults ++


### PR DESCRIPTION
This allows the caller to use a pinned nixpkgs, rather than the `<nixpkgs>` default value. Among other things, this makes it possible to build at least some NixOps networks on a Hydra (or from any Nix expression), which addresses #1320.