### PR TITLE
MachineState.run_command: remove duplicate flags

### DIFF
--- a/nixops/backends/__init__.py
+++ b/nixops/backends/__init__.py
@@ -592,9 +592,7 @@ class MachineState(
         # mainly operating in a chroot environment.
         if self.state == self.RESCUE:
             command = "export LANG= LC_ALL= LC_TIME=; " + command
-        return self.ssh.run_command(
-            command, flags=self.get_ssh_flags(), user=self.ssh_user, **kwargs
-        )
+        return self.ssh.run_command(command, user=self.ssh_user, **kwargs)
 
     def switch_to_configuration(
         self, method: str, sync: bool, command: Optional[str] = None


### PR DESCRIPTION
The configured ssh options are already included since e21d5b3
https://github.com/NixOS/nixops/pull/1493

Solves errors like `Only a single -J option is permitted (use commas to separate multiple jump hops)`, provided that the duplicate `-J` isn't user error of course.
