### PR TITLE
build: update backend to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ charon = 'nixops.__main__:main'
 
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 addopts = """


### PR DESCRIPTION
This is [recommended by upstream poetry][1]. Without this new backend, you cannot do an editable install.

[1]: https://python-poetry.org/docs/pyproject/#poetry-and-pep-517

@moduon MT-904