### PR TITLE
Flake support

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -50,7 +50,7 @@ rec {
       if network ? nixpkgs
       then (head (network.nixpkgs)).lib.nixosSystem
       else throw "NixOps network must have a 'nixpkgs' attribute"
-    else import "<nixpkgs/nixos/lib/eval-config.nix>";
+    else import <nixpkgs/nixos/lib/eval-config.nix>;
 
   # Compute the definitions of the machines.
   nodes =

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -8,19 +8,22 @@
 , pluginNixExprs
 }:
 
-# FIXME: don't rely on <nixpkgs>.
-with import <nixpkgs> { inherit system; };
-with lib;
+let
+  # FIXME: don't rely on <nixpkgs>.
+  pkgs = import <nixpkgs> { inherit system; };
+  inherit (pkgs) lib;
 
-
-rec {
+in rec {
 
   importedPluginNixExprs = map
     (expr: import expr)
     pluginNixExprs;
-  pluginOptions = { imports = (foldl (a: e: a ++ e.options) [] importedPluginNixExprs); };
+  pluginOptions = { imports = (lib.foldl (a: e: a ++ e.options) [] importedPluginNixExprs); };
   pluginResources = map (e: e.resources) importedPluginNixExprs;
-  pluginDeploymentConfigExporters = (foldl (a: e: a ++ (e.config_exporters { inherit optionalAttrs pkgs; })) [] importedPluginNixExprs);
+  pluginDeploymentConfigExporters = (lib.foldl (a: e: a ++ (e.config_exporters {
+    inherit pkgs;
+    inherit (lib) optionalAttrs;
+  })) [] importedPluginNixExprs);
 
   networks =
     let
@@ -35,12 +38,12 @@ rec {
       };
     in
       map ({ key }: getNetworkFromExpr key) networkExprClosure
-      ++ optional (flakeUri != null)
+      ++ lib.optional (flakeUri != null)
         ((call (builtins.getFlake flakeUri).outputs.nixopsConfigurations.default) // { _file = "<${flakeUri}>"; });
 
   call = x: if builtins.isFunction x then x args else x;
 
-  network = zipAttrs networks;
+  network = lib.zipAttrs networks;
 
   defaults = network.defaults or [];
 
@@ -48,20 +51,20 @@ rec {
     if flakeUri != null
     then
       if network ? nixpkgs
-      then (head (network.nixpkgs)).lib.nixosSystem
+      then (lib.head (network.nixpkgs)).lib.nixosSystem
       else throw "NixOps network must have a 'nixpkgs' attribute"
     else import <nixpkgs/nixos/lib/eval-config.nix>;
 
   # Compute the definitions of the machines.
   nodes =
-    listToAttrs (map (machineName:
+    lib.listToAttrs (map (machineName:
       let
         # Get the configuration of this machine from each network
         # expression, attaching _file attributes so the NixOS module
         # system can give sensible error messages.
         modules =
-          concatMap (n: optional (hasAttr machineName n)
-            { imports = [(getAttr machineName n)]; inherit (n) _file; })
+          lib.concatMap (n: lib.optional (lib.hasAttr machineName n)
+            { imports = [(lib.getAttr machineName n)]; inherit (n) _file; })
           networks;
       in
       { name = machineName;
@@ -75,18 +78,18 @@ rec {
                 imports = [ ./options.nix ./resource.nix pluginOptions ];
                 # Provide a default hostname and deployment target equal
                 # to the attribute name of the machine in the model.
-                networking.hostName = mkOverride 900 machineName;
-                deployment.targetHost = mkOverride 900 machineName;
-                environment.checkConfigurationOptions = mkOverride 900 checkConfigurationOptions;
+                networking.hostName = lib.mkOverride 900 machineName;
+                deployment.targetHost = lib.mkOverride 900 machineName;
+                environment.checkConfigurationOptions = lib.mkOverride 900 checkConfigurationOptions;
               }
             ];
           extraArgs = { inherit nodes resources uuid deploymentName; name = machineName; };
         };
       }
-    ) (attrNames (removeAttrs network [ "network" "defaults" "resources" "require" "nixpkgs" "_file" ])));
+    ) (lib.attrNames (removeAttrs network [ "network" "defaults" "resources" "require" "nixpkgs" "_file" ])));
 
   # Compute the definitions of the non-machine resources.
-  resourcesByType = zipAttrs (network.resources or []);
+  resourcesByType = lib.zipAttrs (network.resources or []);
 
   deploymentInfoModule = {
     deployment = {
@@ -97,28 +100,31 @@ rec {
   };
 
   evalResources = mainModule: _resources:
-    mapAttrs (name: defs:
-      (builtins.removeAttrs (fixMergeModules
+    lib.mapAttrs (name: defs:
+      (builtins.removeAttrs (lib.fixMergeModules
         ([ mainModule deploymentInfoModule ./resource.nix ] ++ defs)
         { inherit pkgs uuid name resources; nodes = info.machines; }
       ).config) ["_module"]) _resources;
 
-  resources = foldl
-    (a: b: a // (b { inherit evalResources zipAttrs resourcesByType;}))
+  resources = lib.foldl
+    (a: b: a // (b {
+      inherit evalResources resourcesByType;
+      inherit (lib) zipAttrs;
+    }))
     {
-      sshKeyPairs = evalResources ./ssh-keypair.nix (zipAttrs resourcesByType.sshKeyPairs or []);
-      commandOutput = evalResources ./command-output.nix (zipAttrs resourcesByType.commandOutput or []);
-      machines = mapAttrs (n: v: v.config) nodes;
+      sshKeyPairs = evalResources ./ssh-keypair.nix (lib.zipAttrs resourcesByType.sshKeyPairs or []);
+      commandOutput = evalResources ./command-output.nix (lib.zipAttrs resourcesByType.commandOutput or []);
+      machines = lib.mapAttrs (n: v: v.config) nodes;
     }
     pluginResources;
 
   # check if there are duplicate elements in a sorted list
   noDups = l:
-    if length l > 1
+    if lib.length l > 1
     then
-      if (head l) == (head (tail l))
-      then throw "found resources with duplicate names: ${head l}"
-      else noDups (tail l)
+      if (lib.head l) == (lib.head (lib.tail l))
+      then throw "found resources with duplicate names: ${lib.head l}"
+      else noDups (lib.tail l)
     else true;
 
   # Phase 1: evaluate only the deployment attributes.
@@ -129,8 +135,8 @@ rec {
     in rec {
 
     machines =
-      flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
-      foldr (a: b: a // b)
+      lib.flip lib.mapAttrs nodes (n: v': let v = lib.scrubOptionValue v'; in
+      lib.foldr (a: b: a // b)
         {
           inherit (v.config.deployment)
             targetEnv
@@ -145,7 +151,7 @@ rec {
             hasFastConnection
             provisionSSHKey
             ;
-          nixosRelease = v.config.system.nixos.release or v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
+          nixosRelease = v.config.system.nixos.release or v.config.system.nixosRelease or (lib.removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
           publicIPv4 = v.config.networking.publicIPv4;
         }
       (map
@@ -153,17 +159,17 @@ rec {
         pluginDeploymentConfigExporters
       ));
 
-    network = fold (as: bs: as // bs) {} (network'.network or []);
+    network = lib.fold (as: bs: as // bs) {} (network'.network or []);
 
     resources =
     let
       resource_referenced = list: check: recurse:
-          any id (map (value: (check value) ||
-                              ((isAttrs value) && (!(value ? _type) || recurse)
-                                               && (resource_referenced (attrValues value) check false)))
+          lib.any lib.id (map (value: (check value) ||
+                              ((lib.isAttrs value) && (!(value ? _type) || recurse)
+                                               && (resource_referenced (lib.attrValues value) check false)))
                       list);
 
-      flatten_resources = resources: flatten ( map attrValues (attrValues resources) );
+      flatten_resources = resources: lib.flatten ( map lib.attrValues (lib.attrValues resources) );
 
       resource_used = res_set: resource:
           resource_referenced
@@ -173,9 +179,9 @@ rec {
 
       resources_without_defaults = res_class: defaults: res_set:
         let
-          missing = filter (res: !(resource_used (removeAttrs res_set [res_class])
+          missing = lib.filter (res: !(resource_used (removeAttrs res_set [res_class])
                                                   res_set."${res_class}"."${res}"))
-                           (attrNames defaults);
+                           (lib.attrNames defaults);
         in
         res_set // { "${res_class}" = ( removeAttrs res_set."${res_class}" missing ); };
 
@@ -185,12 +191,12 @@ rec {
 
   # Phase 2: build complete machine configurations.
   machines = { names }:
-    let nodes' = filterAttrs (n: v: elem n names) nodes; in
-    runCommand "nixops-machines"
+    let nodes' = lib.filterAttrs (n: v: lib.elem n names) nodes; in
+    pkgs.runCommand "nixops-machines"
       { preferLocalBuild = true; }
       ''
         mkdir -p $out
-        ${toString (attrValues (mapAttrs (n: v: ''
+        ${toString (lib.attrValues (lib.mapAttrs (n: v: ''
           ln -s ${v.config.system.build.toplevel} $out/${n}
         '') nodes'))}
       '';

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -106,6 +106,9 @@ class MachineState(
     cur_toplevel: Optional[str] = nixops.util.attr_property("toplevel", None)
     new_toplevel: Optional[str]
 
+    # Immutable flake URI from which this machine was built.
+    cur_flake_uri: Optional[str] = nixops.util.attr_property("curFlakeUri", None)
+
     # Time (in Unix epoch) the instance was started, if known.
     start_time: Optional[int] = nixops.util.attr_property("startTime", None, int)
 

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -134,7 +134,9 @@ class Deployment:
                     stderr=self.logger.log_file,
                 )
             )
-            self._cur_flake_uri = out["uri"]
+            self._cur_flake_uri = out["url"].replace(
+                "ref=HEAD&rev=0000000000000000000000000000000000000000&", ""
+            )  # FIXME
         return self._cur_flake_uri
 
     @property

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -63,6 +63,8 @@ class Deployment:
     name: Optional[str] = nixops.util.attr_property("name", None)
     nix_exprs = nixops.util.attr_property("nixExprs", [], "json")
     nix_path = nixops.util.attr_property("nixPath", [], "json")
+    flake_uri = nixops.util.attr_property("flakeUri", None)
+    cur_flake_uri = nixops.util.attr_property("curFlakeUri", None)
     args = nixops.util.attr_property("args", {}, "json")
     description = nixops.util.attr_property("description", default_description)
     configs_path = nixops.util.attr_property("configsPath", None)
@@ -113,6 +115,8 @@ class Deployment:
 
         self.definitions: Optional[Definitions] = None
 
+        self._cur_flake_uri: Optional[str] = None
+
     @property
     def tempdir(self) -> nixops.util.SelfDeletingDir:
         if not self._tempdir:
@@ -120,6 +124,18 @@ class Deployment:
                 tempfile.mkdtemp(prefix="nixops-tmp")
             )
         return self._tempdir
+
+    def _get_cur_flake_uri(self):
+        assert self.flake_uri is not None
+        if self._cur_flake_uri is None:
+            out = json.loads(
+                subprocess.check_output(
+                    ["nix", "flake", "info", "--json", "--", self.flake_uri],
+                    stderr=self.logger.log_file,
+                )
+            )
+            self._cur_flake_uri = out["uri"]
+        return self._cur_flake_uri
 
     @property
     def machines(self) -> Dict[str, nixops.backends.GenericMachineState]:
@@ -382,9 +398,22 @@ class Deployment:
                 "--arg",
                 "pluginNixExprs",
                 py2nix(extraexprs),
-                "<nixops/eval-machine-info.nix>",
+                (self.expr_path + "/eval-machine-info.nix"),
             ]
         )
+
+        if self.flake_uri is not None:
+            flags.extend(
+                [
+                    # "--pure-eval", # FIXME
+                    "--argstr",
+                    "flakeUri",
+                    self._get_cur_flake_uri(),
+                    "--allowed-uris",
+                    self.expr_path,
+                ]
+            )
+
         return flags
 
     def set_arg(self, name: str, value: str) -> None:
@@ -923,6 +952,10 @@ class Deployment:
                 if dry_activate:
                     return None
 
+                self.cur_flake_uri = (
+                    self._get_cur_flake_uri() if self.flake_uri is not None else None
+                )
+
                 if res != 0 and res != 100:
                     raise Exception(
                         "unable to activate new configuration (exit code {})".format(
@@ -949,6 +982,9 @@ class Deployment:
                 # configuration.
                 m.cur_configs_path = configs_path
                 m.cur_toplevel = m.new_toplevel
+                m.cur_flake_uri = (
+                    self._get_cur_flake_uri() if self.flake_uri is not None else None
+                )
 
             except Exception:
                 # This thread shouldn't throw an exception because
@@ -1455,6 +1491,8 @@ class Deployment:
             boot=False,
             max_concurrent_activate=max_concurrent_activate,
         )
+
+        self.cur_flake_uri = None
 
     def rollback(self, **kwargs: Any) -> None:
         with self._get_deployment_lock():

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -151,12 +151,35 @@ def set_name(depl: nixops.deployment.Deployment, name: Optional[str]):
 def modify_deployment(args, depl: nixops.deployment.Deployment):
     nix_exprs = args.nix_exprs
     templates = args.templates or []
-    for i in templates:
-        nix_exprs.append("<nixops/templates/{0}.nix>".format(i))
-    if len(nix_exprs) == 0:
-        raise Exception("you must specify the path to a Nix expression and/or use ‘-t’")
-    depl.nix_exprs = [os.path.abspath(x) if x[0:1] != "<" else x for x in nix_exprs]
-    depl.nix_path = [nixops.util.abs_nix_path(x) for x in sum(args.nix_path or [], [])]
+
+    if args.flake is None:
+        for i in templates:
+            nix_exprs.append("<nixops/templates/{0}.nix>".format(i))
+        if len(nix_exprs) == 0:
+            raise Exception(
+                "you must specify the path to a Nix expression and/or use ‘-t’"
+            )
+        depl.nix_exprs = [os.path.abspath(x) if x[0:1] != "<" else x for x in nix_exprs]
+        depl.nix_path = [
+            nixops.util.abs_nix_path(x) for x in sum(args.nix_path or [], [])
+        ]
+    else:
+        if nix_exprs:
+            raise Exception(
+                "you cannot specify a Nix expression in conjunction with '--flake'"
+            )
+        if args.nix_path:
+            raise Exception(
+                "you cannot specify a Nix search path ('-I') in conjunction with '--flake'"
+            )
+        if len(templates) != 0:
+            raise Exception(
+                "you cannot specify a template ('-t') in conjunction with '--flake'"
+            )
+        # FIXME: should absolutize args.flake if it's a local path.
+        depl.flake_uri = args.flake
+        depl.nix_exprs = []
+        depl.nix_path = []
 
 
 def op_create(args):
@@ -321,9 +344,16 @@ def op_info(args):  # noqa: C901
                 print("Network name:", depl.name or "(none)")
                 print("Network UUID:", depl.uuid)
                 print("Network description:", depl.description)
-                print("Nix expressions:", " ".join(depl.nix_exprs))
-                if depl.nix_path != []:
-                    print("Nix path:", " ".join(["-I " + x for x in depl.nix_path]))
+
+                if depl.flake_uri is None:
+                    print("Nix expressions:", " ".join(depl.nix_exprs))
+                    if depl.nix_path != []:
+                        print("Nix path:", " ".join(["-I " + x for x in depl.nix_path]))
+                else:
+                    print("Flake URI:", depl.flake_uri)
+                    if depl.cur_flake_uri is not None:
+                        print("Deployed flake URI:", depl.cur_flake_uri)
+
                 if depl.rollback_enabled:
                     print("Nix profile:", depl.get_profile())
                 if depl.args != {}:
@@ -1122,6 +1152,12 @@ def add_common_modify_options(subparser: ArgumentParser):
         dest="templates",
         metavar="TEMPLATE",
         help="name of template to be used",
+    )
+    subparser.add_argument(
+        "--flake",
+        dest="flake",
+        metavar="FLAKE_URI",
+        help="URI of the flake that defines the network",
     )
 
 


### PR DESCRIPTION
Copied PR body from #1202

As we are now using Flakes for development on master the scope of this PR is much smaller than the original one.
It's only about adding Flakes support to NixOps, we are not touching the development workflow.

------------

This PR adds flake support to NixOps, meaning that you can do things like
```
# nixops create -d hydra-ec2-demo --flake github:edolstra/hydra-ec2-demo
# nixops deploy
```
This will create an [EC2 instance running Hydra](https://github.com/edolstra/hydra-ec2-demo/blob/master/flake.nix), using exactly the configuration locked by [`flake.lock`](https://github.com/edolstra/hydra-ec2-demo/blob/master/flake.lock).

Currently evaluation is not as hermetic as we'd like since the NixOps-specific NixOS modules are provided impurely. Ideally, the flake would lock a particular version of the NixOps flake as input.

Likewise, NixOps needs to pass in the generated file `physical.nix` as an impure input. This is something of an inherent issue with the NixOps model. Maybe for flakes in local Git repositories, `physical.nix` could be auto-committed.