### PR TITLE
Mention keyFile in the 'Managing keys' section

### DIFF
--- a/doc/manual/overview.rst
+++ b/doc/manual/overview.rst
@@ -186,7 +186,9 @@ Add a key to a machine like so.
 This will create a file ``/run/keys/my-secret`` with the specified
 contents, ownership, and permissions.
 
-Among the key options, only ``text`` is required. The ``user`` and
+Only the contents of the secret is required.
+It can be specified using one of the options ``text``, ``keyFile``
+or ``keyCommand``. The ``user`` and
 ``group`` options both default to ``"root"``, and ``permissions``
 defaults to ``"0600"``.
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -188,7 +188,9 @@ Add a key to a machine like so.
 This will create a file :file:`/run/keys/my-secret` with the specified
 contents, ownership, and permissions.
 
-Among the key options, only ``text`` is required. The ``user`` and
+Only the contents of the secret is required.
+It can be specified using one of the options ``text``, ``keyFile``
+or ``keyCommand``. The ``user`` and
 ``group`` options both default to ``"root"``, and ``permissions``
 defaults to ``"0600"``.
 


### PR DESCRIPTION
The 'Managing keys' section suggested that `text` is required, and did not mention that `keyFile` can be used instead.

I simply added a `keyFile` mention without further changing of the example, mainly because I don't know how to best indicate the two choices in the code example.