### PR TITLE
resources: Allow full access to nodes

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -122,7 +122,7 @@ in rec {
     lib.mapAttrs (name: defs:
       (builtins.removeAttrs (lib.fixMergeModules
         ([ mainModule deploymentInfoModule ./resource.nix ] ++ defs)
-        { inherit pkgs uuid name resources; nodes = info.machines; }
+        { inherit pkgs uuid name resources nodes; }
       ).config) ["_module"]) _resources;
 
   resources = lib.foldl

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -122,8 +122,24 @@ in rec {
     lib.mapAttrs (name: defs:
       (builtins.removeAttrs (lib.fixMergeModules
         ([ mainModule deploymentInfoModule ./resource.nix ] ++ defs)
-        { inherit pkgs uuid name resources nodes; }
+        {
+          inherit pkgs uuid name resources;
+
+          # inherit nodes, essentially
+          nodes =
+            lib.mapAttrs (nodeName: node:
+              lib.mapAttrs
+                (key: lib.warn "Resource ${name} accesses nodes.${nodeName}.${key}, which is deprecated. Use the equivalent option instead: nodes.${nodeName}.${newOpt key}.")
+                info.machines.${nodeName}
+              // node)
+            nodes;
+        }
       ).config) ["_module"]) _resources;
+
+  newOpt = key: {
+    nixosRelease = "config.system.nixos.release and make sure it is set properly";
+    publicIPv4 = "config.networking.publicIPv4";
+  }.${key} or "config.deployment.${key}";
 
   resources = lib.foldl
     (a: b: a // (b {


### PR DESCRIPTION
The previous restriction seems rather arbitrary. By allowing full
access to `nodes`, one can for example derive security group rules
from the NixOS firewall options (or custom options), simplifying
deployments substantially.

For context:

Without this, the security groups must be hand-written for each
node, which is cumbersome and error-prone.
Also note that it's easy to hit the max SGs per node, so using
an SG per service does not scale.
SGs themselves are much less limited at around 2500 per VPC, so
you can get away with a security group per node. A particularly
huge VPC could even use a naming scheme to deduplicate equivalent
SGs, although you'd be hitting NixOps practical limitations such
as evaluation performance well before that.