### PR TITLE
Locking usability improvements

### DIFF
--- a/nixops/args.py
+++ b/nixops/args.py
@@ -352,6 +352,13 @@ subparser.add_argument("machine", metavar="MACHINE", help="identifier of the mac
 subparser.add_argument(
     "args", metavar="SSH_ARGS", nargs=REMAINDER, help="SSH flags and/or command",
 )
+subparser.add_argument(
+    "--now",
+    dest="now",
+    default=False,
+    action="store_true",
+    help="do not acquire a lock before fetching the state",
+)
 
 subparser = add_subparser(
     subparsers, "ssh-for-each", help="execute a command on each machine via SSH"

--- a/nixops/args.py
+++ b/nixops/args.py
@@ -355,7 +355,6 @@ subparser.add_argument(
 subparser.add_argument(
     "--now",
     dest="now",
-    default=False,
     action="store_true",
     help="do not acquire a lock before fetching the state",
 )
@@ -450,14 +449,12 @@ subparser.add_argument(
     "--freeze",
     dest="freeze_fs",
     action="store_true",
-    default=False,
     help="freeze filesystems for non-root filesystems that support this (e.g. xfs)",
 )
 subparser.add_argument(
     "--force",
     dest="force",
     action="store_true",
-    default=False,
     help="start new backup even if previous is still running",
 )
 subparser.add_argument(
@@ -485,17 +482,12 @@ subparser.add_argument(
     help="do not perform backup actions on the specified machines",
 )
 subparser.add_argument(
-    "--wait",
-    dest="wait",
-    action="store_true",
-    default=False,
-    help="wait until backup is finished",
+    "--wait", dest="wait", action="store_true", help="wait until backup is finished",
 )
 subparser.add_argument(
     "--latest",
     dest="latest",
     action="store_true",
-    default=False,
     help="show status of latest backup only",
 )
 
@@ -505,7 +497,6 @@ subparser.add_argument("backupid", metavar="BACKUP-ID", help="backup ID to remov
 subparser.add_argument(
     "--keep-physical",
     dest="keep_physical",
-    default=False,
     action="store_true",
     help="do not remove the physical backups, only remove backups from nixops state",
 )
@@ -525,7 +516,6 @@ subparser.add_argument(
 subparser.add_argument(
     "--keep-physical",
     dest="keep_physical",
-    default=False,
     action="store_true",
     help="do not remove the physical backups, only remove backups from nixops state",
 )

--- a/nixops/locks/__init__.py
+++ b/nixops/locks/__init__.py
@@ -17,7 +17,7 @@ class LockInterface(Protocol):
     # lock: acquire a lock.
     # Note: no arguments will be passed over kwargs. Making it part of
     # the type definition allows adding new arguments later.
-    def lock(self, **kwargs) -> None:
+    def lock(self, description: str, exclusive: bool, **kwargs) -> None:
         raise NotImplementedError
 
     # unlock: release the lock.

--- a/nixops/locks/__init__.py
+++ b/nixops/locks/__init__.py
@@ -2,10 +2,35 @@ from typing import TypeVar, Type
 from typing_extensions import Protocol
 
 
+"""
+Interface to a lock driver.
+
+An implementation should inherit from LockDriver in order to for a plugin to be
+able to integrate it.
+"""
+
+
+# This separation was introduced to hide the LockOptions details from the
+# LockInterface type. It only matters for construction and clients don't have
+# to know about it.
+class LockInterface(Protocol):
+    # lock: acquire a lock.
+    # Note: no arguments will be passed over kwargs. Making it part of
+    # the type definition allows adding new arguments later.
+    def lock(self, **kwargs) -> None:
+        raise NotImplementedError
+
+    # unlock: release the lock.
+    # Note: no arguments will be passed over kwargs. Making it part of
+    # the type definition allows adding new arguments later.
+    def unlock(self, **kwargs) -> None:
+        raise NotImplementedError
+
+
 LockOptions = TypeVar("LockOptions")
 
 
-class LockDriver(Protocol[LockOptions]):
+class LockDriver(LockInterface, Protocol[LockOptions]):
     # Hack: Make T a mypy invariant. According to PEP-0544, a
     # Protocol[T] whose T is only used in function arguments and
     # returns is "de-facto covariant".
@@ -25,16 +50,4 @@ class LockDriver(Protocol[LockOptions]):
         pass
 
     def __init__(self, args: LockOptions) -> None:
-        raise NotImplementedError
-
-    # lock: acquire a lock.
-    # Note: no arguments will be passed over kwargs. Making it part of
-    # the type definition allows adding new arguments later.
-    def lock(self, **kwargs) -> None:
-        raise NotImplementedError
-
-    # unlock: release the lock.
-    # Note: no arguments will be passed over kwargs. Making it part of
-    # the type definition allows adding new arguments later.
-    def unlock(self, **kwargs) -> None:
         raise NotImplementedError

--- a/nixops/locks/noop.py
+++ b/nixops/locks/noop.py
@@ -19,5 +19,5 @@ class NoopLock(LockDriver[NoopLockOptions]):
     def unlock(self, **_kwargs) -> None:
         pass
 
-    def lock(self, **_kwargs) -> None:
+    def lock(self, description, exclusive, **_kwargs) -> None:
         pass

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -493,7 +493,11 @@ def op_check(args: Namespace) -> None:  # noqa: C901
             else:
                 resources.append(m)
 
-    with one_or_all(args, writable=False, activityDescription="nixops check") as depls:
+    # TODO: writable=False?
+    # Historically, nixops check was allowed to write to the state file.
+    # With remote state however, this requires an exclusive lock, which may
+    # not be the best choice.
+    with one_or_all(args, writable=True, activityDescription="nixops check") as depls:
         for depl in depls:
             check(depl)
 

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -130,7 +130,8 @@ def network_state(
                 yield state
             finally:
                 state.close()
-                storage.uploadFromFile(statefile)
+                if writable:
+                    storage.uploadFromFile(statefile)
         finally:
             lock.unlock()
 

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -2,8 +2,8 @@
 
 from nixops.nix_expr import py2nix
 from nixops.parallel import run_tasks
-from nixops.storage import StorageBackend
-from nixops.locks import LockDriver
+from nixops.storage import StorageBackend, StorageInterface
+from nixops.locks import LockDriver, LockInterface
 
 import contextlib
 import nixops.statefile
@@ -75,8 +75,8 @@ def deployment(
         yield depl
 
 
-def get_lock(network: NetworkEval) -> LockDriver:
-    lock: LockDriver
+def get_lock(network: NetworkEval) -> LockInterface:
+    lock: LockInterface
     lock_class: Type[LockDriver]
     lock_drivers = PluginManager.lock_drivers()
     try:
@@ -113,14 +113,14 @@ def network_state(
         )
         raise Exception("Missing storage provider plugin.")
 
-    lock: Optional[LockDriver]
+    lock: Optional[LockInterface]
     if doLock:
         lock = get_lock(network)
     else:
         lock = None
 
     storage_class_options = storage_class.options(**network.storage.configuration)
-    storage: StorageBackend = storage_class(storage_class_options)
+    storage: StorageInterface = storage_class(storage_class_options)
 
     with TemporaryDirectory("nixops") as statedir:
         statefile = statedir + "/state.nixops"

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -123,7 +123,7 @@ def network_state(
         lock.lock(description=description, exclusive=writable)
         try:
             storage.fetchToFile(statefile)
-            state = nixops.statefile.StateFile(statefile)
+            state = nixops.statefile.StateFile(statefile, writable)
             try:
                 storage.onOpen(state)
 

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -121,15 +121,17 @@ def network_state(
     with TemporaryDirectory("nixops") as statedir:
         statefile = statedir + "/state.nixops"
         lock.lock(description=description, exclusive=writable)
-        storage.fetchToFile(statefile)
-        state = nixops.statefile.StateFile(statefile)
         try:
-            storage.onOpen(state)
+            storage.fetchToFile(statefile)
+            state = nixops.statefile.StateFile(statefile)
+            try:
+                storage.onOpen(state)
 
-            yield state
+                yield state
+            finally:
+                state.close()
+                storage.uploadFromFile(statefile)
         finally:
-            state.close()
-            storage.uploadFromFile(statefile)
             lock.unlock()
 
 

--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -10,6 +10,7 @@ from types import TracebackType
 import re
 
 import nixops.deployment
+from nixops.locks import LockDriver
 
 
 class Connection(sqlite3.Connection):
@@ -84,9 +85,13 @@ class StateFile(object):
     """NixOps state file."""
 
     current_schema = 3
+    lock: Optional[LockDriver]
 
-    def __init__(self, db_file: str, writable: bool) -> None:
+    def __init__(
+        self, db_file: str, writable: bool, lock: Optional[LockDriver] = None
+    ) -> None:
         self.db_file: str = db_file
+        self.lock = lock
 
         if os.path.splitext(db_file)[1] not in [".nixops", ".charon"]:
             raise Exception(

--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -10,7 +10,7 @@ from types import TracebackType
 import re
 
 import nixops.deployment
-from nixops.locks import LockDriver
+from nixops.locks import LockInterface
 
 
 class Connection(sqlite3.Connection):
@@ -85,10 +85,10 @@ class StateFile(object):
     """NixOps state file."""
 
     current_schema = 3
-    lock: Optional[LockDriver]
+    lock: Optional[LockInterface]
 
     def __init__(
-        self, db_file: str, writable: bool, lock: Optional[LockDriver] = None
+        self, db_file: str, writable: bool, lock: Optional[LockInterface] = None
     ) -> None:
         self.db_file: str = db_file
         self.lock = lock

--- a/nixops/statefile.py
+++ b/nixops/statefile.py
@@ -15,7 +15,7 @@ from nixops.locks import LockInterface
 
 class Connection(sqlite3.Connection):
     def __init__(self, db_file: str, **kwargs: Any) -> None:
-        matchMaybe: Optional[re.Match] = re.fullmatch(
+        matchMaybe: Optional[re.Match[str]] = re.fullmatch(
             "(file://)?([^?]*)(\\?.*)?", db_file
         )
         file: str

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,7 @@ db_file = "%s/test.nixops" % (path.dirname(__file__))
 
 
 def setup():
-    nixops.statefile.StateFile(db_file).close()
+    nixops.statefile.StateFile(db_file, writable=True).close()
 
 
 def destroy(sf, uuid):
@@ -30,7 +30,7 @@ def destroy(sf, uuid):
 
 
 def teardown():
-    sf = nixops.statefile.StateFile(db_file)
+    sf = nixops.statefile.StateFile(db_file, writable=True)
     uuids = sf.query_deployments()
     threads = []
     for uuid in uuids:

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -8,7 +8,7 @@ class DatabaseUsingTest(object):
     _multiprocess_can_split_ = True
 
     def setup(self):
-        self.sf = nixops.statefile.StateFile(db_file)
+        self.sf = nixops.statefile.StateFile(db_file, writable=True)
 
     def teardown(self):
         self.sf.close()


### PR DESCRIPTION
With remote state and locking, concurrent use of `nixops` commands has become impossible. This is bad when, for example, you want to `nixops ssh` while a `nixops deploy` is running.

This PR solves a couple of locking related problems by
 - creating a distinction between read-only and read-write NixOps commands
    - allowing read-only commands to run concurrently if supported by the lock backend
    - prevent corrupting state by uploading only when in read-write mode
 - making `nixops ssh` unlock before the session starts, so read-write operations can resume while presumably-interactive sessions exist
 - adding `nixops ssh --now` which uses whatever state it can get but does not lock at all


More details are in the commit messages.