### PR TITLE
add deployment.keys.<name>.name

### DIFF
--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -191,6 +191,11 @@ in
                   (opts.text != null && opts.keyFile == null && opts.keyCommand == null) ||
                   (opts.text == null && opts.keyFile == null && opts.keyCommand != null);
       message = "Deployment key '${key}' must have either a 'text', 'keyCommand' or a 'keyFile' specified.";
+    })) ++ (flip mapAttrsToList config.deployment.keys (key: opts: let
+      dups = lib.attrNames (lib.filterAttrs (n: v: n != key && v.path == opts.path) config.deployment.keys);
+    in {
+      assertion = dups == [];
+      message = "Deployment key '${key}' has non-unique paths, duplicated in: ${lib.concatStringsSep ", " dups}.";
     }));
 
     system.activationScripts.nixops-keys =

--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -4,6 +4,15 @@ with lib;
 
 let
   keyOptionsType = types.submodule ({ config, name, ... }: {
+    options.name = mkOption {
+       example = "secret.txt";
+       default = name;
+       type = types.str;
+       description = ''
+         The name of the key file.
+       '';
+     };
+
     options.text = mkOption {
       example = "super secret stuff";
       default = null;
@@ -77,7 +86,7 @@ let
 
     options.path = mkOption {
       type = types.path;
-      default = "${config.destDir}/${name}";
+      default = "${config.destDir}/${config.name}";
       internal = true;
       description = ''
         Path to the destination of the file, a shortcut to
@@ -228,7 +237,7 @@ in
           serviceConfig.RestartSec = "100ms";
           path = [ pkgs.inotifyTools ];
           preStart = ''
-            (while read f; do if [ "$f" = "${name}" ]; then break; fi; done \
+            (while read f; do if [ "$f" = "${keyCfg.name}" ]; then break; fi; done \
               < <(inotifywait -qm --format '%f' -e create,move ${keyCfg.destDir}) ) &
 
             if [[ -e "${keyCfg.path}" ]]; then

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -16,6 +16,8 @@ class KeyOptions(nixops.resources.ResourceOptions):
     text: Optional[str]
     keyFile: Optional[str]
     keyCommand: Optional[Sequence[str]]
+    name: str
+    path: str
     destDir: str
     user: str
     group: str
@@ -348,7 +350,7 @@ class MachineState(
             return
 
         for k, opts in self.get_keys().items():
-            self.log("uploading key ‘{0}’...".format(k))
+            self.log("uploading key ‘{0}’ to ‘{1}’...".format(k, opts["path"]))
             tmp = self.depl.tempdir + "/key-" + self.name
 
             destDir = opts["destDir"].rstrip("/")
@@ -379,10 +381,10 @@ class MachineState(
                     )
                 )
 
-            outfile = destDir + "/" + k
+            outfile = opts["path"]
             # We scp to a temporary file and then mv because scp is not atomic.
             # See https://github.com/NixOS/nixops/issues/762
-            tmp_outfile = destDir + "/." + k + ".tmp"
+            tmp_outfile = destDir + "/." + opts["name"] + ".tmp"
             outfile_esc = "'" + outfile.replace("'", r"'\''") + "'"
             tmp_outfile_esc = "'" + tmp_outfile.replace("'", r"'\''") + "'"
             self.run_command("rm -f " + outfile_esc + " " + tmp_outfile_esc)


### PR DESCRIPTION
allows multiple keys to have the same name

I haven't tested these changes against the master branch because I'm using nixops 1.7 currently. But similar changes work against 1.7. 