### PR TITLE
ImmutableValidatedObject: Support nested Mapping types

### DIFF
--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence
+from typing import Any, Sequence, Mapping
 import json
 from nixops.logger import Logger
 from io import StringIO
@@ -121,4 +121,14 @@ class TestUtilTest(unittest.TestCase):
         class WithSequence(util.ImmutableValidatedObject):
             subs: Sequence[SubResource]
 
-        WithSequence(subs=[SubResource(x=1), SubResource(x=2)])
+        seq = WithSequence(subs=[{"x": 1}, {"x": 2}])
+        for i in seq.subs:
+            self.assertIsInstance(i, SubResource)
+
+        # Test Mapping[str, ImmutableValidatedObject]
+        class WithMapping(util.ImmutableValidatedObject):
+            mapping: Mapping[str, SubResource]
+
+        mapped = WithMapping(mapping={"aaa": {"x": 1}, "bbb": {"x": 2}})
+        for _, v in mapped.mapping.items():
+            self.assertIsInstance(v, SubResource)


### PR DESCRIPTION
Since typeguard was updated in #1569, the use of `deployment.keys` (+ a few required options in `nixops-gce`, like `bootstrapImage`), has been broken. This is because typeguard now inspects the type of mapping containers (`Mapping[str, KeyOptions]` and such) and nested such containers weren't handled by `ImmutableValidatedObject`.

This also improves the handling of nested sequences and fixes their associated test.

fixes #1570