### PR TITLE
Bump pretty tables version to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["nix/*.nix", "nixops/py.typed" ]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-PrettyTable = "^0.7.2"
+PrettyTable = "^2.0.0"
 pluggy = "^0.13.1"
 typeguard = "^2.7.1"
 typing-extensions = "^3.7.4"


### PR DESCRIPTION
nixops package is broken; attempts to install it yields the error:

ERROR: Package 'prettytable' requires a different Python: 2.7.18
not in '>=3.6'

This bumps the version of prettytables to 2.0.0 which resolves the
issue.