### PR TITLE
Include sshOptions when building ssh flags

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -489,7 +489,7 @@ class MachineState(
             return None
 
     def get_ssh_flags(self, scp: bool = False) -> List[str]:
-        flags: List[str] = []
+        flags: List[str] = list(self.ssh_options)
 
         if self.ssh_port is not None:
             flags = flags + ["-o", "Port=" + str(self.ssh_port)]


### PR DESCRIPTION
Looks like this was broken in https://github.com/NixOS/nixops/commit/94a68844451ed5e81b25f1f864c27ee4ba6e5f76