### PR TITLE
nixops copy-closure: use the copy mechanism as exposed by the machine

### DIFF
--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -992,20 +992,7 @@ def op_edit(args):
 def op_copy_closure(args):
     with deployment(args) as depl:
         (username, machine, m) = parse_machine(args.machine, depl)
-        env = dict(os.environ)
-        env["NIX_SSHOPTS"] = " ".join(m.get_ssh_flags())
-        res = nixops.util.logged_exec(
-            [
-                "nix",
-                "copy",
-                "--to",
-                "ssh://{}".format(m.get_ssh_name()),
-                args.storepath,
-            ],
-            m.logger,
-            env=env,
-        )
-        sys.exit(res)
+        m.copy_closure_to(args.storepath)
 
 
 # Set up logging of all commands and output


### PR DESCRIPTION
For one this behaves different from the closure copying that happends
during deployment and it also makes use of unstable nix features that
might change without any notice.