### PR TITLE
fix #1437

### DIFF
--- a/nixops/state.py
+++ b/nixops/state.py
@@ -46,7 +46,10 @@ class StateDict(collections.MutableMapping):
             row: Tuple[str] = c.fetchone()
             if row is not None:
                 try:
-                    return json.loads(row[0])
+                    v = json.loads(row[0])
+                    if isinstance(v, list):
+                        v = tuple(v)
+                    return v
                 except ValueError:
                     return row[0]
             raise KeyError("couldn't find key {} in the state file".format(key))


### PR DESCRIPTION
fixes #1437:
When querying state, casting list typed values into tuples makes diff comparisons type-consistent. 

The JSON encoder may squish both lists and tuples into JSON arrays, however this information loss doesn't affect us because we never parse nix definitions in as lists, only as tuples. As such, decoding all JSON arrays to tuples is safe, and solves our problem.