### PR TITLE
Use flake-compat without fetchGit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Prefetch shell.nix
@@ -23,8 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Prefetch shell.nix
@@ -36,8 +32,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Prefetch shell.nix
@@ -49,8 +43,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Prefetch shell.nix
@@ -62,8 +54,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Prefetch shell.nix
@@ -75,8 +65,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Prefetch shell.nix
@@ -88,8 +76,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Prefetch shell.nix
@@ -101,8 +87,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Prefetch shell.nix
@@ -114,8 +98,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Nix
         uses: cachix/install-nix-action@v8
       - name: Prefetch shell.nix

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,2 @@
-(import (
-  fetchTarball {
-    url = https://github.com/edolstra/flake-compat/archive/f012cc5092f01fc67d5cd6f04999f964c3e05cbf.tar.gz;
-    sha256 = "1n8q7v7alq802kl3b6zan6v27whi2ppbnlv8df6cz64vqf658ija"; }) {
-      src = builtins.fetchGit ./.;
-}).defaultNix
+{ pkgs ? import <nixpkgs> {} }:
+(import ./flake-compat.nix { inherit pkgs; }).defaultNix

--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -1,0 +1,10 @@
+{ pkgs }:
+
+(import (
+  fetchTarball {
+    url = https://github.com/edolstra/flake-compat/archive/f012cc5092f01fc67d5cd6f04999f964c3e05cbf.tar.gz;
+    sha256 = "1n8q7v7alq802kl3b6zan6v27whi2ppbnlv8df6cz64vqf658ija"; }) {
+      src = pkgs.poetry2nix.cleanPythonSources {
+        src = ./.;
+      };
+})

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,2 @@
-(import (
-  fetchTarball {
-    url = https://github.com/edolstra/flake-compat/archive/f012cc5092f01fc67d5cd6f04999f964c3e05cbf.tar.gz;
-    sha256 = "1n8q7v7alq802kl3b6zan6v27whi2ppbnlv8df6cz64vqf658ija"; }) {
-      src = builtins.fetchGit ./.;
-}).shellNix
+{ pkgs ? import <nixpkgs> {} }:
+(import ./flake-compat.nix { inherit pkgs; }).shellNix


### PR DESCRIPTION
An alternative approach to #1371 that doesn't force you to rebuild everything on every change.

This fixes 2 different issues:
1. Github actions Checkout does a shallow clone by default.
   We want to use a shallow clone but force a deep clone because
   builtins.fetchGit doesn't seem to work on shallow clones.

2. It doesn't work when this repo is a store path and .git is removed.
