### PR TITLE
docs: mention `$NIXOPS_STATE`

### DIFF
--- a/doc/manual/migrating.rst
+++ b/doc/manual/migrating.rst
@@ -40,6 +40,9 @@ database located in ``~/.nixops`` add the following snippet to your deployment:
      };
    }
 
+To use a different location than ``~/.nixops``, also export the environment
+variable ``$NIXOPS_STATE``. You can define that in your ``shell.nix``.
+
 To implement a fire-and-forget strategy use this code snippet:
 
 .. code-block:: nix


### PR DESCRIPTION
As seen in https://github.com/NixOS/nixops/issues/1472, the current documented way to specify a different storage location does not really work.

However, one can add `$NIXOPS_STATE` and it works. Also this is a very comfortable options for integrating with i.e. devshell.

Thus I'm documenting it here, while the other issue gets fixed.