### PR TITLE
CI poetry check: delete poetry lock

### DIFF
--- a/ci/check-poetry.sh
+++ b/ci/check-poetry.sh
@@ -4,6 +4,5 @@
 set -eu
 
 set -x
-poetry lock
 poetry export --dev -f requirements.txt > doc/requirements.txt
 git diff --exit-code poetry.lock doc/requirements.txt


### PR DESCRIPTION
poetry lock updates dependencies, which is not what we want. This
check is just to be sure we didn't forget to update the docs'
requirements.txt.