### PR TITLE
nixops.util.ImmutableValidatedObject: Allow passing an instance of self

### DIFF
--- a/nixops/util.py
+++ b/nixops/util.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import os
 import sys
@@ -125,8 +126,21 @@ class ImmutableValidatedObject:
 
     _frozen: bool
 
-    def __init__(self, **kwargs):
-        anno: Dict = self.__annotations__
+    def __init__(self, *args: ImmutableValidatedObject, **kwargs):
+
+        kw = {}
+        for arg in args:
+            if not isinstance(arg, ImmutableValidatedObject):
+                raise TypeError("Arg not a Immutablevalidatedobject instance")
+            kw.update(dict(arg))
+        kw.update(kwargs)
+
+        # Support inheritance
+        anno: Dict = {}
+        for x in reversed(self.__class__.mro()):
+            if not hasattr(x, "__annotations__"):
+                continue
+            anno.update(x.__annotations__)
 
         def _transform_value(key: Any, value: Any) -> Any:
             ann = anno.get(key)
@@ -149,7 +163,7 @@ class ImmutableValidatedObject:
             #
             # is set this attribute is set on self before __init__ is called
             default = getattr(self, key) if hasattr(self, key) else None
-            value = kwargs.get(key, default)
+            value = kw.get(key, default)
             setattr(self, key, _transform_value(key, value))
 
         self._frozen = True

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -94,3 +94,15 @@ class TestUtilTest(unittest.TestCase):
             x: int = 1
 
         self.assertEqual(WithDefaults().x, 1)
+
+        # Extensible
+        class A(util.ImmutableValidatedObject):
+            x: int
+
+        class B(A):
+            y: int
+
+        a = A(x=1)
+        b = B(a, y=1)
+        self.assertEqual(a.x, b.x)
+        self.assertEqual(b.x, 1)


### PR DESCRIPTION
This is useful for plugins or others that want to extend a class.

Consider the following code

``` python
from nixops.util import ImmutableValidatedObject

class A(ImmutableValidatedObject):
    x: int

class B(A):
    y: int

a = A(x=1)
B(a, y=1)  # Type checks both x and y
```