### PR TITLE
Exploratory: Add bootstrap script hook

### DIFF
--- a/doc/manual/release-notes.xml
+++ b/doc/manual/release-notes.xml
@@ -5,7 +5,7 @@
 
 <!--==================================================================-->
 
-<section xml:id="ssec-relnotes-1.7"><title>Release 1.7 (April XX, 2019)</title>
+<section xml:id="ssec-relnotes-1.7"><title>Release 1.7 (April 17, 2019)</title>
 <itemizedlist>
 
   <listitem><para>General</para>

--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -305,7 +305,7 @@ rec {
 
     machines =
       flip mapAttrs nodes (n: v': let v = scrubOptionValue v'; in
-        { inherit (v.config.deployment) targetEnv targetPort targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys hasFastConnection;
+        { inherit (v.config.deployment) targetEnv targetPort targetHost encryptedLinksTo storeKeysOnMachine alwaysActivate owners keys hasFastConnection bootstrapScript;
           nixosRelease = v.config.system.nixos.release or v.config.system.nixosRelease or (removeSuffix v.config.system.nixosVersionSuffix v.config.system.nixosVersion);
           azure = optionalAttrs (v.config.deployment.targetEnv == "azure")  v.config.deployment.azure;
           ec2 = optionalAttrs (v.config.deployment.targetEnv == "ec2") v.config.deployment.ec2;

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -57,6 +57,16 @@ in
       '';
     };
 
+    deployment.bootstrapScript = mkOption {
+      type = types.nullOr types.lines;
+      default = null;
+      description = ''
+        This option specifies an optional bash script to be run on the target
+        before nix-specific operations are run. It only assumes `bash` to be
+        installed on the target.
+      '';
+    };
+
     deployment.targetPort = mkOption {
       type = types.int;
       description = ''

--- a/nixops/backends/none.py
+++ b/nixops/backends/none.py
@@ -21,6 +21,9 @@ class NoneDefinition(MachineDefinition):
         public_ipv4 = xml.find("attrs/attr[@name='publicIPv4']/string")
         self._public_ipv4 = None if public_ipv4 is None else public_ipv4.get("value")
 
+        bootstrap_cript = xml.find("attrs/attr[@name='bootstrapScript']/string")
+        self._bootstrap_script = None if bootstrap_cript is None else bootstrap_cript.get("value")
+
 class NoneState(MachineState):
     """State of a trivial machine."""
 
@@ -30,6 +33,7 @@ class NoneState(MachineState):
 
     target_host = nixops.util.attr_property("targetHost", None)
     public_ipv4 = nixops.util.attr_property("publicIpv4", None)
+    bootstrap_script = nixops.util.attr_property("bootstrapScript", None)
     _ssh_private_key = attr_property("none.sshPrivateKey", None)
     _ssh_public_key = attr_property("none.sshPublicKey", None)
     _ssh_public_key_deployed = attr_property("none.sshPublicKeyDeployed", False, bool)
@@ -52,6 +56,7 @@ class NoneState(MachineState):
         self.set_common_state(defn)
         self.target_host = defn._target_host
         self.public_ipv4 = defn._public_ipv4
+        self.bootstrap_script = defn._bootstrap_script
 
         if not self.vm_id:
             self.log_start("generating new SSH keypair... ")

--- a/nixops/deployment.py
+++ b/nixops/deployment.py
@@ -1004,6 +1004,8 @@ class Deployment(object):
 
         if build_only or dry_run: return
 
+        self.bootstrap_resources()
+
         # Copy the closures of the machine configurations to the
         # target machines.
         self.copy_closures(self.configs_path, include=include, exclude=exclude,
@@ -1229,6 +1231,18 @@ class Deployment(object):
 
         nixops.parallel.run_tasks(nr_workers=-1, tasks=self.active.itervalues(), worker_fun=worker)
 
+    def bootstrap_resources(self):
+
+        def worker(r):
+            if is_machine(r):
+                if r.bootstrap_script is not None:
+                    r.run_command(r.bootstrap_script)
+
+        nixops.parallel.run_tasks(
+            nr_workers=-1,
+            tasks=iter(self.active_resources.values()),
+            worker_fun=worker,
+        )
 
 def should_do(m, include, exclude):
     return should_do_n(m.name, include, exclude)


### PR DESCRIPTION
Hi, this PR is more of an exploratory PR, to see whether this idea is useful for the general public. Internally at our company we're using nixops to deploy to **non-NixOS** systemd distributions. One of the issues we used to have is that nixops makes certain assumptions about the target machine, namely that it has a working multi-user nix installation, and that it has a `keys` group defined for secrets. For a while we've handled this explicitly outside nixops, we basically made the machine look like NixOS for the purposes of nixops.

However, with a small addition to nixops, we now tackle this issue much more elegantly. Namely, this PR adds a nullable config option `deployment.bootstrapScript`, which (if set) is run on the master SSH connection before any nix-specific actions are taken, but after the resource closure has been built. This allows us to do the nix installation and certain early setup (like mounting of /nix from a separate hard disk), independent of the /nix/store.

The actual mechanism I added is a bit broken as it only handles None type targets, but the control flow of the resource configuration is a bit too tricky and I couldn't figure out how to do it for a general resource type.

Question is, is this a useful enough feature to be included upstream? If so, can I get any pointers to how to expose the option to a more generic resource type? Also, the changes are on top of the 1.7 tag (the PR is submitted against release-1.7, which seems to have diverged from the tag(??)), would this feature go into 2.0 only? I tried upgrading to 2.0 but got into a bunch of unrelated issues with deployment.

Thank you!