### PR TITLE
Nixops ssh conn quantity and stderr fixup

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -280,6 +280,7 @@ class MachineState(
                     timeout=1,
                     logged=False,
                     connection_tries=1,
+                    ssh_quiet=True,
                 )
             except Exception:
                 return False
@@ -302,6 +303,7 @@ class MachineState(
         callback: Optional[Callable[[], Any]] = None,
     ) -> None:
         nixops.util.wait_for_success(self._ping, timeout=timeout, callback=callback)
+        self.ssh.reset()  # To avoid passing a stderr suppressed master conn forward
 
     def wait_for_down(
         self,
@@ -309,6 +311,7 @@ class MachineState(
         callback: Optional[Callable[[], Any]] = None,
     ) -> None:
         nixops.util.wait_for_fail(self._ping, timeout=timeout, callback=callback)
+        self.ssh.reset()  # To avoid passing a stderr suppressed master conn forward
 
     def reboot_sync(self, hard: bool = False) -> None:
         """Reboot this machine and wait until it's up again."""

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -275,10 +275,14 @@ class MachineState(
         def _worker():
             try:
                 self.ssh.run_command(
-                    ["true"], user=self.ssh_user, logged=False, connection_tries=1
+                    ["true"],
+                    user=self.ssh_user,
+                    timeout=1,
+                    logged=False,
+                    connection_tries=1,
                 )
             except Exception:
-                pass
+                return False
             else:
                 event.set()
 

--- a/nixops/util.py
+++ b/nixops/util.py
@@ -35,6 +35,7 @@ from typing import (
     Iterable,
 )
 
+import nixops.util
 from nixops.logger import MachineLogger
 from io import StringIO
 
@@ -211,6 +212,7 @@ def logged_exec(  # noqa: C901
     logger: MachineLogger,
     check: bool = True,
     capture_stdout: bool = False,
+    capture_stderr: Optional[bool] = True,
     stdin: Optional[IO[Any]] = None,
     stdin_string: Optional[str] = None,
     env: Optional[Mapping[str, str]] = None,
@@ -246,7 +248,7 @@ def logged_exec(  # noqa: C901
             env=env,
             stdin=passed_stdin,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.PIPE if capture_stderr else nixops.util.devnull,
             preexec_fn=preexec_fn,
             text=True,
         )
@@ -258,7 +260,7 @@ def logged_exec(  # noqa: C901
             env=env,
             stdin=passed_stdin,
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            stderr=subprocess.STDOUT if capture_stderr else nixops.util.devnull,
             preexec_fn=preexec_fn,
             text=True,
         )


### PR DESCRIPTION
* Fixes issue #1375, too many ssh conns, as observed in testing with nixops-packet plugin https://github.com/input-output-hk/nixops-packet/pull/21.  Not yet tested with other plugins.
* The recent tcp port probe to ssh probe change (362d049) introduced threaded workers which persist in their ssh conn task despite event blocking timing out.  Adding an ssh connecttimeout to match the event block timeout resolves the buildup of worker threads.
* An option for suppression of ssh master stderr was added to enable ssh status probes to avoid outputting large quantities of expected stderr messages to the user. 
