### PR TITLE
eval-machine-info.nix: Fix nixpkgs setting

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -48,7 +48,10 @@ let
       if network ? nixpkgs
       then (builtins.head network.nixpkgs).legacyPackages.${system}
       else throw "NixOps network must have a 'nixpkgs' attribute"
-    else (builtins.head (network.network)).nixpkgs or (import <nixpkgs> { inherit system; });
+    else
+      if (network.network or []) == []
+      then import <nixpkgs> { inherit system; }
+      else (builtins.head network.network).nixpkgs or (import <nixpkgs> { inherit system; });
 
   inherit (pkgs) lib;
 


### PR DESCRIPTION
Fixes the errors encountered in the test suite:

```
error: --- EvalError ---------------- nix-instantiate
at: (51:26) in file: /home/user/h/nixops/nix/eval-machine-info.nix

    50|       else throw "NixOps network must have a 'nixpkgs' attribute"
    51|     else (builtins.head (network.network)).nixpkgs or (import <nixpkgs> { inherit system; });
      |                          ^
    52|

attribute 'network' missing
```

However, I'm a bit puzzled by the fact that the tests succeeded, even without this "fix".