### PR TITLE
Use new inotify tools alias

### DIFF
--- a/nix/keys.nix
+++ b/nix/keys.nix
@@ -237,7 +237,7 @@ in
           serviceConfig.TimeoutStartSec = "infinity";
           serviceConfig.Restart = "always";
           serviceConfig.RestartSec = "100ms";
-          path = [ pkgs.inotifyTools ];
+          path = [ pkgs.inotify-tools ];
           preStart = ''
             (while read f; do if [ "$f" = "${keyCfg.name}" ]; then break; fi; done \
               < <(inotifywait -qm --format '%f' -e create,move ${keyCfg.destDir}) ) &


### PR DESCRIPTION
A recent commit of nixpkgs removed the old alias of `inotifyTools` and causes it to fail to evaluate. This PR simply uses the new alias.