### PR TITLE
Fix DiffEngineResourceState

### DIFF
--- a/nixops/resources/__init__.py
+++ b/nixops/resources/__init__.py
@@ -343,7 +343,7 @@ class DiffEngineResourceState(ResourceState):
         # handlers calls
         if check:
             self._check()
-        diff_engine = self.setup_diff_engine(config=defn.config)
+        diff_engine = self.setup_diff_engine(defn.config)
 
         for handler in diff_engine.plan():
             handler.handle(allow_recreate)
@@ -363,7 +363,7 @@ class DiffEngineResourceState(ResourceState):
         diff_engine = Diff(
             depl=self.depl,
             logger=self.logger,
-            config=config,
+            config=dict(config),
             state=self._state,
             res_type=self.get_type(),
         )


### PR DESCRIPTION
Following on from the welcome changes in #697 it seems the vpc resources are a bit broken downstream and one of the issues originates here.

DiffEngineResourceState is the base state class for custom resources utilising the new diff engine. When deploying (or planning) a deployment of this type of resource the diff engine gets initialised with
https://github.com/NixOS/nixops/blob/0330ead36be75c0b0f80cf84c227f13380daf414/nixops/resources/__init__.py#L346
The issue is that `defn.config` here is a ResourceOptions subclass instance. Eventually a diff gets constructed with this object when it requires a dict
https://github.com/NixOS/nixops/blob/0330ead36be75c0b0f80cf84c227f13380daf414/nixops/diff.py#L59
and chaos soon ensues, causing the following error (nixops-aws vpc example) deploying affected resources.
```
Traceback (most recent call last):
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/bin/nixops", line 33, in <module>
    sys.exit(load_entry_point('nixops', 'console_scripts', 'nixops')())
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/src/nixops/nixops/__main__.py", line 710, in main
    args.op(args)
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/src/nixops/nixops/script_defs.py", line 637, in op_deploy
    max_concurrent_activate=args.max_concurrent_activate,
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/src/nixops/nixops/deployment.py", line 1458, in deploy
    self.run_with_notify("deploy", lambda: self._deploy(**kwargs))
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/src/nixops/nixops/deployment.py", line 1447, in run_with_notify
    f()
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/src/nixops/nixops/deployment.py", line 1458, in <lambda>
    self.run_with_notify("deploy", lambda: self._deploy(**kwargs))
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/src/nixops/nixops/deployment.py", line 1364, in _deploy
    worker_fun=worker,
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/src/nixops/nixops/parallel.py", line 106, in run_tasks
    raise list(exceptions.values())[0]
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/src/nixops/nixops/parallel.py", line 70, in thread_fun
    work_result = (worker_fun(t), None, t.name)
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/src/nixops/nixops/deployment.py", line 1319, in worker
    allow_recreate=allow_recreate,
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/src/nixops/nixops/resources/__init__.py", line 348, in create
    for handler in diff_engine.plan():
  File "/home/lukebfox/.cache/pypoetry/virtualenvs/nixops-aws-dVwxRzVJ-py3.7/src/nixops/nixops/diff.py", line 99, in plan
    keys = list(self._state.keys()) + list(self._definition.keys())
AttributeError: 'VpcOptions' object has no attribute 'keys'
```
It's a simple fix, and I'd like to get this merged because I'm using the diff engine in a nixops plugin I am writing for hetzner cloud.
Thanks!