### PR TITLE
upgrading install-nix-action to fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
         run: 'nix-shell --run true'
       - name: Coverage
         run: './ci/check-tests.sh'
+        env:
+          NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz"
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Prefetch shell.nix
         run: 'nix-shell --run true'
       - name: Parsing
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Prefetch shell.nix
         run: 'nix-shell --run true'
       - name: Build
@@ -39,7 +39,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Prefetch shell.nix
         run: 'nix-shell --run true'
       - name: Black
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Prefetch shell.nix
         run: 'nix-shell --run true'
       - name: Mypy
@@ -65,7 +65,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Prefetch shell.nix
         run: 'nix-shell --run true'
       - name: Mypy
@@ -78,7 +78,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Prefetch shell.nix
         run: 'nix-shell --run true'
       - name: Mypy Ratchet
@@ -91,7 +91,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Prefetch shell.nix
         run: 'nix-shell --run true'
       - name: Coverage
@@ -104,7 +104,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
         # To use nixFlake in the next step
       - name: Prefetch shell.nix
         run: 'nix-shell --run true'
@@ -120,7 +120,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Prefetch shell.nix
         run: 'nix-shell --run true'
       - name: Poetry Locks Consistent


### PR DESCRIPTION
All nixops as well as nixops-plugins' builds are failing at the 'nix installation' part

```Error: Unable to process command '::add-path::/nix/var/nix/profiles/per-user/runner/profile/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::add-path::/nix/var/nix/profiles/default/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::set-env name=NIX_PATH::/nix/var/nix/profiles/per-user/root/channels' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```


Ref : https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

It was fixed per https://github.com/cachix/install-nix-action/pull/52 so we need to upgrade to v12

cc @adisbladis 