### PR TITLE
Fixes a missing key error for attrs

### DIFF
--- a/nixops/plugins/manager.py
+++ b/nixops/plugins/manager.py
@@ -20,6 +20,8 @@ class DeploymentHooksManager:
 
         for hook in PluginManager.deployment_hooks():
             for name, attrs in hook.physical_spec(deployment).items():
+                if name not in attrs_per_resource:
+                    attrs_per_resource[name] = []
                 attrs_per_resource[name].extend(attrs)
 
         return attrs_per_resource


### PR DESCRIPTION
* Enables the encrypted-links plugin, which otherwise throws a missing key error on `attrs_per_resource[name].extend(attrs)` without this handling
* See the encrypted-links plugin fixup PR at: https://github.com/nix-community/nixops-encrypted-links/pull/3