### PR TITLE
doc: add default.nix to build the doc

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -1,0 +1,25 @@
+# FIXME: pin nixpkgs
+{ nixpkgs ? <nixpkgs>
+, pkgs ? import nixpkgs {}
+}:
+
+pkgs.stdenv.mkDerivation {
+  name = "nixops-manual";
+  src = pkgs.nix-gitignore.gitignoreSource [] ../.;
+  sourceRoot = "nixops/doc";
+
+  buildInputs = [(
+    pkgs.python3.withPackages(p: [ p.sphinx ]))
+    pkgs.codespell
+  ];
+  buildPhase = ''
+    find ./ -name '*.rst' | xargs codespell
+
+    # Workaround for https://github.com/sphinx-doc/sphinx/issues/3451
+    export SOURCE_DATE_EPOCH=$(${pkgs.coreutils}/bin/date +%s)
+    SPHINXOPTS=-Wn make html
+  '';
+  installPhase = ''
+    cp -r _build/html $out
+  '';
+}


### PR DESCRIPTION
This also allows to reproduce the CI behavior.