### PR TITLE
Clarify Linux requirement in README (macOS seems unsupported)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ $ nixops --version
 NixOps @version@
 ```
 
+**Note**: Currently NixOps only supports deploying from a Linux machine. macOS users should read
+[these](https://github.com/NixOS/nixops/issues/260)
+[open](https://github.com/NixOS/nixops/issues/560)
+[issues](https://github.com/NixOS/nixops/issues/1027).
+
 ### Building And Developing
 
 #### Building The Nix Package


### PR DESCRIPTION
As a Nix(Ops) noob, this was particularly confusing - I assumed that since Nix supports macOS that NixOps would also support macOS. However, that does not seem to be true*. I think that adding a relevant note to the README will protect some future noobs from this confusion.

*Sources:
https://github.com/NixOS/nixops/issues/260
https://github.com/NixOS/nixops/issues/560
https://github.com/NixOS/nixops/issues/1027
https://github.com/NixOS/nixops/pull/412