### PR TITLE
backends: s/provison/provision/

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -120,7 +120,7 @@ class MachineState(nixops.resources.ResourceState):
         self.ssh_user = defn.ssh_user
         self.ssh_options = defn.ssh_options
         self.has_fast_connection = defn.has_fast_connection
-        self.provison_ssh_key = defn.provision_ssh_key
+        self.provision_ssh_key = defn.provision_ssh_key
         if not self.has_fast_connection:
             self.ssh.enable_compression()
 

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -32,7 +32,7 @@ class NoneState(MachineState):
     def get_type(cls):
         return "none"
 
-    provison_ssh_key: bool = nixops.util.attr_property("provisionSSHKey", True, bool)
+    provision_ssh_key: bool = nixops.util.attr_property("provisionSSHKey", True, bool)
     target_host = nixops.util.attr_property("targetHost", None)
     public_ipv4 = nixops.util.attr_property("publicIpv4", None)
     _ssh_private_key: Optional[str] = attr_property("none.sshPrivateKey", None)
@@ -70,7 +70,7 @@ class NoneState(MachineState):
         self.public_ipv4 = defn._public_ipv4
 
         if not self.vm_id:
-            if self.provison_ssh_key:
+            if self.provision_ssh_key:
                 self.log_start("generating new SSH keypair... ")
                 key_name = "NixOps client key for {0}".format(self.name)
                 self._ssh_private_key, self._ssh_public_key = create_key_pair(


### PR DESCRIPTION
Sure hope this works. I just ran `sed 's/provison/provision/g' -i **.py` and don't know how to test this.