### PR TITLE
{default,shell}.nix: don't use builtins.fetchGit

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 (import (
   fetchTarball {
-    url = https://github.com/edolstra/flake-compat/archive/f012cc5092f01fc67d5cd6f04999f964c3e05cbf.tar.gz;
-    sha256 = "1n8q7v7alq802kl3b6zan6v27whi2ppbnlv8df6cz64vqf658ija"; }) {
-      src = builtins.fetchGit ./.;
+    url = "https://github.com/edolstra/flake-compat/archive/c75e76f80c57784a6734356315b306140646ee84.tar.gz";
+    sha256 = "071aal00zp2m9knnhddgr2wqzlx6i6qa1263lv1y7bdn2w20h10h"; }) {
+      src =  ./.;
 }).defaultNix

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 (import (
   fetchTarball {
-    url = https://github.com/edolstra/flake-compat/archive/f012cc5092f01fc67d5cd6f04999f964c3e05cbf.tar.gz;
-    sha256 = "1n8q7v7alq802kl3b6zan6v27whi2ppbnlv8df6cz64vqf658ija"; }) {
-      src = builtins.fetchGit ./.;
+    url = "https://github.com/edolstra/flake-compat/archive/c75e76f80c57784a6734356315b306140646ee84.tar.gz";
+    sha256 = "071aal00zp2m9knnhddgr2wqzlx6i6qa1263lv1y7bdn2w20h10h"; }) {
+      src =  ./.;
 }).shellNix


### PR DESCRIPTION
Otherwise, this would prevent one from using `import (fetchTarball
"https://github.com/NixOS/nixops/archive/master.tar.gz")` to run NixOps
from the master branch, for example. If you try to do so, you would see
some output like the following:

    fatal: '/nix/store/nysvzmqi11zfchympbksb8wcb2dxw6yz-source' does not appear to be a git repository
    fatal: Could not read from remote repository.

---

Fixes https://github.com/NixOS/nixops/issues/1370.