### PR TITLE
'nix flake': 'info' -> 'metadata'

### DIFF
--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -143,7 +143,7 @@ class Deployment:
         if self._cur_flake_uri is None:
             out = json.loads(
                 subprocess.check_output(
-                    ["nix", "flake", "info", "--json", "--", self.flake_uri],
+                    ["nix", "flake", "metadata", "--json", "--", self.flake_uri],
                     stderr=self.logger.log_file,
                 )
             )


### PR DESCRIPTION
https://github.com/NixOS/nix/issues/4613

~~Yup, no deprecation warning, no nothing.~~ Deprecation warning was added, but nix without it got to unstable

Checked on https://github.com/NixOS/nixpkgs/commit/fab6fcdceb2560a4ab943830a2b1632458c7a6ff, works fine on flake configurations.