### PR TITLE
Switch from fixMergeModules to evalModules

### DIFF
--- a/nix/eval-machine-info.nix
+++ b/nix/eval-machine-info.nix
@@ -140,7 +140,6 @@ in rec {
                     // node)
                   nodes;
             };
-            _module.check = false;
           };
           modules = [
             moduleArgs


### PR DESCRIPTION
`fixMergeModules` is deprecated and using it produces deprecation warning messages in newer revisions of nixpkgs. Since it's implemented as a simple wrapper around `evalModules`, let's just use `evalModules` instead and set the module arguments through `config._module.args`.

Fixes #1507