### PR TITLE
ResourceState.definition_type: introduce for run-time accessible definition type validation

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -66,9 +66,7 @@ class MachineDefinition(nixops.resources.ResourceDefinition):
         self.provision_ssh_key = config["provisionSSHKey"]
 
 
-MachineDefinitionType = TypeVar(
-    "MachineDefinitionType", bound="MachineDefinition", contravariant=True
-)
+MachineDefinitionType = TypeVar("MachineDefinitionType", bound="MachineDefinition")
 
 
 @runtime_checkable

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -65,6 +65,7 @@ DEBUG = False
 NixosConfigurationType = List[Dict[Tuple[str, ...], Any]]
 
 TypedResource = TypeVar("TypedResource")
+TypedDefinition = TypeVar("TypedDefinition")
 
 
 class Deployment:
@@ -195,6 +196,26 @@ class Deployment:
         if not isinstance(res, type):
             raise ValueError(f"{res} not of type {type}")
         return res
+
+    def get_generic_definition(
+        self, name: str, type_name: str
+    ) -> nixops.resources.ResourceDefinition:
+        defn = self._definitions().get(name, None)
+        if not defn:
+            raise Exception("definition ‘{0}’ does not exist".format(name))
+        if defn.get_type() != type_name:
+            raise Exception(
+                "definition ‘{0}’ is not of type ‘{1}’".format(name, type_name)
+            )
+        return defn
+
+    def get_typed_definition(
+        self, name: str, type_name: str, type: Type[TypedDefinition]
+    ) -> TypedDefinition:
+        defn = self.get_generic_definition(name, type_name)
+        if not isinstance(defn, type):
+            raise ValueError(f"{defn} not of type {type}")
+        return defn
 
     def get_machine(self, name: str, type: Type[TypedResource]) -> TypedResource:
         m = self.get_generic_machine(name)

--- a/nixops/diff.py
+++ b/nixops/diff.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import itertools
 
-from typing import Any, AnyStr, Callable, Dict, List, Optional, Tuple
+from typing import Any, AnyStr, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
 from nixops.logger import MachineLogger
 from nixops.state import StateDict
+
+if TYPE_CHECKING:
+    import nixops.deployment
 
 
 class Handler:
@@ -51,16 +54,12 @@ class Diff:
 
     def __init__(
         self,
-        # FIXME: type should be 'nixops.deployment.Deployment'
-        # however we have to upgrade to python3 in order
-        # to solve the import cycle by forward declaration
-        depl: Any,
+        depl: nixops.deployment.Deployment,
         logger: MachineLogger,
         config: Dict[str, Any],
         state: StateDict,
         res_type: str,
-    ):
-        # type: (...) -> None
+    ) -> None:
         self.handlers: List[Handler] = []
         self._definition = config
         self._state = state

--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import re
 import nixops.util
 from threading import Event
-from typing import List, Optional, Dict, Any, TypeVar, Union, TYPE_CHECKING
-from nixops.monkey import Protocol
+from typing import List, Optional, Dict, Any, Type, TypeVar, Union, TYPE_CHECKING
+from nixops.monkey import Protocol, runtime_checkable
 from nixops.state import StateDict, RecordId
 from nixops.diff import Diff, Handler
 from nixops.util import ImmutableMapping, ImmutableValidatedObject
@@ -70,13 +70,14 @@ class ResourceDefinition:
         return self.get_type()
 
 
-ResourceDefinitionType = TypeVar(
-    "ResourceDefinitionType", bound="ResourceDefinition", contravariant=True
-)
+ResourceDefinitionType = TypeVar("ResourceDefinitionType", bound="ResourceDefinition")
 
 
+@runtime_checkable
 class ResourceState(Protocol[ResourceDefinitionType]):
     """Base class for NixOps resource state objects."""
+
+    definition_type: Type[ResourceDefinitionType]
 
     name: str
 
@@ -329,7 +330,10 @@ class ResourceState(Protocol[ResourceDefinitionType]):
         return None
 
 
-class DiffEngineResourceState(ResourceState):
+@runtime_checkable
+class DiffEngineResourceState(
+    ResourceState[ResourceDefinitionType], Protocol[ResourceDefinitionType]
+):
     _reserved_keys: List[str] = []
     _state: StateDict
 
@@ -376,11 +380,10 @@ class DiffEngineResourceState(ResourceState):
             getattr(self, h) for h in dir(self) if isinstance(getattr(self, h), Handler)
         ]
 
-    def get_defn(self):
-        if self.depl.definitions is not None and self.name in self.depl.definitions:
-            return self.depl.definitions[self.name].config
-        else:
-            return {}
+    def get_defn(self) -> ResourceDefinitionType:
+        return self.depl.get_typed_definition(
+            self.name, self.get_type(), self.definition_type
+        )
 
 
 GenericResourceState = ResourceState[ResourceDefinition]

--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -341,20 +341,26 @@ class DiffEngineResourceState(
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
 
-    def create(self, defn, check, allow_reboot, allow_recreate):
+    def create(
+        self,
+        defn: ResourceDefinitionType,
+        check: bool,
+        allow_reboot: bool,
+        allow_recreate: bool,
+    ):
         # if --check is true check against the api and update the state
         # before firing up the diff engine in order to get the needed
         # handlers calls
         if check:
             self._check()
-        diff_engine = self.setup_diff_engine(defn.config)
+        diff_engine = self.setup_diff_engine(defn)
 
         for handler in diff_engine.plan():
             handler.handle(allow_recreate)
 
-    def plan(self, defn):
+    def plan(self, defn: ResourceDefinitionType):
         if hasattr(self, "_state"):
-            diff_engine = self.setup_diff_engine(defn.config)
+            diff_engine = self.setup_diff_engine(defn)
             diff_engine.plan(show=True)
         else:
             self.warn(
@@ -363,11 +369,11 @@ class DiffEngineResourceState(
                 )
             )
 
-    def setup_diff_engine(self, config):
+    def setup_diff_engine(self, defn: ResourceDefinitionType):
         diff_engine = Diff(
             depl=self.depl,
             logger=self.logger,
-            config=dict(config),
+            defn=defn,
             state=self._state,
             res_type=self.get_type(),
         )


### PR DESCRIPTION
This is paired with https://github.com/NixOS/nixops-aws/pull/108. Adding these types here showed zillions of type errors in the nixops-aws plugin. #108 fixes a zillion issues in the types, which makes it actually work. :)