### PR TITLE
known_hosts: Don't update a key to an empty IP address

### DIFF
--- a/nixops/known_hosts.py
+++ b/nixops/known_hosts.py
@@ -66,4 +66,5 @@ def update(prev_address: str, new_address: str, public_host_key: str) -> None:
     # FIXME: this rewrites known_hosts twice.
     if prev_address != new_address:
         remove(prev_address, public_host_key)
-    add(new_address, public_host_key)
+    if new_address is not None:
+        add(new_address, public_host_key)


### PR DESCRIPTION
Remove keys that have an empty IP address instead of trying to re-add
them during the update phase.

Should resolve error seen in
https://github.com/nix-community/nixops-vbox/pull/3#issuecomment-620104958