### PR TITLE
Don't hijack `pkgs` in the nixos config

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -86,7 +86,6 @@ in rec {
       in
       { name = machineName;
         value = evalConfig {
-          inherit pkgs;
           modules =
             modules ++
             defaults ++
@@ -99,6 +98,8 @@ in rec {
                 networking.hostName = lib.mkOverride 900 machineName;
                 deployment.targetHost = lib.mkOverride 900 machineName;
                 environment.checkConfigurationOptions = lib.mkOverride 900 checkConfigurationOptions;
+
+                nixpkgs.system = lib.mkDefault system;
               }
             ];
           extraArgs = { inherit nodes resources uuid deploymentName; name = machineName; };


### PR DESCRIPTION
Don't pass `pkgs` to `evalConfig` as

1. This prevents most `nixpkgs.*` option from working
2. This doesn't add any encapsulation guaranty as by default NixOS gets nixpkgs from the path of the toplevel module − which is the same as what NixOps does (see https://github.com/NixOS/nixpkgs/blob/4d43de3/nixos/modules/misc/nixpkgs.nix#L58-L60)

Hopefully fixes #1389 and #1418