### PR TITLE
Make --network accept a file argument and add a --flake flag

### DIFF
--- a/doc/manual/nixops.rst
+++ b/doc/manual/nixops.rst
@@ -6,6 +6,19 @@ NixOps is a tool for deploying NixOS machines in a network or cloud.
 Common options
 ==============
 
+``--network``; ``-n``
+   Path to file that contains the NixOps network specification, or the
+   path to a directory containing it. By default, a file called
+   ``nixops.nix`` in the current working directory is used; if a
+   directory is specified, it is searched instead.
+
+``--flake``; ``-f``
+   Path to the flake file that contains the NixOps network
+   specification in ``outputs.nixopsConfigurations.default``, or the
+   path to a directory containing it. By default, a file called
+   ``flake.nix`` in the current working directory is used; if a
+   directory is specified, it is searched instead.
+
 ``--state``; ``-s``
    Path to the state file that contains the deployments. It defaults to
    the value of the NIXOPS_STATE environment variable, or
@@ -222,7 +235,6 @@ Synopsis
 nixops modify
 nixexprs
 --name
--n
 name
 -I
 path
@@ -241,9 +253,9 @@ from ``foo`` to ``bar``:
 
 ::
 
-   $ nixops modify -d foo -n bar expr3.nix expr4.nix
+   $ nixops modify -d foo --name bar expr3.nix expr4.nix
 
-Note that ``-d`` identifies the existing deployment, while ``-n``
+Note that ``-d`` identifies the existing deployment, while ``--name``
 specifies its new name.
 
 Command ``nixops clone``
@@ -254,7 +266,6 @@ Synopsis
 
 nixops clone
 --name
--n
 name
 Description
 -----------
@@ -273,7 +284,7 @@ To create a new deployment ``bar`` by cloning the deployment ``foo``:
 
 ::
 
-   $ nixops clone -d foo -n bar
+   $ nixops clone -d foo --name bar
 
 Command ``nixops delete``
 =========================

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -185,7 +185,7 @@ in rec {
     let
       network' = network;
       resources' = resources;
-    in rec {
+    in {
 
     machines =
       lib.flip lib.mapAttrs nodes (n: v': let v = lib.scrubOptionValue v'; in
@@ -218,31 +218,7 @@ in rec {
       [ "nixpkgs" ]  # Not serialisable
       ;
 
-    resources =
-    let
-      resource_referenced = list: check: recurse:
-          lib.any lib.id (map (value: (check value) ||
-                              ((lib.isAttrs value) && (!(value ? _type) || recurse)
-                                               && (resource_referenced (lib.attrValues value) check false)))
-                      list);
-
-      flatten_resources = resources: lib.flatten ( map lib.attrValues (lib.attrValues resources) );
-
-      resource_used = res_set: resource:
-          resource_referenced
-              (flatten_resources res_set)
-              (value: value == resource )
-              true;
-
-      resources_without_defaults = res_class: defaults: res_set:
-        let
-          missing = lib.filter (res: !(resource_used (removeAttrs res_set [res_class])
-                                                  res_set."${res_class}"."${res}"))
-                           (lib.attrNames defaults);
-        in
-        res_set // { "${res_class}" = ( removeAttrs res_set."${res_class}" missing ); };
-
-    in (removeAttrs resources' [ "machines" ]);
+    resources = removeAttrs resources' [ "machines" ];
 
   };
 

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -22,18 +22,19 @@ let
   networks =
     let
       getNetworkFromExpr = networkExpr:
-        (call (import networkExpr)) // { _file = networkExpr; };
+        if networkExpr == flakeUri then
+          (call flakeExpr) // { _file = "<${flakeUri}>"; }
+        else
+          (call (import networkExpr)) // { _file = networkExpr; };
 
       exprToKey = key: { key = toString key; };
 
       networkExprClosure = builtins.genericClosure {
-        startSet = map exprToKey networkExprs;
+        startSet = map exprToKey (networkExprs ++ optional (flakeUri != null) flakeUri);
         operator = { key }: map exprToKey ((getNetworkFromExpr key).require or []);
       };
     in
-      map ({ key }: getNetworkFromExpr key) networkExprClosure
-      ++ optional (flakeUri != null)
-        ((call flakeExpr) // { _file = "<${flakeUri}>"; });
+      map ({ key }: getNetworkFromExpr key) networkExprClosure;
 
   network = zipAttrs networks;
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -10,6 +10,6 @@ with lib;
     merge = mergeOneOption;
   };
 
-  shorten_uuid = uuid: replaceChars ["-"] [""] uuid;
+  shorten_uuid = uuid: builtins.replaceStrings ["-"] [""] uuid;
 
 }

--- a/nixops/args.py
+++ b/nixops/args.py
@@ -61,20 +61,19 @@ subparser.set_defaults(op=op_list_deployments)
 subparser = add_subparser(subparsers, "create", help="create a new deployment")
 subparser.set_defaults(op=op_create)
 subparser.add_argument(
-    "--name", "-n", dest="name", metavar="NAME", help=SUPPRESS
+    "--name", dest="name", metavar="NAME", help=SUPPRESS
 )  # obsolete, use -d instead
 
 subparser = add_subparser(subparsers, "modify", help="modify an existing deployment")
 subparser.set_defaults(op=op_modify)
 subparser.add_argument(
-    "--name", "-n", dest="name", metavar="NAME", help="new symbolic name of deployment"
+    "--name", dest="name", metavar="NAME", help="new symbolic name of deployment"
 )
 
 subparser = add_subparser(subparsers, "clone", help="clone an existing deployment")
 subparser.set_defaults(op=op_clone)
 subparser.add_argument(
     "--name",
-    "-n",
     dest="name",
     metavar="NAME",
     help="symbolic name of the cloned deployment",

--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -37,27 +37,42 @@ PluginManager.load()
 
 
 def get_network_file(args: Namespace) -> NetworkFile:
-    network_dir: str = os.path.abspath(args.network_dir)
+    network_path: str = ""
+    flake_dir: str = ""
+    flake_path: str = ""
 
-    if not os.path.exists(network_dir):
-        raise ValueError(f"{network_dir} does not exist")
+    network_path = args.network_path or os.path.join(os.getcwd(), "nixops.nix")
+    network_path = os.path.abspath(network_path)
+    if os.path.isdir(network_path):
+        network_path = os.path.join(network_path, "nixops.nix")
+    network_exists: bool = os.path.exists(network_path)
+    if args.network_path and not network_exists:
+        raise ValueError(f"{network_path} does not exist")
 
-    classic_path = os.path.join(network_dir, "nixops.nix")
-    flake_path = os.path.join(network_dir, "flake.nix")
-
-    classic_exists: bool = os.path.exists(classic_path)
+    flake_dir = args.flake_path or os.getcwd()
+    flake_dir = os.path.abspath(flake_dir)
+    flake_path = flake_dir
+    if os.path.isdir(flake_dir):
+        flake_path = os.path.join(flake_dir, "flake.nix")
+    else:
+        flake_dir = os.path.dirname(flake_path)
     flake_exists: bool = os.path.exists(flake_path)
+    if args.flake_path and not flake_exists:
+        raise ValueError(f"{flake_path} does not exist")
 
-    if all((flake_exists, classic_exists)):
-        raise ValueError("Both flake.nix and nixops.nix cannot coexist")
+    if all((not args.network_path, not args.flake_path, flake_exists, network_exists)):
+        raise ValueError("Both flake.nix and nixops.nix found in current directory")
 
-    if classic_exists:
-        return NetworkFile(network=classic_path, is_flake=False)
+    if flake_exists and not args.network_path:
+        if os.path.exists(os.path.join(flake_dir, ".git")):
+            return NetworkFile(network=f"git+file:{flake_dir}", is_flake=True)
+        else:
+            return NetworkFile(network=flake_dir, is_flake=True)
 
-    if flake_exists:
-        return NetworkFile(network=network_dir, is_flake=True)
+    if network_exists:
+        return NetworkFile(network=network_path, is_flake=False)
 
-    raise ValueError(f"Neither flake.nix nor nixops.nix exists in {network_dir}")
+    raise ValueError("Neither flake.nix nor nixops.nix exists in current directory")
 
 
 def set_common_depl(depl: nixops.deployment.Deployment, args: Namespace) -> None:
@@ -1171,12 +1186,20 @@ def add_subparser(
 ) -> ArgumentParser:
     subparser: ArgumentParser
     subparser = subparsers.add_parser(name, help=help)
-    subparser.add_argument(
+    network = subparser.add_mutually_exclusive_group()
+    network.add_argument(
         "--network",
-        dest="network_dir",
+        "-n",
+        dest="network_path",
         metavar="FILE",
-        default=os.getcwd(),
-        help="path to a directory containing either nixops.nix or flake.nix",
+        help="path to network file or a directory containing nixops.nix",
+    )
+    network.add_argument(
+        "--flake",
+        "-f",
+        dest="flake_path",
+        metavar="FILE",
+        help="path to flake or a directory containing flake.nix",
     )
     subparser.add_argument(
         "--deployment",


### PR DESCRIPTION
To make it possible to keep multiple network definitions in the same directory, make the `--network` flag accept a file in addition to a directory. Also, add a corresponding `--flake` flag and create short flags for both (`-n` and `-f` respectively).