### PR TITLE
Use flake check for the documentation linting test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,11 @@ jobs:
           fetch-depth: 0
       - name: Nix
         uses: cachix/install-nix-action@v8
+        # To use nixFlake in the next step
       - name: Prefetch shell.nix
         run: 'nix-shell --run true'
       - name: Restructured Text Lint
-        run: './ci/lint-docs.sh'
+        run: 'nix-shell --run "nix build .#checks.x86_64-linux.doc --experimental-features \"nix-command flakes\""'
   poetry-up-to-date:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Serving on http://127.0.0.1:5500
 and verify its lints before committing:
 
 ```
-nixops$ ./ci/lint-docs.sh
+nixops$ lint-docs
 ```
 
 ### Contributing

--- a/ci/lint-docs.sh
+++ b/ci/lint-docs.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell ../shell.nix -i bash
-
-set -eux
-
-git ls-files | xargs codespell -L keypair,iam,hda
-sphinx-build -M clean doc/ doc/_build
-sphinx-build -n doc/ doc/_build

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,23 @@
 
   outputs = { self, nixpkgs, utils }: utils.lib.eachDefaultSystem (system: let
     pkgs = import nixpkgs { inherit system; };
+
+    sphinx = pkgs.python3.withPackages(p: [ p.sphinx ]);
+    linters.doc = pkgs.writers.writeBashBin "lint-docs" ''
+      set -eux
+      # When running it in the Nix sandbox, there is no git repository
+      # but sources are filtered.
+      if [ -d .git ];
+      then
+          FILES=$(${pkgs.git}/bin/git ls-files)
+      else
+          FILES=$(find .)
+      fi
+      echo "$FILES" | xargs ${pkgs.codespell}/bin/codespell -L keypair,iam,hda
+      ${sphinx}/bin/sphinx-build -M clean doc/ doc/_build
+      ${sphinx}/bin/sphinx-build -n doc/ doc/_build
+      '';
+
   in {
     devShell = pkgs.mkShell {
       buildInputs = [
@@ -16,8 +33,9 @@
         pkgs.openssh
         pkgs.poetry
         pkgs.rsync  # Included by default on NixOS
+        pkgs.nixFlakes
         pkgs.codespell
-      ];
+      ] ++ (builtins.attrValues linters);
 
       shellHook = ''
         export PATH=${builtins.toString ./scripts}:$PATH
@@ -50,6 +68,19 @@
         cp ${(import ./doc/manual { revision = "1.8"; inherit nixpkgs; system = "x86_64-linux"; }).optionsDocBook} doc/manual/machine-options.xml
 
         make -C doc/manual install docdir=$out/share/doc/nixops mandir=$out/share/man
+      '';
+    };
+
+    checks.doc = pkgs.stdenv.mkDerivation {
+      name = "lint-docs";
+      # we use cleanPythonSources because the default gitignore
+      # implementation doesn't support the restricted evaluation
+      src = pkgs.poetry2nix.cleanPythonSources {
+        src = ./.;
+      };
+      dontBuild = true;
+      installPhase = ''
+        ${linters.doc}/bin/lint-docs | tee $out
       '';
     };
   });


### PR DESCRIPTION
The goal is to easily run the documentation CI tests locally. 

- It moves the documentation linting test as a `flake check` attribute.
- The script `lint-docs` is now part of the shell environment.

The idea would be to move more CI scripts to `nix flake check`: it is easier to discover them and to reproduce them.