### PR TITLE
modify statedict: enable storing dict via json.dump

### DIFF
--- a/nixops/state.py
+++ b/nixops/state.py
@@ -29,7 +29,7 @@ class StateDict(collections.MutableMapping):
                 )
             else:
                 v = value
-                if isinstance(value, list):
+                if isinstance(value, list) or isinstance(value, dict):
                     v = json.dumps(value, cls=nixops.util.NixopsEncoder)
                 c.execute(
                     "insert or replace into ResourceAttrs(machine, name, value) values (?, ?, ?)",


### PR DESCRIPTION
attr_property has the ability to set state for attributes created with the "json" type with values of the list or dict type.
https://github.com/NixOS/nixops/blob/a287225018ced729d7fcf0858ed4fab2d7131c56/nixops/util.py#L487-L488
The diff engine uses the newer StateDict, which has it's own setter for state.
https://github.com/NixOS/nixops/blob/78a88155f1d9e935a2f73e61db4e77093a4a4b54/nixops/state.py#L31-L37
The nixops-aws VPC resources which motivated the diff engine never had a dict case, so I guess it was left out, but it's important to keep this functionality for other resources which want to use the diff engine in the future (I am working on some).