### PR TITLE
Follow redirects in nixos-infect's nix/install URL

### DIFF
--- a/nixops/data/nixos-infect
+++ b/nixops/data/nixos-infect
@@ -154,7 +154,7 @@ export HOME="/root"
 groupadd -r nixbld -g 30000
 seq 1 10 | xargs -I{} useradd -c "Nix build user {}" -d /var/empty -g nixbld -G nixbld -M -N -r -s `which nologin` nixbld{}
 
-curl https://nixos.org/nix/install | sh
+curl -L https://nixos.org/nix/install | sh
 
 source ~/.nix-profile/etc/profile.d/nix.sh
 


### PR DESCRIPTION
Originally I described the issue under [Kiwi/nixops-digitalocean](https://github.com/Kiwi/nixops-digitalocean/pull/1#issuecomment-653757244) however, the issue existed before the v2.0 NixOps plugin system, so it's more appropriate for this repo, specifically v1.7 and earlier probably.

Related to nixos.org migrating to Netlify, see [announcement](https://discourse.nixos.org/t/announcement-moving-nixos-org-to-netlify/6212). 