### PR TITLE
Define plugins hooks as classes

### DIFF
--- a/doc/plugins/authoring.rst
+++ b/doc/plugins/authoring.rst
@@ -107,11 +107,15 @@ Important Notes
 
    .. code-block:: python
 
-     @nixops.plugins.hookimpl
-     def nixexprs():
-         return [
-             os.path.dirname(os.path.abspath(__file__)) + "/nix"
-         ]
+     from nixops.plugins import Plugin
+
+     class NeatCloudPlugin(Plugin):
+
+         @staticmethod
+         def nixexprs():
+             return [
+                 os.path.dirname(os.path.abspath(__file__)) + "/nix"
+             ]
 
 5. Resource subclasses must now work with Python objects instead of XML
 
@@ -261,7 +265,7 @@ return it in the appropriate plugin hook:
   from nixops.plugins import Plugin
   import nixops.plugins
 
-  class MyPlugin(Plugin):
+  class NeatCloudPlugin(Plugin):
 
       @staticmethod
       def nixexprs():
@@ -269,7 +273,7 @@ return it in the appropriate plugin hook:
 
   @nixops.plugins.hookimpl
   def plugin():
-      return MyPlugin()
+      return NeatCloudPlugin()
 
 
 

--- a/doc/plugins/authoring.rst
+++ b/doc/plugins/authoring.rst
@@ -250,6 +250,29 @@ discover and load plugins. The glue which hooks things together is in
 NixOps implements a handful of hooks which your plugin can integrate
 with. See ``nixops/plugins/hookspec.py`` for a complete list.
 
+Defining a plugin
+-----------------
+
+To define a plugin you need to inherit from the `Plugin` base class and
+return it in the appropriate plugin hook:
+
+.. code-block:: python
+
+  from nixops.plugins import Plugin
+  import nixops.plugins
+
+  class MyPlugin(Plugin):
+
+      @staticmethod
+      def nixexprs():
+          return [ ]  # List of paths to nix expressions
+
+  @nixops.plugins.hookimpl
+  def plugin():
+      return MyPlugin()
+
+
+
 Developing NixOps and a plugin at the same time
 -----------------------------------------------
 

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -608,8 +608,3 @@ class CheckResult(object):
 
 
 GenericMachineState = MachineState[MachineDefinition]
-
-
-class MachinePlugin(Protocol):
-    def post_wait(self, m: MachineState) -> None:
-        pass

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -118,8 +118,11 @@ class MachineState(
     # machine was created.
     state_version: Optional[str] = nixops.util.attr_property("stateVersion", None, str)
 
+    defn: Optional[MachineDefinition] = None
+
     def __init__(self, depl, name: str, id: RecordId) -> None:
         super().__init__(depl, name, id)
+        self.defn = None
         self._ssh_pinged_this_time = False
         self.ssh = nixops.ssh_util.SSH(self.logger)
         self.ssh.register_flag_fun(self.get_ssh_flags)
@@ -138,6 +141,7 @@ class MachineState(
         return state == self.STARTING or state == self.UP
 
     def set_common_state(self, defn: MachineDefinitionType) -> None:
+        self.defn = defn
         self.keys = defn.keys
         self.ssh_port = defn.ssh_port
         self.ssh_user = defn.ssh_user

--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -608,3 +608,8 @@ class CheckResult(object):
 
 
 GenericMachineState = MachineState[MachineDefinition]
+
+
+class MachinePlugin(Protocol):
+    def post_wait(self, m: MachineState) -> None:
+        pass

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -56,6 +56,7 @@ class UnknownBackend(Exception):
 
 DEBUG = False
 
+NixosConfigurationType = List[Dict[Tuple[str, ...], Any]]
 
 TypedResource = TypeVar("TypedResource")
 
@@ -603,7 +604,7 @@ class Deployment:
         active_machines = self.active_machines
         active_resources = self.active_resources
 
-        attrs_per_resource: Dict[str, List[Dict[Tuple[str, ...], Any]]] = {
+        attrs_per_resource: Dict[str, NixosConfigurationType] = {
             m.name: [] for m in active_resources.values()
         }
         authorized_keys: Dict[str, List[str]] = {
@@ -690,7 +691,7 @@ class Deployment:
             do_machine(m)
 
         def emit_resource(r: nixops.resources.GenericResourceState) -> Any:
-            config: List[Dict[Tuple[str, ...], Any]] = []
+            config: NixosConfigurationType = []
             config.extend(attrs_per_resource[r.name])
             if is_machine(r):
                 # Sort the hosts by its canonical host names.

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -1795,5 +1795,12 @@ def _load_modules_from(dir: str) -> None:
         importlib.import_module("nixops." + dir + "." + module[:-3])
 
 
+class DeploymentPlugin(Protocol):
+    def physical_spec(
+        self, d: Deployment
+    ) -> Dict[str, List[Dict[Tuple[str, ...], Any]]]:
+        return {}
+
+
 _load_modules_from("backends")
 _load_modules_from("resources")

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -1345,6 +1345,9 @@ class Deployment:
 
                         m.wait_for_ssh(check=check)
 
+                        for p in get_plugin_manager().hook.machine_hook():
+                            p.post_wait(m)
+
                 except Exception:
                     r._errored = True
                     raise

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -679,7 +679,7 @@ class Deployment:
             do_machine(m)
 
         def emit_resource(r: nixops.resources.GenericResourceState) -> Any:
-            config = []
+            config: List[Dict[Tuple[str, ...], Any]] = []
             config.extend(attrs_per_resource[r.name])
             if is_machine(r):
                 # Sort the hosts by its canonical host names.

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -613,6 +613,10 @@ class Deployment:
             m.name: set() for m in active_machines.values()
         }
 
+        for p in get_plugin_manager().hook.deployment_hook():
+            for name, attrs in p.physical_spec(self).items():
+                attrs_per_resource[name].extend(attrs)
+
         # Hostnames should be accumulated like this:
         #
         #   hosts[local_name][remote_ip] = [name1, name2, ...]

--- a/nixops/plugins/__init__.py
+++ b/nixops/plugins/__init__.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+from typing import Generator
 import pluggy
 from . import hookspecs
 
@@ -5,8 +7,15 @@ hookimpl = pluggy.HookimplMarker("nixops")
 """Marker to be imported and used in plugins (and for own implementations)"""
 
 
+@lru_cache()
 def get_plugin_manager():
     pm = pluggy.PluginManager("nixops")
     pm.add_hookspecs(hookspecs)
     pm.load_setuptools_entrypoints("nixops")
     return pm
+
+
+def get_plugins() -> Generator[hookspecs.Plugin, None, None]:
+    pm = get_plugin_manager()
+    for plugin in pm.hook.plugin():
+        yield plugin

--- a/nixops/plugins/__init__.py
+++ b/nixops/plugins/__init__.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
+from nixops.backends import MachineState
+from typing import List, Dict, Optional
+
 from functools import lru_cache
 from typing import Generator
 import pluggy
-from . import hookspecs
+
 
 hookimpl = pluggy.HookimplMarker("nixops")
 """Marker to be imported and used in plugins (and for own implementations)"""
@@ -9,13 +14,73 @@ hookimpl = pluggy.HookimplMarker("nixops")
 
 @lru_cache()
 def get_plugin_manager():
+    from . import hookspecs
+
     pm = pluggy.PluginManager("nixops")
     pm.add_hookspecs(hookspecs)
     pm.load_setuptools_entrypoints("nixops")
     return pm
 
 
-def get_plugins() -> Generator[hookspecs.Plugin, None, None]:
+def get_plugins() -> Generator[Plugin, None, None]:
     pm = get_plugin_manager()
     for plugin in pm.hook.plugin():
         yield plugin
+
+
+class DeploymentHooks:
+    """
+    Deployment level hooks
+    """
+
+    def physical_spec(self, d) -> Dict[str, Dict]:
+        """
+        Manipulate NixOS configurations for machines in deployment
+
+        :return a dict with NixOS configuration
+        """
+        return {}
+
+
+class MachineHooks:
+    def post_wait(self, m: MachineState) -> None:
+        """
+        Do action once SSH is available
+        """
+        pass
+
+
+class Plugin:
+    def deployment_hooks(self) -> Optional[DeploymentHooks]:
+        """
+        Run deployment hooks
+        """
+        return None
+
+    def machine_hooks(self) -> Optional[MachineHooks]:
+        """
+        Run machine hooks
+        """
+        return None
+
+    def load(self) -> List[str]:
+        """
+        Load plugins (import)
+
+        :return a list of modules to import
+        """
+        return []
+
+    def nixexprs(self) -> List[str]:
+        """
+        Get all the Nix expressions to load
+
+        :return a list of Nix expressions to import
+        """
+        return []
+
+    def parser(self, parser, subparsers):
+        """
+        Extend the core nixops cli parser
+        """
+        pass

--- a/nixops/plugins/__init__.py
+++ b/nixops/plugins/__init__.py
@@ -6,6 +6,7 @@ from typing import List, Dict, Optional, Union
 from functools import lru_cache
 from typing import Generator
 import pluggy
+import nixops
 
 
 hookimpl = pluggy.HookimplMarker("nixops")
@@ -33,7 +34,9 @@ class DeploymentHooks:
     Deployment level hooks
     """
 
-    def physical_spec(self, d) -> Dict[str, Union[List[Dict], Dict]]:
+    def physical_spec(
+        self, d: "nixops.deployment.Deployment"
+    ) -> Dict[str, Union[List[Dict], Dict]]:
         """
         Manipulate NixOS configurations for machines in deployment
 

--- a/nixops/plugins/__init__.py
+++ b/nixops/plugins/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from nixops.backends import MachineState
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union
 
 from functools import lru_cache
 from typing import Generator
@@ -33,7 +33,7 @@ class DeploymentHooks:
     Deployment level hooks
     """
 
-    def physical_spec(self, d) -> Dict[str, Dict]:
+    def physical_spec(self, d) -> Dict[str, Union[List[Dict], Dict]]:
         """
         Manipulate NixOS configurations for machines in deployment
 

--- a/nixops/plugins/hookspecs.py
+++ b/nixops/plugins/hookspecs.py
@@ -23,3 +23,10 @@ def parser(parser, subparsers):
     """ Extend the core nixops cli parser
     :return a set of plugin parser extensions
     """
+
+
+@hookspec
+def deployment_hook():
+    """Load hooks at early NixOps startup"""
+
+

--- a/nixops/plugins/hookspecs.py
+++ b/nixops/plugins/hookspecs.py
@@ -30,3 +30,6 @@ def deployment_hook():
     """Load hooks at early NixOps startup"""
 
 
+@hookspec
+def machine_hook():
+    """Hook into various stages of a machine lifecycle"""

--- a/nixops/plugins/hookspecs.py
+++ b/nixops/plugins/hookspecs.py
@@ -1,35 +1,73 @@
+from typing import List, Dict, Optional
+from nixops.backends import MachineState
+
 import pluggy
 
 
 hookspec = pluggy.HookspecMarker("nixops")
 
 
-@hookspec
-def load():
-    """ Load plugins (import)
-    :return a list of modules to import
+class DeploymentHooks:
+    """
+    Deployment level hooks
     """
 
+    def physical_spec(self, d) -> Dict[str, Dict]:
+        """
+        Manipulate NixOS configurations for machines in deployment
+
+        :return a dict with NixOS configuration
+        """
+        return {}
+
+
+class MachineHooks:
+    def post_wait(self, m: MachineState) -> None:
+        """
+        Do action once SSH is available
+        """
+        pass
+
+
+class Plugin:
+    def deployment_hooks(self) -> Optional[DeploymentHooks]:
+        """
+        Run deployment hooks
+        """
+        return None
+
+    def machine_hooks(self) -> Optional[MachineHooks]:
+        """
+        Run machine hooks
+        """
+        return None
+
+    def load(self) -> List[str]:
+        """
+        Load plugins (import)
+
+        :return a list of modules to import
+        """
+        return []
+
+    def nixexprs(self) -> List[str]:
+        """
+        Get all the Nix expressions to load
+
+        :return a list of Nix expressions to import
+        """
+        return []
+
+    def parser(self, parser, subparsers):
+        """
+        Extend the core nixops cli parser
+        """
+        pass
+
 
 @hookspec
-def nixexprs():
-    """ Get all the Nix expressions to load
-    :return a list of Nix expressions to import
+def plugin() -> Plugin:
     """
-
-
-@hookspec
-def parser(parser, subparsers):
-    """ Extend the core nixops cli parser
-    :return a set of plugin parser extensions
+    Register a plugin base class
     """
-
-
-@hookspec
-def deployment_hook():
-    """Load hooks at early NixOps startup"""
-
-
-@hookspec
-def machine_hook():
-    """Hook into various stages of a machine lifecycle"""
+    pass

--- a/nixops/plugins/hookspecs.py
+++ b/nixops/plugins/hookspecs.py
@@ -1,68 +1,9 @@
-from typing import List, Dict, Optional
-from nixops.backends import MachineState
+from . import Plugin
 
 import pluggy
 
 
 hookspec = pluggy.HookspecMarker("nixops")
-
-
-class DeploymentHooks:
-    """
-    Deployment level hooks
-    """
-
-    def physical_spec(self, d) -> Dict[str, Dict]:
-        """
-        Manipulate NixOS configurations for machines in deployment
-
-        :return a dict with NixOS configuration
-        """
-        return {}
-
-
-class MachineHooks:
-    def post_wait(self, m: MachineState) -> None:
-        """
-        Do action once SSH is available
-        """
-        pass
-
-
-class Plugin:
-    def deployment_hooks(self) -> Optional[DeploymentHooks]:
-        """
-        Run deployment hooks
-        """
-        return None
-
-    def machine_hooks(self) -> Optional[MachineHooks]:
-        """
-        Run machine hooks
-        """
-        return None
-
-    def load(self) -> List[str]:
-        """
-        Load plugins (import)
-
-        :return a list of modules to import
-        """
-        return []
-
-    def nixexprs(self) -> List[str]:
-        """
-        Get all the Nix expressions to load
-
-        :return a list of Nix expressions to import
-        """
-        return []
-
-    def parser(self, parser, subparsers):
-        """
-        Extend the core nixops cli parser
-        """
-        pass
 
 
 @hookspec

--- a/nixops/plugins/manager.py
+++ b/nixops/plugins/manager.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from nixops.backends import MachineState
+from typing import List, Dict, Generator, Tuple, Any, Set
+import importlib
+
+from . import get_plugins, MachineHooks, DeploymentHooks
+import nixops
+
+
+NixosConfigurationType = List[Dict[Tuple[str, ...], Any]]
+
+
+class DeploymentHooksManager:
+    @staticmethod
+    def physical_spec(
+        deployment: "nixops.deployment.Deployment",
+    ) -> Dict[str, NixosConfigurationType]:
+        attrs_per_resource: Dict[str, NixosConfigurationType] = {}
+
+        for hook in PluginManager.deployment_hooks():
+            for name, attrs in hook.physical_spec(deployment).items():
+                attrs_per_resource[name].extend(attrs)
+
+        return attrs_per_resource
+
+
+class MachineHooksManager:
+    @staticmethod
+    def post_wait(m: MachineState) -> None:
+        for hook in PluginManager.machine_hooks():
+            hook.post_wait(m)
+
+
+class PluginManager:
+    @staticmethod
+    def deployment_hooks() -> Generator[DeploymentHooks, None, None]:
+        for plugin in get_plugins():
+            machine_hooks = plugin.deployment_hooks()
+            if not machine_hooks:
+                continue
+            yield machine_hooks
+
+    @staticmethod
+    def machine_hooks() -> Generator[MachineHooks, None, None]:
+        for plugin in get_plugins():
+            machine_hooks = plugin.machine_hooks()
+            if not machine_hooks:
+                continue
+            yield machine_hooks
+
+    @staticmethod
+    def load():
+        seen: Set[str] = set()
+        for plugin in get_plugins():
+            for mod in plugin.load():
+                if mod not in seen:
+                    importlib.import_module(mod)
+            seen.add(mod)
+
+    @staticmethod
+    def nixexprs() -> List[str]:
+        nixexprs: List[str] = []
+        for plugin in get_plugins():
+            nixexprs.extend(plugin.nixexprs())
+        return nixexprs
+
+    @staticmethod
+    def parser(parser, subparsers):
+        for plugin in get_plugins():
+            plugin.parser(parser, subparsers)

--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -27,6 +27,7 @@ class ResourceOptions(ImmutableValidatedObject):
 class ResourceDefinition:
     """Base class for NixOps resource definitions."""
 
+    resource_eval: ResourceEval
     config: ResourceOptions
 
     @classmethod
@@ -46,6 +47,7 @@ class ResourceDefinition:
                 '"config" type annotation must be a ResourceOptions subclass'
             )
 
+        self.resource_eval = config
         self.config = config_type(**config)
         self.name = name
 

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -21,19 +21,14 @@ import logging.handlers
 import json
 import pipes
 from typing import Tuple, List, Optional, Union, Generator
-import importlib
 import nixops.ansi
 
-from nixops.plugins import get_plugin_manager, get_plugins
+from nixops.plugins.manager import PluginManager
+
+from nixops.plugins import get_plugin_manager
 
 
-def __load_plugins():
-    for plugin in get_plugins():
-        for mod in plugin.load():
-            importlib.import_module(mod)
-
-
-__load_plugins()
+PluginManager.load()
 
 
 @contextlib.contextmanager
@@ -1213,5 +1208,4 @@ def error(msg):
 
 
 def parser_plugin_hooks(parser, subparsers):
-    for plugin in get_plugins():
-        plugin.parser(parser=parser, subparsers=subparsers)
+    PluginManager.parser(parser, subparsers)

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -24,14 +24,16 @@ from typing import Tuple, List, Optional, Union, Generator
 import importlib
 import nixops.ansi
 
-from nixops.plugins import get_plugin_manager
+from nixops.plugins import get_plugin_manager, get_plugins
 
 
-pm = get_plugin_manager()
-[
-    [importlib.import_module(mod) for mod in pluginimports]
-    for pluginimports in pm.hook.load()
-]
+def __load_plugins():
+    for plugin in get_plugins():
+        for mod in plugin.load():
+            importlib.import_module(mod)
+
+
+__load_plugins()
 
 
 @contextlib.contextmanager
@@ -51,6 +53,8 @@ def network_state(args: Namespace) -> Generator[nixops.statefile.StateFile, None
 
 
 def op_list_plugins(args):
+    pm = get_plugin_manager()
+
     if args.verbose:
         tbl = create_table([("Installed Plugins", "c"), ("Plugin Reference", "c")])
     else:
@@ -1209,4 +1213,5 @@ def error(msg):
 
 
 def parser_plugin_hooks(parser, subparsers):
-    pm.hook.parser(parser=parser, subparsers=subparsers)
+    for plugin in get_plugins():
+        plugin.parser(parser=parser, subparsers=subparsers)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,14 +5,6 @@ import threading
 from os import path
 import nixops.statefile
 
-import importlib
-from nixops.plugins import get_plugin_manager
-
-[
-    [importlib.import_module(mod) for mod in pluginimports]
-    for pluginimports in get_plugin_manager().hook.load()
-]
-
 _multiprocess_shared_ = True
 
 db_file = "%s/test.nixops" % (path.dirname(__file__))


### PR DESCRIPTION
This is a better way to deal with plugins as we can statically type each individual function, something not possible with pluggy hooks.