### PR TITLE
Fix deprecated `pipes` module

### DIFF
--- a/nixops/script_defs.py
+++ b/nixops/script_defs.py
@@ -22,7 +22,7 @@ import logging
 import logging.handlers
 import json
 from tempfile import TemporaryDirectory
-import pipes
+import shlex
 from typing import Tuple, List, Optional, Union, Generator, Type, Set, Sequence
 import nixops.ansi
 
@@ -1117,7 +1117,7 @@ def op_edit(args: Namespace) -> None:
         if not editor:
             raise Exception("the $EDITOR environment variable is not set")
         os.system(
-            "$EDITOR " + " ".join([pipes.quote(x) for x in depl.network_expr.network])
+            "$EDITOR " + " ".join([shlex.quote(x) for x in depl.network_expr.network])
         )
 
 


### PR DESCRIPTION
Fix `pipes`  deprecation in Python 3.13, see [PEP 594](https://peps.python.org/pep-0594/).
```
> nixops
Traceback (most recent call last):
  File "/nix/store/kflgqvvc23cr4s3sgma6zdcinzn24rkc-nixops-1.7-unstable-2024-02-28/bin/.nixops-wrapped", line 6, in <module>
    from nixops.__main__ import main
  File "/nix/store/kflgqvvc23cr4s3sgma6zdcinzn24rkc-nixops-1.7-unstable-2024-02-28/lib/python3.13/site-packages/nixops/__main__.py", line 35, in <module>
    from nixops.script_defs import setup_logging
  File "/nix/store/kflgqvvc23cr4s3sgma6zdcinzn24rkc-nixops-1.7-unstable-2024-02-28/lib/python3.13/site-packages/nixops/script_defs.py", line 25, in <module>
    import pipes
ModuleNotFoundError: No module named 'pipes'
```