### PR TITLE
Fixing info for commandOutput resource

### DIFF
--- a/nixops/resources/commandOutput.py
+++ b/nixops/resources/commandOutput.py
@@ -65,7 +65,7 @@ class CommandOutputState(nixops.resources.ResourceState):
         if self.value is not None:
             # Avoid printing any potential secret information
             return "{0}-{1}".format(
-                self.commandName, hashlib.sha256(self.value).hexdigest()[:32]
+                self.commandName, hashlib.sha256(self.value.encode()).hexdigest()[:32]
             )
         else:
             return None


### PR DESCRIPTION
Without this

```
raceback (most recent call last):
  File "/home/tewfikghariani/.cache/pypoetry/virtualenvs/nixops-grafana-FCCl2_6c-py3.7/bin/nixops", line 11, in <module>
    load_entry_point('nixops', 'console_scripts', 'nixops')()
  File "/home/tewfikghariani/.cache/pypoetry/virtualenvs/nixops-grafana-FCCl2_6c-py3.7/src/nixops/nixops/__main__.py", line 630, in main
    args.op(args)
  File "/home/tewfikghariani/.cache/pypoetry/virtualenvs/nixops-grafana-FCCl2_6c-py3.7/src/nixops/nixops/script_defs.py", line 342, in op_info
    print_deployment(depl)
  File "/home/tewfikghariani/.cache/pypoetry/virtualenvs/nixops-grafana-FCCl2_6c-py3.7/src/nixops/nixops/script_defs.py", line 305, in print_deployment
    r.resource_id or "" if r else "",
  File "/home/tewfikghariani/.cache/pypoetry/virtualenvs/nixops-grafana-FCCl2_6c-py3.7/src/nixops/nixops/resources/commandOutput.py", line 68, in resource_id
    self.commandName, hashlib.sha256(self.value).hexdigest()[:32]
TypeError: Unicode-objects must be encoded before hashing
```

With the fix

```
+------+--------+----------------+---------------------------------------+------------+
| Name | Status | Type           | Resource Id                           | IP address |
+------+--------+----------------+---------------------------------------+------------+
| test |   Up   | command-output | test-afc21edad3e1050cde1bde655014dd59 |            |
+------+--------+----------------+---------------------------------------+------------+
```