### PR TITLE
Add --boot flag to deploy and correct ratchet script

### DIFF
--- a/ci/mypy-ratchet.sh
+++ b/ci/mypy-ratchet.sh
@@ -17,7 +17,7 @@ base=origin/${GITHUB_BASE_REF:-master}
 
 git fetch origin
 
-echo "Checking base branch at %s, then PR at %s...\n" "$base" "$head"
+printf "Checking base branch at %s, then PR at %s...\n" "$base" "$head"
 
 git checkout "$base"
 nix-shell shell.nix --run "$scratch/run-ratchet.sh $scratch base"

--- a/nixops/__main__.py
+++ b/nixops/__main__.py
@@ -210,6 +210,11 @@ subparser.add_argument(
     help="build and activate the new configuration; do not enable it in the bootloader. Rebooting the system will roll back automatically.",
 )
 subparser.add_argument(
+    "--boot",
+    action="store_true",
+    help="build the new configuration and enable it in the bootloader; do not activate it. Upon reboot, the system will use the new configuration.",
+)
+subparser.add_argument(
     "--repair", action="store_true", help="use --repair when calling nix-build (slow)"
 )
 subparser.add_argument(

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -860,6 +860,7 @@ class Deployment:
         always_activate: bool,
         dry_activate: bool,
         test: bool,
+        boot: bool,
         max_concurrent_activate: int,
     ) -> None:
         """Activate the new configuration on a machine."""
@@ -902,7 +903,7 @@ class Deployment:
 
                 m.send_keys()
 
-                if force_reboot or m.state == m.RESCUE:
+                if boot or force_reboot or m.state == m.RESCUE:
                     switch_method = "boot"
                 elif dry_activate:
                     switch_method = "dry-activate"
@@ -1144,6 +1145,7 @@ class Deployment:
         self,
         dry_run: bool = False,
         test: bool = False,
+        boot: bool = False,
         plan_only: bool = False,
         build_only: bool = False,
         create_only: bool = False,
@@ -1321,6 +1323,7 @@ class Deployment:
             always_activate=always_activate,
             dry_activate=dry_activate,
             test=test,
+            boot=boot,
             max_concurrent_activate=max_concurrent_activate,
         )
 
@@ -1449,6 +1452,7 @@ class Deployment:
             always_activate=True,
             dry_activate=False,
             test=False,
+            boot=False,
             max_concurrent_activate=max_concurrent_activate,
         )
 

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -588,6 +588,7 @@ def op_deploy(args):
         depl.deploy(
             dry_run=args.dry_run,
             test=args.test,
+            boot=args.boot,
             build_only=args.build_only,
             plan_only=args.plan_only,
             create_only=args.create_only,


### PR DESCRIPTION
This is similar to running `nixos-rebuild boot`, just as `nixops deploy
--test` is similar to running `nixos-rebuild test`. The flag creates a
new config and sets it as the default to boot into, but doesn't switch
to it right away.

---

`%s` has no special meaning to echo, so the ratchet script was printing `Checking base branch at %s, then PR at %s...\n origin/master d2cb660583ce356af51d9978329c0e77ad284620`.

---

Since we already have `--test`, I figured "why not go for all three major uses?" (the implicit switch, and the explicit `--test` and now `--boot`).

Sometimes I have a config I want to switch into a boot time (because it may be destructive to switch mid-session), so this is the perfect use for it. For example: recently, I was messing with udev rules. Setting `services.udev.extraRules` and switching into this configuration rendered my USB devices (mouse, keyboard) unresponsive until I rebooted. Now, in the future, I know that this is potentially game-over, so I want the change to be available at boot and not switch into it right away.

Let me know if I need to do anything else!

P.S. One thing I noticed when running the various CI scripts is that `ci/check-tests.sh` failed to check coverage with the error: `nose.plugins.cover: ERROR: Coverage not available: unable to import coverage module`. Maybe it's fine (and you just let CI handle it), but it might be nice to have a `nix-shell` shebang or have `pkgs.python3.pkgs.nose` in the shell's `buildInputs`.

EDIT: I imagine ratchet is failing because the new `boot` argument is also of type `Any` (due to `def deploy(self, **kwargs: Any) -> None:`). If not (and there's a way I can fix it), let me know.